### PR TITLE
fix: modal blur not taking account background color

### DIFF
--- a/src/theme.scss
+++ b/src/theme.scss
@@ -2977,14 +2977,14 @@ body.mod-windows:not(.windows-mode-off):not(.is-mobile) {
     .modal,
     .vertical-tab-content,
     .community-modal-details {
-      background-color: rgb(from var(--background-secondary) r g b / 90%);
+      background-color: rgba(246, 246, 246, 90%);
     }
   }
   &.theme-dark {
     .modal,
     .vertical-tab-content,
     .community-modal-details {
-      background-color: rgb(from var(--background-primary) r g b / 90%);
+      background-color: rgba(30, 30, 30, 90%);
     }
   }
 


### PR DESCRIPTION
official obsidian vars doesn't offer rgb values for background, so i had to put stock rgb values that reflects obsidian's colors

fixes how modal looks when there's a negative color (white with dark background, & viceversa)

---

**before**

![image](https://github.com/user-attachments/assets/69a3b687-2ad9-4c29-aa63-4c8edccff418)

**after**

![image](https://github.com/user-attachments/assets/29814cb3-1826-4fc7-bde4-91db70920045)

