### PR TITLE
fix: core Plugin: Backlinks scroll not working

### DIFF
--- a/src/theme.scss
+++ b/src/theme.scss
@@ -3339,10 +3339,12 @@ body.is-tablet {
 }
 
 /********** Core Plugin: Backlinks **********/
-.backlink-pane,
-.outgoing-link-pane {
-  padding-bottom: unset;
-  overflow: scroll;
+body.is-mobile {
+  .backlink-pane,
+  .outgoing-link-pane {
+    padding-bottom: unset;
+    overflow: visible;
+  }
 }
 
 body.is-mobile .embedded-backlinks {

--- a/src/theme.scss
+++ b/src/theme.scss
@@ -3342,7 +3342,7 @@ body.is-tablet {
 .backlink-pane,
 .outgoing-link-pane {
   padding-bottom: unset;
-  overflow: visible;
+  overflow: scroll;
 }
 
 body.is-mobile .embedded-backlinks {


### PR DESCRIPTION
previously the overflow was set to visible for the .backlink-pane and .outgoing-link-pane elements. this caused the inability to scroll in backlinks pane when it has been added to the sidebars

the overflow was changed to scroll to enable scrolling in the plug-in when it was added to the sidebars.

this was the fix that i came up with that worked on my local. I am not sure how the scroll functionality has been handled in the other areas of the theme. 

If any change is needed to be made kindly let me know and i can update the code. 