### PR TITLE
Add configurable image alignment and fix oversized tall images in Reading view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 .vscode/*
-.DS_Store
+.DS_Store.tools/

--- a/src/app/root.scss
+++ b/src/app/root.scss
@@ -78,6 +78,13 @@ body,
   --code-string: #0d97b3;
   --code-tag: #e45749;
   --code-value: #a626a4;
+
+  /* Markdown links: fixed system blue / indigo (independent of accent) */
+  --link-color: #006edc;
+  --link-color-hover: #0055b0;
+  --link-external-color: #006edc;
+  --link-external-color-hover: #0055b0;
+  --link-unresolved-color: #4a7db5;
 }
 .theme-dark {
   --workspace-background-translucent: rgb(from var(--background-secondary) r g b / var(--translucent-dark-opacity));
@@ -101,6 +108,13 @@ body,
   --code-string: #58b6c2;
   --code-tag: #e16d76;
   --code-value: #c678de;
+
+  /* Markdown links: system blue on dark UI */
+  --link-color: #5cadff;
+  --link-color-hover: #8ac4ff;
+  --link-external-color: #5cadff;
+  --link-external-color-hover: #8ac4ff;
+  --link-unresolved-color: #7a9ab8;
 }
 
 body:not(.is-mobile) {

--- a/src/app/style-settings.scss
+++ b/src/app/style-settings.scss
@@ -1,166 +1,229 @@
 /*!
 /* @settings
 
-name: Cupertino
+name: Cupertino · 库比蒂诺
 id: cupertino
 settings:
-    - 
+    -
         id: cupertino-desc
         description: "Cupertino offers simplified, native-style UI. For granular controls, try [Baseline](obsidian://show-theme?name=Baseline)."
+        description.zh: "Cupertino 提供简洁的原生风格界面。若需要更细粒度选项，可尝试 [Baseline](obsidian://show-theme?name=Baseline)。"
         type: info-text
         markdown: true
     -
         id: colorful-frame
         title: Tinted sidebar
+        title.zh: 侧边栏着色
         description: Apply a subtle tint to the sidebar based on accent color.
+        description.zh: 根据强调色为侧边栏施加淡淡着色。
         type: class-toggle
     -
         id: material-color
         title: Dynamic color
+        title.zh: 动态配色
         description: Apply dynamic theming based on accent color.
+        description.zh: 根据强调色应用动态主题配色。
         type: class-toggle
     -
         id: adaptive-mode-off
         title: Disable adaptive mode
+        title.zh: 关闭自适应模式
         description: Prevent automatic styling based on operating system.
+        description.zh: 停止根据操作系统自动调整样式。
         type: class-toggle
     -
         id: tab-floating
         title: Disable centered tabs
+        title.zh: 取消标签居中
+        description: Use left-aligned tabs instead of centered tabs in the tab bar.
+        description.zh: 将标签栏改为传统左侧对齐，而非居中排列。
         type: class-toggle
     -
         id: desktop-header
         title: Desktop
+        title.zh: 桌面端
         type: heading
         level: 1
         collapsed: true
     -
         id: hover-ribbon
         title: Hover ribbon
+        title.zh: 悬停显示功能区
         description: Reveal ribbon by hovering over left window edge.
+        description.zh: 鼠标靠近左侧窗口边缘时显示功能区（Ribbon）。
         type: class-toggle
         addCommand: true
     -
         id: hover-sidedock
         title: Hover sidebar
+        title.zh: 悬停显示侧边栏
         description: Reveal collapsed sidebars by hovering over window edges.
+        description.zh: 鼠标靠近窗口边缘时展开已收起的侧边栏。
         type: class-toggle
         addCommand: true
     -
         id: focus-view
         title: Focus view
+        title.zh: 专注视图
         description: Hide tabs and table title bar when both sidebars are collapsed.
+        description.zh: 当两侧栏均收起时隐藏标签与表格标题栏。
         type: class-toggle
         addCommand: true
     -
         id: nav-action-center
         title: Disable compact panel actions
+        title.zh: 取消紧凑面板操作区
+        description: Use default alignment for narrow sidebar header actions.
+        description.zh: 窄侧边栏顶栏操作按钮恢复默认对齐，不再居中紧凑排列。
         type: class-toggle
     -
         id: tab-icon
         title: Disable compact sidebar tabs
+        title.zh: 取消紧凑侧边栏标签
+        description: Keep full sidebar tab labels instead of icon-only compact tabs.
+        description.zh: 保留侧边栏标签的完整文字，而非仅图标的紧凑标签。
         type: class-toggle
     -
         id: status-bar-baseline
         title: Disable compact status bar
+        title.zh: 取消紧凑状态栏
+        description: Use a taller default-style status bar instead of the compact row.
+        description.zh: 使用更高的默认风格状态栏，而非单行紧凑状态栏。
         type: class-toggle
     -
         id: zoom-off
         title: Disable media zoom
+        title.zh: 关闭媒体缩放
+        description: Disable click-to-zoom behavior on images and media.
+        description.zh: 关闭图片与媒体的点击放大效果。
         type: class-toggle
     -
         id: editor
         title: Editor
+        title.zh: 编辑器
         type: heading
         level: 1
         collapsed: true
     -
         id: active-line-off
         title: Disable active line highlight
+        title.zh: 关闭当前行高亮
+        description: Turn off background highlight for the active line in the editor.
+        description.zh: 关闭编辑器中当前行的背景高亮。
         type: class-toggle
     -
         id: banner-off
         title: Disable banner
+        title.zh: 关闭 Banner
+        description: Disable styling for banner areas used by banner-style plugins.
+        description.zh: 关闭 Banner 类插件常用的顶部横幅区域样式。
         type: class-toggle
     -
         id: block-width-off
         title: Disable block width
+        title.zh: 关闭块级宽度
+        description: Do not widen blocks beyond the default reading column.
+        description.zh: 不将块元素加宽到默认阅读栏之外。
         type: class-toggle
     -
         id: font-variant-off
         title: Disable font variants
+        title.zh: 关闭字体变体
+        description: Disable OpenType stylistic alternates for interface fonts.
+        description.zh: 关闭界面字体的 OpenType 变体与替代字形特性。
         type: class-toggle
     -
         id: full-width-media-off
         title: Disable full-width elements
+        title.zh: 关闭全宽元素
+        description: Keep embeds and wide elements within the main text column.
+        description.zh: 将嵌入与全宽元素限制在正文主栏宽度内。
         type: class-toggle
     -
         id: image-align
         title: Image alignment
+        title.zh: 图片对齐
         description: Set default image alignment in editor and reading view.
+        description.zh: 设置编辑与阅读模式下的默认图片对齐方式。
         type: class-select
         allowEmpty: false
         default: image-align-center
         options:
             -
-                label: Left
+                label: Left / 左
                 value: image-align-left
             -
-                label: Center
+                label: Center / 居中
                 value: image-align-center
             -
-                label: Right
+                label: Right / 右
                 value: image-align-right
+    -
+        id: clean-link-off
+        title: Underlined links
+        title.zh: 链接始终下划线
+        description: Always underline links for improved visibility.
+        description.zh: 始终为链接添加下划线以提高辨识度。
+        type: class-toggle
     -
         id: mode-switcher-off
         title: Disable quick mode switcher
+        title.zh: 关闭快速配色切换
+        description: Hide the quick light/dark switch in the status bar area.
+        description.zh: 隐藏状态栏区域的快速明暗配色切换入口。
         type: class-toggle
     -
         id: accessibility
         title: Accessibility
+        title.zh: 辅助功能
         type: heading
         level: 1
         collapsed: true
-	-
-		id: reduce-contrast-change
-		title: Reduce contrast change
-		description: Minimize contrast shifts when window loses focus.
-		type: class-toggle
-	-
-		id: reduce-motion
-		title: Reduce motion
-		description: Minimize animation effects.
-		type: class-toggle
-	-
-		id: dynamic-type-off
-		title: Standard font size
-		description: Disable operating system-based dynamic font sizes.
-		type: class-toggle
-	-
-		id: font-ui-modifier
-		title: Interface font size
-		description: Fine-tune interface text size.
-		type: variable-number-slider
-		default: 0
-		min: -8
-		max: 8
-		step: 1
-		format: px
-	-
-		id: icon-size-modifier
-		title: Icon size
-		description: Fine-tune icon size.
-		type: variable-number-slider
-		default: 0
-		min: -4
-		max: 4
-		step: 1
-		format: px
     -
-        id: clean-link-off
-        title: Underlined links
-        description: Always underline links for improved visibility.
+        id: reduce-contrast-change
+        title: Reduce contrast change
+        title.zh: 减弱失焦对比变化
+        description: Minimize contrast shifts when window loses focus.
+        description.zh: 减轻窗口失焦时的对比度变化。
         type: class-toggle
+    -
+        id: reduce-motion
+        title: Reduce motion
+        title.zh: 减少动态效果
+        description: Minimize animation effects.
+        description.zh: 尽量减少动画与过渡效果。
+        type: class-toggle
+    -
+        id: dynamic-type-off
+        title: Standard font size
+        title.zh: 固定界面字号层级
+        description: Disable operating system-based dynamic font sizes.
+        description.zh: 关闭随系统「动态字体」调整的界面字号层级。
+        type: class-toggle
+    -
+        id: font-ui-modifier
+        title: Interface font size
+        title.zh: 界面字号微调
+        description: Fine-tune interface text size.
+        description.zh: 细调界面文字大小。
+        type: variable-number-slider
+        default: 0
+        min: -8
+        max: 8
+        step: 1
+        format: px
+    -
+        id: icon-size-modifier
+        title: Icon size
+        title.zh: 图标尺寸微调
+        description: Fine-tune icon size.
+        description.zh: 细调界面图标大小。
+        type: variable-number-slider
+        default: 0
+        min: -4
+        max: 4
+        step: 1
+        format: px
 */
 
 .view-content .style-settings-container .style-settings-container .setting-item {

--- a/src/app/style-settings.scss
+++ b/src/app/style-settings.scss
@@ -1,211 +1,214 @@
 /*!
 /* @settings
 
-name: Cupertino · 库比蒂诺
+# 主文案为中文，保证任意语言回退时仍为中文；英文界面通过 Style Settings 的 title.en / description.en 读取。
+# Primary strings are Chinese so UI stays Chinese even when title.zh does not match Obsidian’s language code.
+
+name: 库比蒂诺（Cupertino）
 id: cupertino
 settings:
     -
         id: cupertino-desc
-        description: "Cupertino offers simplified, native-style UI. For granular controls, try [Baseline](obsidian://show-theme?name=Baseline)."
-        description.zh: "Cupertino 提供简洁的原生风格界面。若需要更细粒度选项，可尝试 [Baseline](obsidian://show-theme?name=Baseline)。"
+        description: "Cupertino 提供简洁的原生风格界面。若需要更细粒度选项，可尝试 [Baseline](obsidian://show-theme?name=Baseline)。"
+        description.en: "Cupertino offers simplified, native-style UI. For granular controls, try [Baseline](obsidian://show-theme?name=Baseline)."
         type: info-text
         markdown: true
     -
         id: colorful-frame
-        title: Tinted sidebar
-        title.zh: 侧边栏着色
-        description: Apply a subtle tint to the sidebar based on accent color.
-        description.zh: 根据强调色为侧边栏施加淡淡着色。
+        title: 侧边栏着色
+        title.en: Tinted sidebar
+        description: 根据强调色为侧边栏施加淡淡着色。
+        description.en: Apply a subtle tint to the sidebar based on accent color.
         type: class-toggle
     -
         id: material-color
-        title: Dynamic color
-        title.zh: 动态配色
-        description: Apply dynamic theming based on accent color.
-        description.zh: 根据强调色应用动态主题配色。
+        title: 动态配色
+        title.en: Dynamic color
+        description: 根据强调色应用动态主题配色。
+        description.en: Apply dynamic theming based on accent color.
         type: class-toggle
     -
         id: adaptive-mode-off
-        title: Disable adaptive mode
-        title.zh: 关闭自适应模式
-        description: Prevent automatic styling based on operating system.
-        description.zh: 停止根据操作系统自动调整样式。
+        title: 关闭自适应模式
+        title.en: Disable adaptive mode
+        description: 停止根据操作系统自动调整样式。
+        description.en: Prevent automatic styling based on operating system.
         type: class-toggle
     -
         id: tab-floating
-        title: Disable centered tabs
-        title.zh: 取消标签居中
-        description: Use left-aligned tabs instead of centered tabs in the tab bar.
-        description.zh: 将标签栏改为传统左侧对齐，而非居中排列。
+        title: 取消标签居中
+        title.en: Disable centered tabs
+        description: 将标签栏改为传统左侧对齐，而非居中排列。
+        description.en: Use left-aligned tabs instead of centered tabs in the tab bar.
         type: class-toggle
     -
         id: desktop-header
-        title: Desktop
-        title.zh: 桌面端
+        title: 桌面端
+        title.en: Desktop
         type: heading
         level: 1
         collapsed: true
     -
         id: hover-ribbon
-        title: Hover ribbon
-        title.zh: 悬停显示功能区
-        description: Reveal ribbon by hovering over left window edge.
-        description.zh: 鼠标靠近左侧窗口边缘时显示功能区（Ribbon）。
+        title: 悬停显示功能区
+        title.en: Hover ribbon
+        description: 鼠标靠近左侧窗口边缘时显示功能区（Ribbon）。
+        description.en: Reveal ribbon by hovering over left window edge.
         type: class-toggle
         addCommand: true
     -
         id: hover-sidedock
-        title: Hover sidebar
-        title.zh: 悬停显示侧边栏
-        description: Reveal collapsed sidebars by hovering over window edges.
-        description.zh: 鼠标靠近窗口边缘时展开已收起的侧边栏。
+        title: 悬停显示侧边栏
+        title.en: Hover sidebar
+        description: 鼠标靠近窗口边缘时展开已收起的侧边栏。
+        description.en: Reveal collapsed sidebars by hovering over window edges.
         type: class-toggle
         addCommand: true
     -
         id: focus-view
-        title: Focus view
-        title.zh: 专注视图
-        description: Hide tabs and table title bar when both sidebars are collapsed.
-        description.zh: 当两侧栏均收起时隐藏标签与表格标题栏。
+        title: 专注视图
+        title.en: Focus view
+        description: 当两侧栏均收起时隐藏标签与表格标题栏。
+        description.en: Hide tabs and table title bar when both sidebars are collapsed.
         type: class-toggle
         addCommand: true
     -
         id: nav-action-center
-        title: Disable compact panel actions
-        title.zh: 取消紧凑面板操作区
-        description: Use default alignment for narrow sidebar header actions.
-        description.zh: 窄侧边栏顶栏操作按钮恢复默认对齐，不再居中紧凑排列。
+        title: 取消紧凑面板操作区
+        title.en: Disable compact panel actions
+        description: 窄侧边栏顶栏操作按钮恢复默认对齐，不再居中紧凑排列。
+        description.en: Use default alignment for narrow sidebar header actions.
         type: class-toggle
     -
         id: tab-icon
-        title: Disable compact sidebar tabs
-        title.zh: 取消紧凑侧边栏标签
-        description: Keep full sidebar tab labels instead of icon-only compact tabs.
-        description.zh: 保留侧边栏标签的完整文字，而非仅图标的紧凑标签。
+        title: 取消紧凑侧边栏标签
+        title.en: Disable compact sidebar tabs
+        description: 保留侧边栏标签的完整文字，而非仅图标的紧凑标签。
+        description.en: Keep full sidebar tab labels instead of icon-only compact tabs.
         type: class-toggle
     -
         id: status-bar-baseline
-        title: Disable compact status bar
-        title.zh: 取消紧凑状态栏
-        description: Use a taller default-style status bar instead of the compact row.
-        description.zh: 使用更高的默认风格状态栏，而非单行紧凑状态栏。
+        title: 取消紧凑状态栏
+        title.en: Disable compact status bar
+        description: 使用更高的默认风格状态栏，而非单行紧凑状态栏。
+        description.en: Use a taller default-style status bar instead of the compact row.
         type: class-toggle
     -
         id: zoom-off
-        title: Disable media zoom
-        title.zh: 关闭媒体缩放
-        description: Disable click-to-zoom behavior on images and media.
-        description.zh: 关闭图片与媒体的点击放大效果。
+        title: 关闭媒体缩放
+        title.en: Disable media zoom
+        description: 关闭图片与媒体的点击放大效果。
+        description.en: Disable click-to-zoom behavior on images and media.
         type: class-toggle
     -
         id: editor
-        title: Editor
-        title.zh: 编辑器
+        title: 编辑器
+        title.en: Editor
         type: heading
         level: 1
         collapsed: true
     -
         id: active-line-off
-        title: Disable active line highlight
-        title.zh: 关闭当前行高亮
-        description: Turn off background highlight for the active line in the editor.
-        description.zh: 关闭编辑器中当前行的背景高亮。
+        title: 关闭当前行高亮
+        title.en: Disable active line highlight
+        description: 关闭编辑器中当前行的背景高亮。
+        description.en: Turn off background highlight for the active line in the editor.
         type: class-toggle
     -
         id: banner-off
-        title: Disable banner
-        title.zh: 关闭 Banner
-        description: Disable styling for banner areas used by banner-style plugins.
-        description.zh: 关闭 Banner 类插件常用的顶部横幅区域样式。
+        title: 关闭 Banner
+        title.en: Disable banner
+        description: 关闭 Banner 类插件常用的顶部横幅区域样式。
+        description.en: Disable styling for banner areas used by banner-style plugins.
         type: class-toggle
     -
         id: block-width-off
-        title: Disable block width
-        title.zh: 关闭块级宽度
-        description: Do not widen blocks beyond the default reading column.
-        description.zh: 不将块元素加宽到默认阅读栏之外。
+        title: 关闭块级宽度
+        title.en: Disable block width
+        description: 不将块元素加宽到默认阅读栏之外。
+        description.en: Do not widen blocks beyond the default reading column.
         type: class-toggle
     -
         id: font-variant-off
-        title: Disable font variants
-        title.zh: 关闭字体变体
-        description: Disable OpenType stylistic alternates for interface fonts.
-        description.zh: 关闭界面字体的 OpenType 变体与替代字形特性。
+        title: 关闭字体变体
+        title.en: Disable font variants
+        description: 关闭界面字体的 OpenType 变体与替代字形特性。
+        description.en: Disable OpenType stylistic alternates for interface fonts.
         type: class-toggle
     -
         id: full-width-media-off
-        title: Disable full-width elements
-        title.zh: 关闭全宽元素
-        description: Keep embeds and wide elements within the main text column.
-        description.zh: 将嵌入与全宽元素限制在正文主栏宽度内。
+        title: 关闭全宽元素
+        title.en: Disable full-width elements
+        description: 将嵌入与全宽元素限制在正文主栏宽度内。
+        description.en: Keep embeds and wide elements within the main text column.
         type: class-toggle
     -
         id: image-align
-        title: Image alignment
-        title.zh: 图片对齐
-        description: Set default image alignment in editor and reading view.
-        description.zh: 设置编辑与阅读模式下的默认图片对齐方式。
+        title: 图片对齐
+        title.en: Image alignment
+        description: 设置编辑与阅读模式下的默认图片对齐方式。
+        description.en: Set default image alignment in editor and reading view.
         type: class-select
         allowEmpty: false
         default: image-align-center
         options:
             -
-                label: Left / 左
+                label: 左
                 value: image-align-left
             -
-                label: Center / 居中
+                label: 居中
                 value: image-align-center
             -
-                label: Right / 右
+                label: 右
                 value: image-align-right
     -
         id: clean-link-off
-        title: Underlined links
-        title.zh: 链接始终下划线
-        description: Always underline links for improved visibility.
-        description.zh: 始终为链接添加下划线以提高辨识度。
+        title: 链接始终下划线
+        title.en: Underlined links
+        description: 始终为链接添加下划线以提高辨识度。
+        description.en: Always underline links for improved visibility.
         type: class-toggle
     -
         id: mode-switcher-off
-        title: Disable quick mode switcher
-        title.zh: 关闭快速配色切换
-        description: Hide the quick light/dark switch in the status bar area.
-        description.zh: 隐藏状态栏区域的快速明暗配色切换入口。
+        title: 关闭快速配色切换
+        title.en: Disable quick mode switcher
+        description: 隐藏状态栏区域的快速明暗配色切换入口。
+        description.en: Hide the quick light/dark switch in the status bar area.
         type: class-toggle
     -
         id: accessibility
-        title: Accessibility
-        title.zh: 辅助功能
+        title: 辅助功能
+        title.en: Accessibility
         type: heading
         level: 1
         collapsed: true
     -
         id: reduce-contrast-change
-        title: Reduce contrast change
-        title.zh: 减弱失焦对比变化
-        description: Minimize contrast shifts when window loses focus.
-        description.zh: 减轻窗口失焦时的对比度变化。
+        title: 减弱失焦对比变化
+        title.en: Reduce contrast change
+        description: 减轻窗口失焦时的对比度变化。
+        description.en: Minimize contrast shifts when window loses focus.
         type: class-toggle
     -
         id: reduce-motion
-        title: Reduce motion
-        title.zh: 减少动态效果
-        description: Minimize animation effects.
-        description.zh: 尽量减少动画与过渡效果。
+        title: 减少动态效果
+        title.en: Reduce motion
+        description: 尽量减少动画与过渡效果。
+        description.en: Minimize animation effects.
         type: class-toggle
     -
         id: dynamic-type-off
-        title: Standard font size
-        title.zh: 固定界面字号层级
-        description: Disable operating system-based dynamic font sizes.
-        description.zh: 关闭随系统「动态字体」调整的界面字号层级。
+        title: 固定界面字号层级
+        title.en: Standard font size
+        description: 关闭随系统「动态字体」调整的界面字号层级。
+        description.en: Disable operating system-based dynamic font sizes.
         type: class-toggle
     -
         id: font-ui-modifier
-        title: Interface font size
-        title.zh: 界面字号微调
-        description: Fine-tune interface text size.
-        description.zh: 细调界面文字大小。
+        title: 界面字号微调
+        title.en: Interface font size
+        description: 细调界面文字大小。
+        description.en: Fine-tune interface text size.
         type: variable-number-slider
         default: 0
         min: -8
@@ -214,10 +217,10 @@ settings:
         format: px
     -
         id: icon-size-modifier
-        title: Icon size
-        title.zh: 图标尺寸微调
-        description: Fine-tune icon size.
-        description.zh: 细调界面图标大小。
+        title: 图标尺寸微调
+        title.en: Icon size
+        description: 细调界面图标大小。
+        description.en: Fine-tune icon size.
         type: variable-number-slider
         default: 0
         min: -4

--- a/src/app/style-settings.scss
+++ b/src/app/style-settings.scss
@@ -95,6 +95,23 @@ settings:
         title: Disable full-width elements
         type: class-toggle
     -
+        id: image-align
+        title: Image alignment
+        description: Set default image alignment in editor and reading view.
+        type: class-select
+        allowEmpty: false
+        default: image-align-center
+        options:
+            -
+                label: Left
+                value: image-align-left
+            -
+                label: Center
+                value: image-align-center
+            -
+                label: Right
+                value: image-align-right
+    -
         id: mode-switcher-off
         title: Disable quick mode switcher
         type: class-toggle

--- a/src/app/style-settings.scss
+++ b/src/app/style-settings.scss
@@ -4,7 +4,7 @@
 # 主文案为中文，保证任意语言回退时仍为中文；英文界面通过 Style Settings 的 title.en / description.en 读取。
 # Primary strings are Chinese so UI stays Chinese even when title.zh does not match Obsidian’s language code.
 
-name: 库比蒂诺（Cupertino）
+name: Cupertino · 库比蒂诺
 id: cupertino
 settings:
     -
@@ -153,13 +153,13 @@ settings:
         default: image-align-center
         options:
             -
-                label: 左
+                label: Left / 左
                 value: image-align-left
             -
-                label: 居中
+                label: Center / 居中
                 value: image-align-center
             -
-                label: 右
+                label: Right / 右
                 value: image-align-right
     -
         id: clean-link-off

--- a/src/editor/editor.scss
+++ b/src/editor/editor.scss
@@ -255,12 +255,52 @@
     padding-inline-end: 0px;
   }
 
+  // Default image alignment, configurable via Style Settings.
+  // Works for both source mode and reading mode image blocks.
+  .workspace-leaf-content[data-type="markdown"] {
+    --image-align-margin-start: auto;
+    --image-align-margin-end: auto;
+  }
+  body.image-align-left .workspace-leaf-content[data-type="markdown"] {
+    --image-align-margin-start: 0;
+    --image-align-margin-end: auto;
+  }
+  body.image-align-center .workspace-leaf-content[data-type="markdown"] {
+    --image-align-margin-start: auto;
+    --image-align-margin-end: auto;
+  }
+  body.image-align-right .workspace-leaf-content[data-type="markdown"] {
+    --image-align-margin-start: auto;
+    --image-align-margin-end: 0;
+  }
+
+  .workspace-leaf-content[data-type="markdown"] {
+    .image-embed,
+    img:not(.link-favicon, .emoji, [alt="banner"]) {
+      display: block;
+      margin-inline-start: var(--image-align-margin-start);
+      margin-inline-end: var(--image-align-margin-end);
+    }
+  }
+
   body:not(.full-width-media-off) .workspace-leaf-content[data-type="markdown"] {
     img:not([width], .cm-widgetBuffer, .link-favicon, .emoji, [alt="banner"]),
     iframe,
     video {
-      width: 100%;
       border-radius: var(--media-radius);
+    }
+
+    // Avoid forcing very tall images to full line width in Reading view.
+    // Keep natural size but never overflow the note container.
+    img:not([width], .cm-widgetBuffer, .link-favicon, .emoji, [alt="banner"]) {
+      width: auto;
+      max-width: 100%;
+      height: auto;
+    }
+
+    iframe,
+    video {
+      width: 100%;
     }
   }
 

--- a/theme.css
+++ b/theme.css
@@ -65,6 +65,12 @@ body,
   --code-string: #0d97b3;
   --code-tag: #e45749;
   --code-value: #a626a4;
+  /* Markdown links: fixed system blue / indigo (independent of accent) */
+  --link-color: #006edc;
+  --link-color-hover: #0055b0;
+  --link-external-color: #006edc;
+  --link-external-color-hover: #0055b0;
+  --link-unresolved-color: #4a7db5;
 }
 
 .theme-dark {
@@ -87,6 +93,12 @@ body,
   --code-string: #58b6c2;
   --code-tag: #e16d76;
   --code-value: #c678de;
+  /* Markdown links: system blue on dark UI */
+  --link-color: #5cadff;
+  --link-color-hover: #8ac4ff;
+  --link-external-color: #5cadff;
+  --link-external-color-hover: #8ac4ff;
+  --link-unresolved-color: #7a9ab8;
 }
 
 body:not(.is-mobile) {

--- a/theme.css
+++ b/theme.css
@@ -2219,166 +2219,229 @@ body.minimal-theme .workspace::before {
 /*!
 /* @settings
 
-name: Cupertino
+name: Cupertino · 库比蒂诺
 id: cupertino
 settings:
-    - 
+    -
         id: cupertino-desc
         description: "Cupertino offers simplified, native-style UI. For granular controls, try [Baseline](obsidian://show-theme?name=Baseline)."
+        description.zh: "Cupertino 提供简洁的原生风格界面。若需要更细粒度选项，可尝试 [Baseline](obsidian://show-theme?name=Baseline)。"
         type: info-text
         markdown: true
     -
         id: colorful-frame
         title: Tinted sidebar
+        title.zh: 侧边栏着色
         description: Apply a subtle tint to the sidebar based on accent color.
+        description.zh: 根据强调色为侧边栏施加淡淡着色。
         type: class-toggle
     -
         id: material-color
         title: Dynamic color
+        title.zh: 动态配色
         description: Apply dynamic theming based on accent color.
+        description.zh: 根据强调色应用动态主题配色。
         type: class-toggle
     -
         id: adaptive-mode-off
         title: Disable adaptive mode
+        title.zh: 关闭自适应模式
         description: Prevent automatic styling based on operating system.
+        description.zh: 停止根据操作系统自动调整样式。
         type: class-toggle
     -
         id: tab-floating
         title: Disable centered tabs
+        title.zh: 取消标签居中
+        description: Use left-aligned tabs instead of centered tabs in the tab bar.
+        description.zh: 将标签栏改为传统左侧对齐，而非居中排列。
         type: class-toggle
     -
         id: desktop-header
         title: Desktop
+        title.zh: 桌面端
         type: heading
         level: 1
         collapsed: true
     -
         id: hover-ribbon
         title: Hover ribbon
+        title.zh: 悬停显示功能区
         description: Reveal ribbon by hovering over left window edge.
+        description.zh: 鼠标靠近左侧窗口边缘时显示功能区（Ribbon）。
         type: class-toggle
         addCommand: true
     -
         id: hover-sidedock
         title: Hover sidebar
+        title.zh: 悬停显示侧边栏
         description: Reveal collapsed sidebars by hovering over window edges.
+        description.zh: 鼠标靠近窗口边缘时展开已收起的侧边栏。
         type: class-toggle
         addCommand: true
     -
         id: focus-view
         title: Focus view
+        title.zh: 专注视图
         description: Hide tabs and table title bar when both sidebars are collapsed.
+        description.zh: 当两侧栏均收起时隐藏标签与表格标题栏。
         type: class-toggle
         addCommand: true
     -
         id: nav-action-center
         title: Disable compact panel actions
+        title.zh: 取消紧凑面板操作区
+        description: Use default alignment for narrow sidebar header actions.
+        description.zh: 窄侧边栏顶栏操作按钮恢复默认对齐，不再居中紧凑排列。
         type: class-toggle
     -
         id: tab-icon
         title: Disable compact sidebar tabs
+        title.zh: 取消紧凑侧边栏标签
+        description: Keep full sidebar tab labels instead of icon-only compact tabs.
+        description.zh: 保留侧边栏标签的完整文字，而非仅图标的紧凑标签。
         type: class-toggle
     -
         id: status-bar-baseline
         title: Disable compact status bar
+        title.zh: 取消紧凑状态栏
+        description: Use a taller default-style status bar instead of the compact row.
+        description.zh: 使用更高的默认风格状态栏，而非单行紧凑状态栏。
         type: class-toggle
     -
         id: zoom-off
         title: Disable media zoom
+        title.zh: 关闭媒体缩放
+        description: Disable click-to-zoom behavior on images and media.
+        description.zh: 关闭图片与媒体的点击放大效果。
         type: class-toggle
     -
         id: editor
         title: Editor
+        title.zh: 编辑器
         type: heading
         level: 1
         collapsed: true
     -
         id: active-line-off
         title: Disable active line highlight
+        title.zh: 关闭当前行高亮
+        description: Turn off background highlight for the active line in the editor.
+        description.zh: 关闭编辑器中当前行的背景高亮。
         type: class-toggle
     -
         id: banner-off
         title: Disable banner
+        title.zh: 关闭 Banner
+        description: Disable styling for banner areas used by banner-style plugins.
+        description.zh: 关闭 Banner 类插件常用的顶部横幅区域样式。
         type: class-toggle
     -
         id: block-width-off
         title: Disable block width
+        title.zh: 关闭块级宽度
+        description: Do not widen blocks beyond the default reading column.
+        description.zh: 不将块元素加宽到默认阅读栏之外。
         type: class-toggle
     -
         id: font-variant-off
         title: Disable font variants
+        title.zh: 关闭字体变体
+        description: Disable OpenType stylistic alternates for interface fonts.
+        description.zh: 关闭界面字体的 OpenType 变体与替代字形特性。
         type: class-toggle
     -
         id: full-width-media-off
         title: Disable full-width elements
+        title.zh: 关闭全宽元素
+        description: Keep embeds and wide elements within the main text column.
+        description.zh: 将嵌入与全宽元素限制在正文主栏宽度内。
         type: class-toggle
     -
         id: image-align
         title: Image alignment
+        title.zh: 图片对齐
         description: Set default image alignment in editor and reading view.
+        description.zh: 设置编辑与阅读模式下的默认图片对齐方式。
         type: class-select
         allowEmpty: false
         default: image-align-center
         options:
             -
-                label: Left
+                label: Left / 左
                 value: image-align-left
             -
-                label: Center
+                label: Center / 居中
                 value: image-align-center
             -
-                label: Right
+                label: Right / 右
                 value: image-align-right
+    -
+        id: clean-link-off
+        title: Underlined links
+        title.zh: 链接始终下划线
+        description: Always underline links for improved visibility.
+        description.zh: 始终为链接添加下划线以提高辨识度。
+        type: class-toggle
     -
         id: mode-switcher-off
         title: Disable quick mode switcher
+        title.zh: 关闭快速配色切换
+        description: Hide the quick light/dark switch in the status bar area.
+        description.zh: 隐藏状态栏区域的快速明暗配色切换入口。
         type: class-toggle
     -
         id: accessibility
         title: Accessibility
+        title.zh: 辅助功能
         type: heading
         level: 1
         collapsed: true
-	-
-		id: reduce-contrast-change
-		title: Reduce contrast change
-		description: Minimize contrast shifts when window loses focus.
-		type: class-toggle
-	-
-		id: reduce-motion
-		title: Reduce motion
-		description: Minimize animation effects.
-		type: class-toggle
-	-
-		id: dynamic-type-off
-		title: Standard font size
-		description: Disable operating system-based dynamic font sizes.
-		type: class-toggle
-	-
-		id: font-ui-modifier
-		title: Interface font size
-		description: Fine-tune interface text size.
-		type: variable-number-slider
-		default: 0
-		min: -8
-		max: 8
-		step: 1
-		format: px
-	-
-		id: icon-size-modifier
-		title: Icon size
-		description: Fine-tune icon size.
-		type: variable-number-slider
-		default: 0
-		min: -4
-		max: 4
-		step: 1
-		format: px
     -
-        id: clean-link-off
-        title: Underlined links
-        description: Always underline links for improved visibility.
+        id: reduce-contrast-change
+        title: Reduce contrast change
+        title.zh: 减弱失焦对比变化
+        description: Minimize contrast shifts when window loses focus.
+        description.zh: 减轻窗口失焦时的对比度变化。
         type: class-toggle
+    -
+        id: reduce-motion
+        title: Reduce motion
+        title.zh: 减少动态效果
+        description: Minimize animation effects.
+        description.zh: 尽量减少动画与过渡效果。
+        type: class-toggle
+    -
+        id: dynamic-type-off
+        title: Standard font size
+        title.zh: 固定界面字号层级
+        description: Disable operating system-based dynamic font sizes.
+        description.zh: 关闭随系统「动态字体」调整的界面字号层级。
+        type: class-toggle
+    -
+        id: font-ui-modifier
+        title: Interface font size
+        title.zh: 界面字号微调
+        description: Fine-tune interface text size.
+        description.zh: 细调界面文字大小。
+        type: variable-number-slider
+        default: 0
+        min: -8
+        max: 8
+        step: 1
+        format: px
+    -
+        id: icon-size-modifier
+        title: Icon size
+        title.zh: 图标尺寸微调
+        description: Fine-tune icon size.
+        description.zh: 细调界面图标大小。
+        type: variable-number-slider
+        default: 0
+        min: -4
+        max: 4
+        step: 1
+        format: px
 */
 .view-content .style-settings-container .style-settings-container .setting-item {
   align-items: center;

--- a/theme.css
+++ b/theme.css
@@ -1,4 +1,2222 @@
-body,.theme-light,.theme-dark{--font-interface-theme: "SF Pro";--font-text-theme: "SF Pro";--font-ui-modifier: 0px;--font-ui-smaller: calc(12px + var(--font-ui-modifier));--font-ui-small: calc(13px + var(--font-ui-modifier));--font-ui-medium: calc(15px + var(--font-ui-modifier));--font-ui-large: calc(20px + var(--font-ui-modifier));--bold-modifier: 300;--icon-size-modifier: 0px;--icon-opacity: 1;--titlebar-background: transparent;--titlebar-background-focused: transparent;--divider-color-hover: var(--color-base-50);--corner-shape: superellipse(1.1);--shadow-s: rgba(0, 0, 0, 0.08) 0px 12px 24px -4px, rgba(0, 0, 0, 0.04) 0px 8px 16px -4px;--shadow-l: 0 14px 62px #00000040;--shadow-tactile: rgba(0, 0, 0, 0.04) 0px 2px 8px -2px, rgba(var(--mono-rgb-100), 0.04) 0px 2px 4px -2px;--anim-speed-modifier: 1;--anim-motion-baseline: cubic-bezier(0.32, 0.72, 0, 1);--anim-duration-superfast: calc(80ms * var(--anim-speed-modifier));--anim-duration-fast: calc(160ms * var(--anim-speed-modifier));--anim-duration-moderate: calc(320ms * var(--anim-speed-modifier));--anim-duration-slow: calc(480ms * var(--anim-speed-modifier));--icon-stroke-modifier: 1;--icon-xs-stroke-width: calc(2.25px * var(--icon-stroke-modifier));--icon-s-stroke-width: calc(2px * var(--icon-stroke-modifier));--icon-m-stroke-width: calc(2px * var(--icon-stroke-modifier));--icon-l-stroke-width: calc(2px * var(--icon-stroke-modifier));--icon-xl-stroke-width: calc(1.25px * var(--icon-stroke-modifier));--density-modifier: 1;--translucent-light-opacity: 0%;--translucent-dark-opacity: 0%;--color-red: rgb(var(--color-red-rgb));--color-orange: rgb(var(--color-orange-rgb));--color-yellow: rgb(var(--color-yellow-rgb));--color-green: rgb(var(--color-green-rgb));--color-cyan: rgb(var(--color-cyan-rgb));--color-blue: rgb(var(--color-blue-rgb));--color-purple: rgb(var(--color-purple-rgb));--color-pink: rgb(var(--color-pink-rgb));--background-modifier-cover: rgba(0, 0, 0, 0.35)}.theme-light{--workspace-background-translucent: rgb(from var(--background-secondary) r g b / var(--translucent-light-opacity));--color-red-rgb: 254, 112, 112;--color-orange-rgb: 242, 154, 100;--color-yellow-rgb: 224, 205, 99;--color-green-rgb: 74, 213, 95;--color-cyan-rgb: 56, 219, 214;--color-blue-rgb: 106, 173, 250;--color-purple-rgb: 187, 158, 245;--color-pink-rgb: 243, 125, 183;--code-normal: #383a42;--code-comment: #b6b9c5;--code-function: #b76b02;--code-important: #b76b02;--code-keyword: #e45749;--code-property: #62afef;--code-punctuation: #383a42;--code-string: #0d97b3;--code-tag: #e45749;--code-value: #a626a4}.theme-dark{--workspace-background-translucent: rgb(from var(--background-secondary) r g b / var(--translucent-dark-opacity));--color-red-rgb: 217, 90, 95;--color-orange-rgb: 219, 134, 80;--color-yellow-rgb: 196, 180, 94;--color-green-rgb: 72, 196, 90;--color-cyan-rgb: 63, 186, 182;--color-blue-rgb: 86, 148, 218;--color-purple-rgb: 142, 125, 194;--color-pink-rgb: 222, 103, 147;--code-normal: #abb2bf;--code-comment: #5c6370;--code-function: #d19a66;--code-important: #d19a66;--code-keyword: #e16d76;--code-property: #62afef;--code-punctuation: #abb2bf;--code-string: #58b6c2;--code-tag: #e16d76;--code-value: #c678de}body:not(.is-mobile){--icon-xs: calc(14px + var(--icon-size-modifier));--icon-s: calc(16px + var(--icon-size-modifier));--icon-m: calc(16px + var(--icon-size-modifier));--icon-l: calc(16px + var(--icon-size-modifier));--icon-xl: calc(32px + var(--icon-size-modifier))}body:not(.is-mobile) .app-container{transition:var(--anim-duration-moderate);align-items:center}body:not(.is-mobile):not(.is-translucent) .workspace{background:var(--background-secondary)}body:not(.is-mobile) .workspace{transition:var(--anim-duration-moderate)}body:not(.is-mobile) .workspace-split{transition:var(--anim-duration-moderate);background-color:rgba(0,0,0,0)}@media(prefers-color-scheme: light){.theme-dark{--workspace-background-translucent: var(--background-secondary)}}@media(prefers-color-scheme: dark){.theme-light{--workspace-background-translucent: var(--background-secondary)}}.is-translucent{--blur-s: none !important;--blur-m: none !important;--blur-l: none !important;--divider-color: var(--background-modifier-border) !important;--tab-outline-color: var(--background-modifier-border)}.is-popout-window{--workspace-background-translucent: var(--background-secondary);background-color:rgb(var(--mono-rgb-100))}body.is-frameless:not(.is-translucent,.is-hidden-frameless,.is-fullscreen) .titlebar{background-color:var(--background-secondary)}body.titlebar-text-off .titlebar-text{display:none}body:not(.mod-macos):not(.is-mobile){--frame-right-space: 144px}body:not(.mod-macos):not(.is-mobile).is-hidden-frameless .titlebar{height:var(--header-height)}body:not(.mod-macos):not(.is-mobile) .titlebar-button-container.mod-right{width:var(--frame-right-space)}body:not(.mod-macos):not(.is-mobile) .titlebar-button-container.mod-right .titlebar-button{justify-content:center;flex:1}body:not(.mod-macos):not(.is-mobile) .titlebar-button-container.mod-right .titlebar-button path,body:not(.mod-macos):not(.is-mobile) .titlebar-button-container.mod-right .titlebar-button rect,body:not(.mod-macos):not(.is-mobile) .titlebar-button-container.mod-right .titlebar-button circle{visibility:hidden}body:not(.mod-macos):not(.is-mobile) .titlebar-button-container.mod-right .titlebar-button svg{-webkit-mask-size:100% 100%;background-color:currentcolor;width:auto;height:10px}body:not(.mod-macos):not(.is-mobile) .titlebar-button.mod-minimize svg{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='2' fill='none' viewBox='0 0 12 2'%3e%3cpath fill='black' d='M.598 1.201A.604.604 0 0 1 0 .604.61.61 0 0 1 .598 0h10.804c.324 0 .598.281.598.604a.605.605 0 0 1-.598.597H.598Z'/%3e%3c/svg%3e")}body:not(.mod-macos):not(.is-mobile) .titlebar-button.mod-maximize svg{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' viewBox='0 0 12 12'%3e%3cpath fill='black' d='M1.77 12C.825 12 0 11.175 0 10.23V1.77C0 .83.828 0 1.77 0h8.46C11.167 0 12 .833 12 1.77v8.46c0 .942-.83 1.77-1.77 1.77H1.77Zm8.431-1.201a.605.605 0 0 0 .598-.598V1.8a.606.606 0 0 0-.599-.6H1.8a.605.605 0 0 0-.6.6v8.4c0 .325.273.598.598.598H10.2Z'/%3e%3c/svg%3e")}body:not(.mod-macos):not(.is-mobile) .titlebar-button.mod-close svg{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' viewBox='0 0 12 12'%3e%3cpath fill='black' d='m6 6.848-4.975 4.974a.618.618 0 0 1-.856.006.618.618 0 0 1 .006-.855L5.15 5.998.175 1.024c-.226-.227-.24-.628 0-.85a.606.606 0 0 1 .85 0l4.974 4.975L10.974.174a.606.606 0 0 1 .85 0 .606.606 0 0 1 0 .85L6.848 5.998l4.974 4.975a.606.606 0 0 1 0 .85c-.222.239-.623.225-.85 0L6 6.847Z'/%3e%3c/svg%3e")}body:not(.mod-macos):not(.is-mobile).is-maximized .titlebar-button.mod-maximize svg{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' viewBox='0 0 12 12'%3e%3cpath fill='black' d='M10.799 3.557C10.799 2.27 9.67 1.2 8.396 1.2H2.502a1.808 1.808 0 0 1 1.7-1.2h4.194C10.352 0 12 1.641 12 3.598v4.2c0 .758-.484 1.45-1.201 1.7V3.557ZM1.769 12C.826 12 0 11.175 0 10.23V4.172c0-.941.828-1.77 1.77-1.77h6.058c.945 0 1.77.825 1.77 1.77v6.058c0 .942-.829 1.77-1.77 1.77H1.77Zm6.03-1.201a.61.61 0 0 0 .603-.598v-6a.607.607 0 0 0-.603-.603h-6A.61.61 0 0 0 1.2 4.2v6c0 .325.273.598.598.598h6Z'/%3e%3c/svg%3e")}body.styled-scrollbars div:not(:hover)::-webkit-scrollbar-thumb{background-color:rgba(0,0,0,0)}body.reduce-motion{--anim-speed-modifier: 0 !important}body.reduce-motion.is-mobile{--mobile-sidebar-width: 90vw}body.reduce-motion.is-mobile .workspace-drawer,body.reduce-motion.is-mobile .workspace-split,body.reduce-motion.is-mobile .mobile-tab-switcher,body.reduce-motion.is-mobile .menu,body.reduce-motion.is-mobile .suggestion-bg,body.reduce-motion.is-mobile .modal,body.reduce-motion.is-mobile .modal-bg,body.reduce-motion.is-mobile .mobile-navbar{transform:none !important;transition:none !important}@starting-style{body.reduce-motion.is-mobile .workspace-drawer,body.reduce-motion.is-mobile .workspace-split,body.reduce-motion.is-mobile .mobile-tab-switcher,body.reduce-motion.is-mobile .menu,body.reduce-motion.is-mobile .suggestion-bg,body.reduce-motion.is-mobile .modal,body.reduce-motion.is-mobile .modal-bg,body.reduce-motion.is-mobile .mobile-navbar{opacity:0 !important}}@supports not (interpolate-size: allow-keywords){body:not(.is-mobile).obsidian-app.obsidian-app.obsidian-app{--modal-background: var(--background-secondary) !important}body:not(.is-mobile):not(.is-popout-window) .mod-root::before{content:"Cupertino requires a newer Obsidian installer. Download and run the latest installer from obsidian.md to remove this message.";display:flex;position:absolute;justify-content:center;align-items:center;z-index:var(--layer-cover);inset:auto 0 0;padding:16px 48px;background-color:var(--background-secondary);color:var(--text-muted);font-size:var(--font-ui-medium);white-space:pre-wrap}}.lucide-folder-closed path[d="M2 10h20"]{display:none}.lucide-arrow-left path[d="M19 12H5"]{display:none}.lucide-arrow-left path[d="m12 19-7-7 7-7"]{transform:translateX(2px)}.lucide-arrow-right path[d="M5 12h14"]{display:none}.lucide-arrow-right path[d="m12 5 7 7-7 7"]{transform:translateX(-2px)}.lucide-edit-3 path[d="M13 21h8"]{display:none}body:not(.reduce-motion,.is-mobile) .workspace svg.svg-icon{transition:var(--anim-duration-moderate) var(--anim-motion-baseline)}@starting-style{body:not(.reduce-motion,.is-mobile) .workspace .clickable-icon:not(.workspace-ribbon>.sidebar-toggle-button>.clickable-icon) svg.svg-icon{filter:blur(4px);scale:.75;opacity:0}}body:not(.reduce-motion,.is-mobile) .workspace .clickable-icon:not([aria-disabled=true]):active svg.svg-icon,body:not(.reduce-motion,.is-mobile) .workspace .mod-sidedock .workspace-tab-header.tappable:active svg.svg-icon{scale:.75;opacity:.75}body:not(.reduce-motion,.is-mobile) .workspace .workspace-tab-header-tab-list .clickable-icon:is(:hover,.has-active-menu) svg.svg-icon{transform:translateY(1px)}body:not(.reduce-motion,.is-mobile) .workspace .view-header-nav-buttons .clickable-icon:not([aria-disabled=true]):first-child:hover svg.svg-icon{transform:translateX(-1px)}body:not(.reduce-motion,.is-mobile) .workspace .view-header-nav-buttons .clickable-icon:not([aria-disabled=true]):last-child:hover svg.svg-icon{transform:translateX(1px)}body{--header-height: 48px;--tab-max-width: var(--tab-width);--tab-radius: var(--radius-s);--tab-radius-active: var(--tab-radius) var(--tab-radius) 0 0;--tab-curve: calc(var(--tab-radius) + 4px);--tab-outline-width: 0px;--tab-divider-color: var(--background-modifier-border);--tab-text-align: left;--tab-text-color-focused-active: var(--text-normal);--tab-text-color-focused-active-current: unset}body.mod-macos{--header-height: 52px}body:not(.is-mobile){--tab-action-width: 32px}body.is-mobile{--header-height: 44px !important;--tab-text-color-active: var(--text-normal);--tab-text-color-focused: var(--text-normal)}body.is-tablet{--header-height: 52px !important;--tab-action-width: 44px}body:not(.is-phone) .workspace-tab-header-container{transition:var(--anim-duration-moderate) var(--anim-motion-baseline);background-color:rgba(0,0,0,0);border-bottom:none}.sidebar-toggle-button{height:100%;padding-bottom:8px;align-items:center}.sidebar-toggle-button .clickable-icon{width:fit-content;height:fit-content}.workspace-tab-header-inner-icon{color:inherit !important}body:not(.is-phone) .workspace .mod-root .workspace-tab-header-container-inner{padding:8px var(--tab-curve) 0;margin:0 -4px 0 0;gap:8px}body:not(.is-phone) .workspace .mod-root .workspace-tab-header{--tab-outline-width: 0px;padding:0}body:not(.is-phone) .workspace .mod-root .workspace-tab-header-inner{padding-inline-start:12px;padding-inline-end:8px;margin-bottom:8px;height:auto}body:not(.is-phone) .workspace .mod-root .workspace-tab-header-inner-title{line-height:normal;text-align:var(--tab-text-align)}body:not(.is-phone) .workspace .mod-root .workspace-tab-header-new-tab,body:not(.is-phone) .workspace .mod-root .workspace-tab-header-tab-list{display:block;align-content:center;padding:4px 0;margin:0}body:not(.is-phone) .workspace .mod-root .workspace-tab-header-new-tab .clickable-icon,body:not(.is-phone) .workspace .mod-root .workspace-tab-header-tab-list .clickable-icon{height:auto;padding:8px}body:not(.is-phone) .workspace .mod-root .workspace-tabs:not(.mod-stacked){--tab-radius-active: var(--tab-radius);--tab-curve: 0}body:not(.is-phone) .workspace .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header-container-inner{padding-bottom:8px;gap:4px;margin:0}body:not(.is-phone) .workspace .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header{padding:0;background-color:var(--background-modifier-hover)}body:not(.is-phone) .workspace .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header:not(.is-active):not(:hover){opacity:.5}body:not(.is-phone) .workspace .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header-inner{padding-inline-start:12px;padding-inline-end:8px;margin-bottom:0}body.is-tablet{--header-height: 60px !important}body.is-tablet .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header-container-inner{padding-block:0 !important}body.is-tablet .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header{margin-block:8px}body:not(.is-phone):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked){container-type:inline-size}@container (min-width: 560px){body:not(.is-phone):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header-container-inner{flex:1;justify-content:safe center;transition:padding-left var(--anim-duration-moderate) var(--anim-motion-baseline),padding-right var(--anim-duration-moderate) var(--anim-motion-baseline)}body:not(.is-phone):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header-spacer{display:none}}@container (min-width: 560px){body.mod-macos:not(.is-mobile):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked):not(.mod-top-left-space).mod-top-right-space .workspace-tab-header-container-inner{padding-left:calc(var(--tab-action-width)*3)}body.mod-macos:not(.is-mobile):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked):not(.mod-top-left-space):not(.mod-top-right-space) .workspace-tab-header-container-inner{padding-left:calc(var(--tab-action-width)*2)}}@container (min-width: 560px){body.mod-macos:not(.is-mobile):not(.tab-floating):not(.is-fullscreen) .mod-root .workspace-tabs:not(.mod-stacked).mod-top-left-space.mod-top-right-space .workspace-tab-header-container-inner{padding-right:calc(var(--frame-left-space) + --tab-action-width*2)}body.mod-macos:not(.is-mobile):not(.tab-floating):not(.is-fullscreen) .mod-root .workspace-tabs:not(.mod-stacked).mod-top-left-space:not(.mod-top-right-space) .workspace-tab-header-container-inner{padding-right:calc(var(--frame-left-space) - var(--tab-action-width))}}@container (min-width: 560px){body.mod-macos:not(.is-mobile):not(.tab-floating).is-fullscreen .mod-root .workspace-tabs:not(.mod-stacked).mod-top-left-space.mod-top-right-space .workspace-tab-header-container-inner{padding-left:calc(var(--tab-action-width)*2)}body.mod-macos:not(.is-mobile):not(.tab-floating).is-fullscreen .mod-root .workspace-tabs:not(.mod-stacked).mod-top-left-space:not(.mod-top-right-space) .workspace-tab-header-container-inner{padding-left:var(--tab-action-width)}}@container (min-width: 560px){body:not(.mod-macos):not(.is-mobile):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked).mod-top-left-space.mod-top-right-space .workspace-tab-header-container-inner{padding-left:calc(var(--frame-right-space) + var(--tab-action-width)*2)}body:not(.mod-macos):not(.is-mobile):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked).mod-top-left-space:not(.mod-top-right-space) .workspace-tab-header-container-inner{padding-left:calc(var(--tab-action-width)*2)}body:not(.mod-macos):not(.is-mobile):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked):not(.mod-top-left-space).mod-top-right-space .workspace-tab-header-container-inner{padding-left:calc(var(--frame-right-space) + var(--tab-action-width)*3)}body:not(.mod-macos):not(.is-mobile):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked):not(.mod-top-left-space):not(.mod-top-right-space).mod-top .workspace-tab-header-container-inner{padding-left:calc(var(--tab-action-width)*3)}body:not(.mod-macos):not(.is-mobile):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked):is(.mod-root>.workspace-tabs):not(:only-of-type).mod-top-left-space:not(.mod-top-right-space) .workspace-tab-header-container-inner{padding-left:var(--tab-action-width)}body:not(.mod-macos):not(.is-mobile):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked):is(.mod-root>.workspace-tabs):not(:only-of-type):first-of-type:not(.mod-top-left-space):not(.mod-top-right-space) .workspace-tab-header-container-inner,body:not(.mod-macos):not(.is-mobile):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked):not(.mod-top) .workspace-tab-header-container-inner{padding-left:calc(var(--tab-action-width)*2)}}@container (min-width: 560px){body.is-tablet:not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked).mod-top-left-space.mod-top-right-space .workspace-tab-header-container-inner{padding-left:calc(var(--tab-action-width)*2)}body.is-tablet:not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked).mod-top-left-space:not(.mod-top-right-space) .workspace-tab-header-container-inner{padding-left:var(--tab-action-width)}body.is-tablet:not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked):not(.mod-top-left-space).mod-top-right-space .workspace-tab-header-container-inner{padding-left:calc(var(--tab-action-width)*3)}body.is-tablet:not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked):not(.mod-top-left-space):not(.mod-top-right-space) .workspace-tab-header-container-inner{padding-left:calc(var(--tab-action-width)*2)}}@container (min-width: 560px){body.is-tablet:not(.tab-floating) .workspace-drawer.is-pinned.mod-left+.mod-root .workspace-tabs:not(.mod-stacked).mod-top-left-space.mod-top-right-space .workspace-tab-header-container-inner{padding-left:calc(var(--tab-action-width)*3)}body.is-tablet:not(.tab-floating) .workspace-drawer.is-pinned.mod-left+.mod-root .workspace-tabs:not(.mod-stacked).mod-top-left-space:not(.mod-top-right-space) .workspace-tab-header-container-inner{padding-left:calc(var(--tab-action-width)*2)}}@container (min-width: 560px){body.is-tablet:not(.tab-floating) .mod-root:has(+.workspace-drawer.is-pinned.mod-right) .workspace-tabs:not(.mod-stacked).mod-top-left-space.mod-top-right-space .workspace-tab-header-container-inner{padding-left:var(--tab-action-width)}body.is-tablet:not(.tab-floating) .mod-root:has(+.workspace-drawer.is-pinned.mod-right) .workspace-tabs:not(.mod-stacked):not(.mod-top-left-space).mod-top-right-space .workspace-tab-header-container-inner{padding-left:calc(var(--tab-action-width)*2)}}.mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header-inner::after{content:none}.mod-root .workspace-tabs.mod-stacked .workspace-tab-header-container-inner{display:none}body.is-tablet .workspace .mod-root .sidebar-toggle-button{padding-left:0}body.is-tablet .workspace .mod-root .sidebar-toggle-button .clickable-icon{margin:auto 0}body.is-tablet .workspace .mod-root .workspace-tab-header-tab-list .clickable-icon,body.is-tablet .workspace .mod-root .workspace-tab-header-new-tab .clickable-icon{--icon-size: var(--icon-l);--icon-stroke: var(--icon-l-stroke-width)}.workspace .mod-sidedock .workspace-tab-header-container,.workspace .mod-sidedock .workspace-tab-header,.workspace .mod-sidedock .workspace-tab-header div{transition:var(--anim-duration-moderate) var(--anim-motion-baseline)}.workspace .mod-sidedock .workspace-tab-header-container{padding-block:8px;align-items:center}.workspace .mod-sidedock .workspace-tab-header-container-inner{-webkit-app-region:no-drag;padding:0 8px 0 0;margin:0;gap:calc(8px*var(--density-modifier));height:100%}.workspace .mod-sidedock .sidebar-toggle-button{position:relative !important;padding:0 !important;height:fit-content}.workspace .mod-sidedock .workspace-tab-header{height:calc-size(auto,size);line-height:normal}.workspace .mod-sidedock .workspace-tab-header.is-active{background-color:inherit;box-shadow:none}.workspace .mod-sidedock .workspace-tab-header.is-active:hover{background-color:inherit}.workspace .mod-sidedock .workspace-tab-header:not(.is-active):not(:hover){opacity:.5}.workspace .mod-sidedock .workspace-tab-header:not(.is-active):hover .workspace-tab-header-inner{background-color:inherit}.workspace .mod-sidedock .workspace-tab-header-inner{gap:8px}body:not(.tab-icon) .mod-sidedock .workspace-tabs:not(.mod-top) .workspace-tab-header-container:not(:hover){height:calc-size(auto,size)}body:not(.tab-icon) .mod-sidedock .workspace-tabs:not(.mod-top) .workspace-tab-header-container:not(:hover) .workspace-tab-header{background-color:var(--background-modifier-hover);height:4px}body:not(.tab-icon) .mod-sidedock .workspace-tabs:not(.mod-top) .workspace-tab-header-container:not(:hover) .workspace-tab-header-inner-icon,body:not(.tab-icon) .mod-sidedock .workspace-tabs:not(.mod-top) .workspace-tab-header-container:not(:hover) .workspace-tab-header-inner-title{opacity:0}body:not(.mod-macos).is-hidden-frameless .mod-sidedock .workspace-tabs.mod-top-right-space .workspace-tab-header-container{padding-right:var(--frame-right-space)}body.mod-macos.is-frameless:not(.is-popout-window) .workspace .workspace-tabs.mod-top-right-space .workspace-tab-header-container{padding-right:8px}body.mod-macos.is-frameless:not(.is-popout-window) .workspace .mod-root .sidebar-toggle-button.mod-right{position:relative;padding-right:0}body{--nav-item-padding: calc(8px * var(--density-modifier)) 16px calc(8px * var(--density-modifier)) 32px;--nav-indentation-guide-width: 0px;--nav-item-children-margin-start: calc(20px - var(--nav-indentation-guide-width) / 2);--ribbon-background: transparent;--ribbon-background-collapsed: var(--ribbon-background);--divider-vertical-height: 100% !important}body.is-mobile{--nav-item-padding: calc(10px * var(--density-modifier)) 24px;--nav-item-color: var(--text-muted);--nav-item-size: var(--font-ui-small);--nav-item-weight-active: var(--font-medium);--nav-item-children-margin-start: 12px}@keyframes workspaceLeafIn{from{opacity:0;transform:scale(0.95)}}.sidebar-toggle-icon-inner{transition:var(--anim-duration-moderate) var(--anim-motion-baseline)}.sidebar-toggle-button .clickable-icon:hover .sidebar-toggle-icon-inner{width:24%}.workspace.is-left-sidedock-open .sidebar-toggle-button.mod-left .clickable-icon:hover .sidebar-toggle-icon-inner,.workspace.is-right-sidedock-open .sidebar-toggle-button.mod-right .clickable-icon:hover .sidebar-toggle-icon-inner{width:revert-layer}body.full-item-name{--nav-item-white-space: none}body.bold-folders .nav-folder-title{--nav-item-weight: calc(var(--font-weight) + var(--bold-modifier));--nav-item-weight-hover: calc(var(--font-weight) + var(--bold-modifier))}.tree-item-self,.tree-item-inner{align-items:center}.nav-header{display:flex;justify-content:center;flex-direction:column;align-items:center;padding:8px 16px}.nav-header .nav-buttons-container{flex-wrap:nowrap}.nav-header .search-input-container{margin:8px 0;width:100%}.nav-action-button,.nav-action-button[aria-disabled=true]{position:relative;height:100%}body.mod-macos.is-hidden-frameless .workspace-ribbon.mod-left{padding-top:0}.workspace-ribbon.mod-left{border-right:none;z-index:11;transition:var(--anim-duration-moderate) !important;position:relative}.workspace-ribbon.mod-left:not(.is-collapsed){padding-left:12px}.workspace-ribbon.mod-left:before{content:none}.workspace-ribbon.mod-left .sidebar-toggle-button{position:relative;display:flex;height:var(--header-height);padding:8px;width:unset;align-items:center;justify-content:center}.workspace-ribbon.mod-left .sidebar-toggle-button .clickable-icon{pointer-events:auto;z-index:1}.workspace-ribbon.mod-left .side-dock-actions{gap:4px;transition:var(--anim-duration-moderate);z-index:1;color:var(--icon-color)}.workspace-ribbon.mod-left .sidebar-toggle-button .clickable-icon,.workspace-ribbon.mod-left .side-dock-actions .side-dock-ribbon-action{width:var(--tab-action-width)}body:not(.mod-macos):not(.is-mobile) .workspace-ribbon.mod-left,body.mod-macos:not(.is-hidden-frameless):not(.is-mobile) .workspace-ribbon.mod-left{margin-top:0}body:not(.mod-macos):not(.is-mobile) .workspace-ribbon.mod-left .sidebar-toggle-button,body.mod-macos:not(.is-hidden-frameless):not(.is-mobile) .workspace-ribbon.mod-left .sidebar-toggle-button{height:auto;padding:0;margin:0 auto}body:not(.mod-macos):not(.is-mobile) .workspace-ribbon.mod-left .sidebar-toggle-button{height:calc(var(--header-height) - 16px)}body:not(.is-mobile) .mod-sidedock>.workspace-leaf-resize-handle:not(:hover){border-color:rgba(0,0,0,0)}body:not(.is-mobile) .mod-sidedock .workspace-leaf{background-color:rgba(0,0,0,0)}body:not(.is-mobile) .mod-sidedock .workspace-leaf:not([style*="display: none"]){animation:workspaceLeafIn var(--anim-duration-moderate) var(--anim-motion-baseline) forwards}body:not(.is-mobile) .mod-sidedock .workspace-leaf-content>.node-insert-event,body:not(.is-mobile) .mod-sidedock .workspace-leaf-content>.view-content{padding:2px 8px}body:not(.is-mobile) .mod-sidedock .workspace-leaf-content>.node-insert-event>.node-insert-event,body:not(.is-mobile) .mod-sidedock .workspace-leaf-content>.view-content>.node-insert-event{padding:0}.nav-header,.nav-buttons-container,.nav-action-button,.nav-action-button::after,.nav-header svg{transition:var(--anim-duration-moderate) var(--anim-motion-baseline),background-color var(--anim-duration-fast)}body:not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child:not(:hover) .nav-buttons-container{gap:4px !important;padding:0 !important;background-color:rgba(0,0,0,0) !important;box-shadow:none !important}body:not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child:not(:hover) .nav-buttons-container .nav-action-button{padding:2px !important;width:0 !important;flex:0;background-color:var(--background-modifier-hover);box-shadow:none !important;min-width:0}body:not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child:not(:hover) .nav-buttons-container .nav-action-button::after{font-size:0;opacity:0}body:not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child:not(:hover) .nav-buttons-container .nav-action-button.is-active{background-color:var(--background-modifier-hover) !important}body:not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child:not(:hover) .nav-buttons-container .nav-action-button.clickable-icon[aria-disabled=true]{opacity:var(--icon-opacity)}body:not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child:not(:hover) .nav-buttons-container svg{width:0px;height:0px}body:not(.is-mobile) .workspace-split.mod-left-split .workspace-drawer-vault-actions .clickable-icon:first-child{display:none}body:not(.is-mobile) .mod-sidedock.mod-left-split .workspace-sidedock-vault-profile{background-color:rgba(0,0,0,0)}body:not(.is-mobile) .mod-sidedock.mod-left-split .workspace-sidedock-vault-profile{border-top:none;position:absolute;inset:auto 0 0;z-index:1;align-items:unset;width:auto}body:not(.is-mobile) .mod-sidedock.mod-left-split .workspace-sidedock-vault-profile:hover~.workspace-tabs:last-child{mask:linear-gradient(to top, transparent, black 64px)}body:not(.is-mobile) .mod-sidedock.mod-left-split .workspace-sidedock-vault-profile .workspace-drawer-vault-switcher.has-active-menu{background-color:var(--interactive-normal)}body:not(.is-mobile) .mod-sidedock.mod-left-split .workspace-sidedock-vault-profile:not(:hover){pointer-events:none}body:not(.is-mobile) .mod-sidedock.mod-left-split .workspace-sidedock-vault-profile:not(:hover) .workspace-drawer-vault-switcher:not(.has-active-menu){opacity:0;filter:blur(4px);pointer-events:none;transform:scale(0.95)}body:not(.is-mobile) .mod-sidedock.mod-left-split .workspace-drawer-vault-switcher,body:not(.is-mobile) .mod-sidedock.mod-left-split .workspace-drawer-vault-actions .clickable-icon{transition:var(--anim-duration-moderate) var(--anim-motion-baseline);pointer-events:visible}body:not(.is-mobile) .mod-sidedock.mod-left-split .workspace-leaf-content>.node-insert-event,body:not(.is-mobile) .mod-sidedock.mod-left-split .workspace-leaf-content>.view-content{padding-bottom:64px}@keyframes menuIn{from{opacity:0;transform:translateY(-8px)}}.menu,.suggestion-container{border-radius:var(--menu-radius);padding:0}.menu .menu-item,.menu .suggestion-item,.suggestion-container .menu-item,.suggestion-container .suggestion-item{padding:calc(6px*var(--density-modifier)) 8px;border-radius:calc(var(--menu-radius) - var(--menu-padding));margin-bottom:0}.menu .menu-item-icon,.suggestion-container .menu-item-icon{order:unset !important;color:var(--text-normal)}.menu .menu-item-icon .svg-icon,.suggestion-container .menu-item-icon .svg-icon{--icon-size: var(--icon-xs);--icon-stroke: var(--icon-xs-stroke-width)}.menu .menu-separator,.suggestion-container .menu-separator{margin:4px 0}body:not(.is-phone){--menu-padding: 4px;--menu-border-color: var(--background-modifier-border)}body:not(.is-phone)>.menu,body:not(.is-phone)>.suggestion-container{animation:menuIn var(--anim-duration-moderate) var(--anim-motion-baseline) forwards}body:not(.is-phone) .menu,body:not(.is-phone) .suggestion-container div:is(.suggestion-item,.suggestion-empty){font-size:var(--font-ui-small);align-items:center}body.is-mobile .menu .menu-item-icon .svg-icon,body.is-mobile .suggestion-container .menu-item-icon .svg-icon{--icon-size: var(--icon-s);--icon-stroke: var(--icon-s-stroke-width)}body.is-phone{--menu-padding: 32px 16px}body.is-phone .menu{border-radius:var(--radius-l) var(--radius-l) 0 0;overflow:hidden}body.is-phone .menu .menu-grabber{margin:8px auto;position:absolute;inset:0}body.is-phone .menu .menu-scroll{max-height:80vh}body.is-phone .menu .menu-item{padding:calc(16px*var(--density-modifier)) 20px;font-size:var(--nav-item-size);gap:16px;border-radius:0}body.is-phone .menu .menu-item:only-child{border-radius:var(--radius-s)}body.is-phone .menu .menu-separator{margin:calc(12px*var(--density-modifier)) 16px}body.is-phone .suggestion-container{border-radius:var(--radius-l)}body.is-phone .suggestion-container .suggestion-item{border-radius:var(--radius-m);padding:calc(8px*var(--density-modifier)) 16px}body.is-tablet .menu,body.is-tablet .suggestion-container{border:1px solid var(--background-modifier-border-hover);border-radius:var(--menu-radius);overflow:auto;max-height:80vh}body.is-tablet .menu .menu-scroll,body.is-tablet .suggestion-container .menu-scroll{overflow:visible}body.is-tablet .menu .menu-item,body.is-tablet .suggestion-container .menu-item{padding:calc(8px*var(--density-modifier)) 12px;font-size:var(--font-ui-small)}body.is-tablet .menu .menu-item-title,body.is-tablet .suggestion-container .menu-item-title{max-width:240px}body{--modal-background: var(--background-secondary);--modal-border-color: var(--background-modifier-border)}body .modal-title{font-family:var(--h1-font);transition:var(--anim-duration-moderate) var(--anim-motion-baseline);overflow:visible;text-align:left}body .modal-close-button{border-radius:100vh;position:absolute;top:8px;inset-inline-end:8px !important;height:unset;width:unset;padding:8px;line-height:12px;z-index:1}body .modal-close-button:empty::before{content:"✕";line-height:1;display:block;text-align:center;width:var(--icon-l);height:var(--icon-l);font-size:var(--icon-m);font-weight:bold}@keyframes modalIn{from{opacity:0;transform:scale(0.975)}}body:not(.is-mobile) .modal-bg{opacity:.2 !important}body:not(.is-mobile) .modal{animation:modalIn var(--anim-duration-moderate) var(--anim-motion-baseline) forwards}body:not(.is-mobile) .modal-title{margin-left:0}body.is-phone .modal-container.mod-confirmation .modal:not(.mod-sidebar-layout){--modal-radius: var(--radius-l) var(--radius-l) 0 0}body.is-phone .modal:not(.mod-sidebar-layout) .modal-header{border-bottom:none;padding-top:24px}body.is-phone .modal:not(.mod-sidebar-layout) .modal-content{padding:var(--safe-area-inset-side)}body.is-phone .modal:not(.mod-sidebar-layout) .modal-nav-action{position:relative;background-color:var(--interactive-normal);margin:0 var(--safe-area-inset-side) 8px}body.is-phone .modal:not(.mod-sidebar-layout)>button:last-child{margin-bottom:var(--safe-area-inset-bottom) !important}body.is-tablet{--modal-radius: var(--radius-l)}.notice-container{display:flex;flex-direction:column;gap:8px;overflow:visible}.notice{padding:calc(12px*var(--density-modifier)) 16px;margin-bottom:0;border:none !important}body{--prompt-input-height: 64px;--prompt-border-color: var(--background-modifier-border)}body .prompt{background-color:var(--background-secondary);animation:modalIn var(--anim-duration-moderate) var(--anim-motion-baseline) forwards}body .prompt .prompt-input,body .prompt .prompt-input:hover,body .prompt .prompt-input:focus,body .prompt .prompt-input:focus-visible{background-color:rgba(0,0,0,0);border-bottom-color:var(--divider-color)}body .prompt .prompt-results{flex:1}body .prompt .suggestion-item{padding:12px}body.is-phone .prompt{animation:none;border-radius:var(--radius-l) var(--radius-l) 0 0}body.is-phone .prompt .prompt-results{padding:var(--safe-area-inset-side)}body.is-phone .prompt .prompt-input-container{width:auto;margin:auto var(--keyboard-spacing) var(--keyboard-spacing)}body.is-phone .prompt .prompt-input{background-color:var(--background-primary)}body.is-phone .prompt .suggestion-item{padding:calc(16px*var(--density-modifier)) 16px}body.is-tablet{--prompt-input-height: 64px}body.is-tablet .prompt{border-radius:var(--modal-radius)}body.is-tablet .prompt-input{background-color:rgba(0,0,0,0)}body:not(.is-phone){--setting-items-radius: var(--radius-m);--setting-items-padding: calc(16px * var(--density-modifier)) 16px;--setting-group-heading-color: var(--text-faint);--setting-group-heading-size: var(--font-ui-small)}body:not(.is-phone) .modal-sidebar{--background-modifier-form-field: var(--interactive-normal)}body:not(.is-phone) .modal.mod-sidebar-layout .vertical-tab-header{border-inline-end:none}body:not(.is-phone) .modal.mod-sidebar-layout .vertical-tab-header-group-title,body:not(.is-phone) .modal.mod-sidebar-layout .vertical-tab-nav-item{padding:calc(8px*var(--density-modifier)) 12px;align-items:center;font-size:var(--font-ui-small)}body:not(.is-phone) .modal.mod-sidebar-layout .vertical-tab-content{background-color:var(--modal-sidebar-background)}body:not(.is-phone) .modal.mod-sidebar-layout .setting-group-search{padding:0 0 8px;background-color:rgba(0,0,0,0)}body:not(.is-phone) .modal.mod-sidebar-layout .setting-item-name{overflow:visible}body:not(.is-phone) .installed-plugins-container .setting-item .setting-item-description div:last-child{color:var(--text-muted);margin-top:4px}body:not(.is-phone) .installed-plugins-container .setting-items{display:grid;grid-template-columns:repeat(auto-fill, minmax(200px, 1fr));grid-auto-rows:1fr;gap:8px;padding:0;background-color:rgba(0,0,0,0)}body:not(.is-phone) .installed-plugins-container .setting-items .setting-item{display:flex;flex-direction:column;margin:0px !important;border:none;border-radius:var(--setting-items-radius) !important;background-color:var(--setting-items-background);padding:calc(16px*var(--density-modifier)) !important;overflow:hidden}body:not(.is-phone) .installed-plugins-container .setting-items .setting-item-info{margin-inline-end:0;width:100%}body:not(.is-phone) .installed-plugins-container .setting-items .setting-item-description>div:last-child{display:-webkit-box;overflow:hidden;-webkit-line-clamp:5;-webkit-box-orient:vertical}body:not(.is-phone) .installed-plugins-container .setting-items .setting-item-control{flex:none;flex-wrap:wrap;align-self:flex-end;width:100%}body:not(.is-phone) .installed-plugins-container .setting-items .setting-item-control button.mod-cta{flex-grow:1;flex-basis:100%}body:not(.is-phone) .installed-plugins-container .setting-items .setting-item:has(button){order:-1}body:not(.is-phone) .modal.mod-community-modal .modal-sidebar{padding:0}body:not(.is-phone) .modal.mod-community-modal .community-modal-controls{display:flex;height:auto;align-items:center;padding:0 8px;width:100%;flex-wrap:wrap}body:not(.is-phone) .modal.mod-community-modal .modal-sidebar:not(:only-child) .community-modal-controls .setting-item{width:100%;margin-right:0}body:not(.is-phone) .modal.mod-community-modal .community-modal-controls .setting-item{margin:0;padding:8px 0;display:flex;align-items:center}body:not(.is-phone) .modal.mod-community-modal .community-modal-controls .setting-item:first-child{margin-right:auto}body:not(.is-phone) .modal.mod-community-modal .community-modal-controls .setting-item.mod-toggle{margin-right:48px}body:not(.is-phone) .modal.mod-community-modal .community-modal-controls .setting-item:first-child .setting-item-info,body:not(.is-phone) .modal.mod-community-modal .community-modal-search-summary{display:none}body:not(.is-phone) .modal.mod-community-modal .community-modal-search-results{gap:8px;padding:8px}body:not(.is-phone) .modal.mod-community-modal .community-item:not(.is-selected){background-color:var(--setting-items-background)}body.is-phone .modal.mod-sidebar-layout{box-shadow:none}body.is-phone .modal.mod-sidebar-layout .modal-header{padding:0;align-items:center;display:inline;z-index:1}body.is-phone .modal.mod-sidebar-layout .modal-title{display:flex;align-items:center;min-width:fit-content;max-width:0}body.is-phone .modal.mod-sidebar-layout .modal-title:not(:has(.modal-setting-back-button)){font-size:1.5rem;font-weight:calc(var(--font-weight) + var(--bold-modifier));max-width:100%;padding-left:20px}body.is-phone .modal.mod-sidebar-layout .modal-setting-back-button{inset-inline-start:8px;bottom:unset}body.is-phone .modal.mod-sidebar-layout .vertical-tab-header-group-title{display:none}body.is-phone .modal.mod-settings .modal-title{margin-top:var(--safe-area-inset-top);height:var(--touch-size-m)}body.is-phone .modal.mod-community-modal .modal-title{height:calc(var(--touch-size-m) + 16px)}body.is-tablet.theme-dark{--settings-background: var(--background-secondary);--setting-items-background: var(--background-primary)}body.is-tablet .modal.mod-sidebar-layout .vertical-tab-header-group-title,body.is-tablet .modal.mod-sidebar-layout .vertical-tab-nav-item{padding:calc(12px*var(--density-modifier)) 16px}body:is(.mod-macos,.adaptive-mode-off,.is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=editor] .vertical-tab-nav-item-icon{--setting-nav-icon-background: var(--color-blue)}body:is(.mod-macos,.adaptive-mode-off,.is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=mobile] .vertical-tab-nav-item-icon{--setting-nav-icon-background: var(--color-blue)}body:is(.mod-macos,.adaptive-mode-off,.is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=file] .vertical-tab-nav-item-icon{--setting-nav-icon-background: var(--color-orange)}body:is(.mod-macos,.adaptive-mode-off,.is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=appearance] .vertical-tab-nav-item-icon{--setting-nav-icon-background: var(--color-accent)}body:is(.mod-macos,.adaptive-mode-off,.is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=hotkeys] .vertical-tab-nav-item-icon{--setting-nav-icon-background: var(--color-pink)}body:is(.mod-macos,.adaptive-mode-off,.is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=keychain] .vertical-tab-nav-item-icon{--setting-nav-icon-background: var(--color-green)}body:is(.mod-macos,.adaptive-mode-off,.is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=plugins] .vertical-tab-nav-item-icon{--setting-nav-icon-background: var(--color-cyan)}body:is(.mod-macos,.adaptive-mode-off,.is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=community-plugins] .vertical-tab-nav-item-icon{--setting-nav-icon-background: var(--color-purple)}body:is(.mod-macos,.adaptive-mode-off,.is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=backlink] .vertical-tab-nav-item-icon{--setting-nav-icon-background: var(--color-purple)}body:is(.mod-macos,.adaptive-mode-off,.is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=canvas] .vertical-tab-nav-item-icon{--setting-nav-icon-background: var(--color-red)}body:is(.mod-macos,.adaptive-mode-off,.is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=daily-notes] .vertical-tab-nav-item-icon{--setting-nav-icon-background: var(--color-red)}body:is(.mod-macos,.adaptive-mode-off,.is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=file-recovery] .vertical-tab-nav-item-icon{--setting-nav-icon-background: var(--color-green)}body:is(.mod-macos,.adaptive-mode-off,.is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=note-composer] .vertical-tab-nav-item-icon{--setting-nav-icon-background: var(--color-cyan)}body:is(.mod-macos,.adaptive-mode-off,.is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=page-preview] .vertical-tab-nav-item-icon{--setting-nav-icon-background: var(--color-blue)}body:is(.mod-macos,.adaptive-mode-off,.is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=switcher] .vertical-tab-nav-item-icon{--setting-nav-icon-background: var(--color-purple)}body:is(.mod-macos,.adaptive-mode-off,.is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=sync] .vertical-tab-nav-item-icon{--setting-nav-icon-background: var(--color-green)}body:is(.mod-macos,.adaptive-mode-off,.is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=templates] .vertical-tab-nav-item-icon{--setting-nav-icon-background: var(--color-blue)}body:is(.mod-macos,.adaptive-mode-off,.is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=zk-prefixer] .vertical-tab-nav-item-icon{--setting-nav-icon-background: var(--color-orange)}body:is(.mod-macos,.adaptive-mode-off,.is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=webviewer] .vertical-tab-nav-item-icon{--setting-nav-icon-background: var(--color-blue)}body.status-bar-baseline .status-bar{transition:var(--anim-duration-moderate) var(--anim-motion-baseline);border:none;transform-origin:bottom right;background-color:rgba(0,0,0,0);min-height:8px;height:calc-size(auto,size)}body.status-bar-baseline .status-bar::before{transition:var(--anim-duration-moderate) var(--anim-motion-baseline);content:"";position:absolute;bottom:0;right:0;width:150%;height:200%;z-index:-1;pointer-events:none;background:radial-gradient(farthest-side at right bottom, var(--background-primary), rgba(var(--mono-rgb-0), 0))}body.status-bar-baseline .status-bar:not(:hover){transform:scale(0.8);opacity:.5}body.status-bar-baseline .status-bar:not(:hover)::before{opacity:0}body:not(.status-bar-baseline) .status-bar{--status-bar-border-width: var(--border-width);right:unset;justify-content:center;transition:var(--anim-duration-moderate) var(--anim-motion-baseline),background-color var(--anim-duration-moderate) ease;border:none;border-radius:100vh;max-width:100%;min-height:unset}body:not(.status-bar-baseline) .status-bar>div{transition:var(--anim-duration-moderate) var(--anim-motion-baseline)}body:not(.status-bar-baseline) .status-bar:not(:hover){bottom:2px;border-width:0;background-color:rgba(var(--mono-rgb-100), 0.2);padding-block:0;max-width:160px;height:4px}body:not(.status-bar-baseline) .status-bar:not(:hover)>div{transform:scale(0.9);opacity:0;filter:blur(16px);white-space:nowrap}body:not(.status-bar-baseline) .status-bar:hover{bottom:4px;box-shadow:var(--shadow-s);border-color:var(--background-modifier-border);padding:8px;height:40px}body:not(.status-bar-baseline) .status-bar:hover::before{transform:scaleY(1)}body:not(.status-bar-baseline) .status-bar::before{position:absolute;transform:scaleY(10);z-index:-1;transition:var(--anim-duration-fast) var(--anim-duration-fast);width:100%;height:100%;content:""}body:not(.status-bar-baseline):not(.is-grabbing) .app-container.no-transition .status-bar{bottom:4px;border-color:rgba(0,0,0,0);background-color:var(--color-accent);color:var(--text-on-accent);max-width:100% !important;height:40px !important}body:not(.status-bar-baseline):not(.is-grabbing) .app-container.no-transition .status-bar>div{transform:none !important;opacity:1 !important;filter:none !important}.workspace-leaf-content[data-type=empty] .empty-state-container{max-height:unset}.workspace-leaf-content[data-type=empty] .empty-state-title{display:none}.workspace-leaf-content[data-type=empty] .empty-state-action-list{margin-top:0}.workspace-leaf-content[data-type=empty] .empty-state-action-list::before{-webkit-mask-size:contain;-webkit-mask-position:center;-webkit-mask-repeat:no-repeat;-webkit-mask-image:url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="140" height="180" viewBox="0 0 140 180" fill="none"><path d="M49.775 105.089C54.3828 103.715 61.8069 101.605 70.3434 101.082C65.2222 88.1449 63.986 76.8242 64.9803 66.7442C66.1285 55.1033 70.23 45.3874 74.228 37.1201C75.0811 35.3561 75.9012 33.7135 76.6879 32.1378C77.8017 29.9069 78.8486 27.81 79.8278 25.6916C81.4579 22.1652 82.6674 19.051 83.2791 16.1576C83.8806 13.3125 83.8838 10.7715 83.1727 8.3342C82.4607 5.89352 80.9475 3.26635 78.0704 0.386692C74.3134 -0.587559 70.1448 0.267767 67.0197 3.08162L29.9298 36.4772C27.861 38.34 26.503 40.8642 26.0879 43.6182L22.8899 64.8384C27.9185 69.2873 40.33 82.2201 47.8789 100.165C48.5525 101.766 49.1875 103.408 49.775 105.089Z" fill="white"/><path d="M21.3902 74.5293C21.2153 75.2761 20.9692 76.0051 20.6549 76.7063L1.05225 120.436C-0.961131 124.928 -0.0336421 130.194 3.39276 133.726L34.2418 165.523C49.9952 142.262 47.6984 120.379 40.5026 103.274C35.0465 90.3037 26.777 80.1526 21.3902 74.5293Z" fill="white"/><path d="M41.3687 169.269C41.9093 169.355 42.4575 169.407 43.0096 169.424C48.864 169.6 58.7098 170.109 66.6947 171.582C73.2088 172.783 86.1213 176.397 96.747 179.505C104.855 181.877 113.211 175.396 114.387 167.024C115.245 160.917 116.855 154.009 119.821 147.677L119.753 147.702C114.73 133.682 108.34 124.629 101.641 118.849C94.9619 113.086 87.7708 110.397 80.8276 109.42C69.2835 107.795 58.7071 110.832 52.0453 112.791C56.0353 129.428 54.8074 149.004 41.3687 169.269Z" fill="white"/><path d="M124.96 139.034C131.626 128.965 136.375 121.134 138.881 116.888C140.135 114.764 139.907 112.102 138.423 110.133C134.554 105.002 127.152 94.5755 123.12 84.9218C118.973 74.9962 118.355 59.5866 118.319 52.081C118.306 49.2279 117.402 46.4413 115.639 44.1994L91.6762 13.73C91.5918 15.1034 91.3946 16.4659 91.1093 17.8158C90.3118 21.5882 88.8073 25.3437 87.0916 29.0552C86.086 31.2306 84.9238 33.5612 83.7497 35.9157C82.9682 37.4827 82.1814 39.0607 81.432 40.6102C77.5579 48.6212 73.9528 57.3151 72.9451 67.5313C72.011 77.0006 73.2894 88.014 79.0482 101.162C80.0074 101.243 80.9727 101.351 81.9422 101.487C90.2067 102.651 98.8807 105.891 106.866 112.781C113.73 118.704 119.932 127.19 124.96 139.034Z" fill="white"/></svg>');background-color:var(--background-modifier-hover);height:80px;content:"";display:flex;margin-bottom:20px;pointer-events:none}body:not(.is-phone) .workspace-leaf-content[data-type=empty] .view-header{justify-content:flex-end}body:not(.is-phone) .workspace-leaf-content[data-type=empty] .view-header .view-header-left,body:not(.is-phone) .workspace-leaf-content[data-type=empty] .view-header .view-header-title-container{display:none}body:not(.is-phone) .workspace-leaf-content[data-type=empty] .empty-state-action.mod-close{visibility:hidden}body.is-mobile{--touch-radius-xxs: var(--radius-s);--touch-radius-xs: var(--radius-s);--touch-radius-s: var(--radius-s);--touch-radius-m: var(--radius-m);--touch-radius-l: var(--radius-l);--touch-radius-xl: var(--radius-xl);--radius-s: calc(16px * var(--radius-modifier));--radius-m: calc(16px * var(--radius-modifier));--radius-l: calc(24px * var(--radius-modifier));--radius-xl: calc(32px * var(--radius-modifier));--tab-radius: var(--radius-s);--tab-curve: var(--tab-radius);--font-ui-smaller: calc(var(--font-text-size) * 0.8 + var(--font-ui-modifier));--font-ui-small: calc(var(--font-text-size) * 0.937 + var(--font-ui-modifier));--font-ui-medium: calc(var(--font-text-size) + var(--font-ui-modifier));--font-ui-large: calc(var(--font-text-size) * 1.2 + var(--font-ui-modifier));--interactive-normal: var(--background-primary);--mobile-sidebar-width: 100%;--view-header-height: var(--header-height);--keyboard-spacing: 8px;--touch-size-l: 48px;--touch-size-xl: 52px;--border-width: 1pt;--divider-width: 1pt;--tab-outline-width: 1pt;--file-margins-y: 8px;--file-margins-x: 24px;--view-top-fade-opacity: 0;--view-bottom-fade-opacity: 0;--mobile-sidebar-background: var(--background-secondary);--tab-switcher-menubar-background: transparent;--tab-switcher-preview-radius: var(--radius-m);--icon-opacity-hover: var(--icon-opacity);--input-border-width-focus: 0;--navbar-max-width: auto !important;--navbar-bottom-offset: max(var(--safe-area-inset-bottom), var(--safe-area-inset-side));--navbar-side-offset: min(var(--navbar-bottom-offset), 32px);--safe-area-inset-side: 16px;--mobile-left-sidebar-width: 360px;--mobile-right-sidebar-width: 360px;--mobile-left-sidebar-width-pinned: 300px;--mobile-right-sidebar-width-pinned: 300px}body.is-mobile.theme-dark{--color-base-00: #1e1e1e;--color-base-10: #242424;--color-base-20: #262626}body.is-mobile:not(.mod-macos):not(.dynamic-type-off){--font-ui-smaller: calc(12px + var(--font-ui-modifier));--font-ui-small: calc(14px + var(--font-ui-modifier));--font-ui-medium: calc(16px + var(--font-ui-modifier));--font-ui-large: calc(24px + var(--font-ui-modifier))}body.is-mobile:not(.mod-macos):not(.dynamic-type-off) .markdown-preview-view,body.is-mobile:not(.mod-macos):not(.dynamic-type-off) .markdown-source-view{font-size:calc(var(--font-text-size)*1.0625)}body.is-mobile.mod-macos:not(.dynamic-type-off){--font-ui-smaller: calc(13px + var(--font-ui-modifier));--font-ui-small: calc(15px + var(--font-ui-modifier));--font-ui-medium: calc(17px + var(--font-ui-modifier));--font-ui-large: calc(20px + var(--font-ui-modifier))}body.is-mobile:not(.mod-macos,.adaptive-mode-off) .mod-raised{backdrop-filter:none;box-shadow:none;background-color:rgba(0,0,0,0);background-image:none;border:none}body.is-mobile:not(.mod-macos,.adaptive-mode-off) .mod-raised::after{content:none !important}body.is-mobile:not(.mod-macos,.adaptive-mode-off) .mobile-navbar{background-color:var(--background-secondary) !important;border:var(--border-width) solid var(--background-modifier-border) !important}body.is-mobile:not(.mod-macos,.adaptive-mode-off) .mobile-tab-preview:before{content:none}body.is-mobile:not(.mod-macos,.adaptive-mode-off).is-mobile .prompt{background-color:var(--prompt-background)}body.is-mobile .workspace-drawer .workspace-leaf-content>.node-insert-event,body.is-mobile .workspace-drawer .workspace-leaf-content>.view-content>.node-insert-event{padding-inline:var(--safe-area-inset-side)}body.is-mobile .workspace-drawer .workspace-leaf-content:after{content:none !important}body.is-mobile .workspace-drawer .workspace-drawer-inner{background-color:rgba(0,0,0,0)}body.is-mobile .workspace-drawer .workspace-drawer-header{padding-top:8px;padding-inline:var(--safe-area-inset-side);z-index:1;min-height:var(--touch-size-m);box-sizing:content-box}body.is-mobile .workspace-drawer .workspace-drawer-header-name-text{font-family:var(--h1-font)}body.is-mobile .workspace-drawer .workspace-drawer-active-tab-chevron{margin-inline-start:0}body.is-mobile .workspace-drawer .workspace-drawer-tab-options.is-collapsed::before{background-color:rgba(0,0,0,0);pointer-events:none}body.is-mobile .workspace-drawer .workspace-drawer-tab-options::before{position:fixed;z-index:1;transition:var(--anim-duration-fast);inset:0;background-color:var(--mobile-sidebar-background);content:""}body.is-mobile .workspace-drawer .workspace-drawer-tab-options-list{background-color:rgba(0,0,0,0);padding:0}body.is-mobile .workspace-drawer .workspace-drawer-tab-options .workspace-tab-header-inner{padding:calc(12px*var(--density-modifier)) 16px;font-weight:var(--font-normal)}body.is-mobile .workspace-drawer .workspace-drawer-tab-options .workspace-drawer-tab-select .workspace-tab-header-inner{background-color:rgba(0,0,0,0)}body.is-mobile .workspace-drawer .nav-header{padding:0}body.is-mobile .workspace-drawer .search-row,body.is-mobile .workspace-drawer .nav-header .search-input-container{margin:8px var(--safe-area-inset-side) 0;width:-webkit-fill-available;width:stretch}body.is-mobile .workspace-drawer .nav-buttons-container{padding:0 var(--safe-area-inset-side)}body.is-mobile .workspace-drawer .nav-buttons-container::after{content:none !important}body.is-mobile .workspace-drawer .nav-action-button{background-color:rgba(0,0,0,0);min-width:0}body.is-mobile .workspace-drawer .nav-action-button svg.svg-icon{flex-shrink:0}body.is-mobile .workspace-drawer .nav-action-button.is-active{color:var(--interactive-accent)}body.is-mobile.horizontal-tab-options .workspace-drawer-tab-options-list{flex-direction:row;overflow:visible}body.is-mobile.horizontal-tab-options .workspace-drawer-tab-options-list .workspace-tab-header{flex:1;animation:none !important}body.is-mobile.horizontal-tab-options .workspace-drawer-tab-options-list .workspace-tab-header-inner{padding-inline:0 !important}body.is-mobile.horizontal-tab-options .workspace-drawer-tab-options-list .workspace-tab-header:not(.is-swiping) .workspace-tab-header-inner-title{opacity:0}body.is-mobile.horizontal-tab-options .workspace-drawer-tab-options-list .workspace-tab-header-inner-title{position:fixed;align-self:center;inset:0;width:100%;color:var(--text-muted);text-align:center}body.is-mobile .mobile-toolbar-spacer{background-color:rgba(0,0,0,0)}body.is-mobile .mobile-toolbar{box-shadow:none}body.is-mobile .pull-action{border-radius:100vh;background-color:var(--background-secondary);background-image:none;border:var(--border-width) solid var(--background-modifier-border);padding:16px;width:auto;color:var(--text-normal);font-size:var(--font-ui-small);transition:var(--anim-duration-fast),opacity var(--anim-duration-slow),transform 0s !important}@starting-style{body.is-mobile .pull-action{opacity:0}}body.is-mobile .pull-action.pull-action.mod-activated{font-weight:calc(var(--font-weight) + var(--bold-modifier));background-color:var(--interactive-accent);color:var(--text-on-accent);border-color:rgba(0,0,0,0)}body.is-mobile .pull-down-action{inset:calc(var(--safe-area-inset-top) + 8px) 8px auto;max-width:480px}body.is-phone{--mobile-sidebar-radius: 0}body.is-phone .workspace-drawer{width:var(--mobile-sidebar-width-override, var(--mobile-sidebar-width))}body.is-phone .workspace-drawer-header{z-index:1;justify-content:flex-end}body.is-phone .workspace-drawer-header-left{position:absolute;flex-direction:row;align-items:center;margin:8px;inset:var(--safe-area-inset-top) var(--safe-area-inset-side) auto;gap:8px}body.is-phone .workspace-drawer-header-name{white-space:nowrap;min-width:0}body.is-phone .workspace-drawer-header-info{margin-top:0;margin-left:auto;color:var(--text-faint);white-space:nowrap}body.is-phone .workspace-drawer-tab-options{position:fixed;bottom:var(--navbar-bottom-offset);z-index:2;width:-webkit-fill-available;width:stretch;margin-inline:var(--safe-area-inset-side);height:var(--touch-size-m)}body.is-phone .workspace-drawer-tab-options.is-collapsed{margin-right:calc(var(--safe-area-inset-side) + var(--touch-size-m))}body.is-phone .workspace-drawer-tab-select{height:100%}body.is-phone .workspace-drawer-tab-select .workspace-tab-header-inner{justify-content:flex-start}body.is-phone .workspace-drawer-tab-select .workspace-tab-header-inner-title{flex:unset;width:auto}body.is-phone .workspace-drawer-tab-options-list{margin:0 0 var(--touch-size-m)}body.is-phone .workspace-drawer .workspace-leaf-content .nav-header~div:last-child{padding-top:16px !important;mask:linear-gradient(to top, hsla(0, 0%, 0%, 0) 0px, hsla(0, 0%, 0%, 0.013) 5px, hsla(0, 0%, 0%, 0.049) 10px, hsla(0, 0%, 0%, 0.104) 14px, hsla(0, 0%, 0%, 0.175) 18px, hsla(0, 0%, 0%, 0.259) 22px, hsla(0, 0%, 0%, 0.352) 26px, hsla(0, 0%, 0%, 0.45) 30px, hsla(0, 0%, 0%, 0.55) 34px, hsla(0, 0%, 0%, 0.648) 38px, hsla(0, 0%, 0%, 0.741) 42px, hsla(0, 0%, 0%, 0.825) 46px, hsla(0, 0%, 0%, 0.896) 50px, hsla(0, 0%, 0%, 0.951) 54px, hsla(0, 0%, 0%, 0.987) 59px, hsl(0, 0%, 0%) 64px, black calc(100% - 16px), transparent)}body.is-phone .workspace-drawer-inner{padding-top:calc(var(--safe-area-inset-top) + 32px)}body.is-phone .mod-root{mask-image:none !important}body.is-phone .mod-root .view-header{top:0;transition:var(--anim-duration-moderate) var(--anim-motion-baseline);will-change:top;z-index:3;padding-inline:var(--safe-area-inset-side)}body.is-phone .mod-root .view-actions{padding:0}body.is-phone .mod-root .workspace-leaf-content[data-type=markdown]>.view-content>div{mask-image:var(--view-bottom-fade-mask)}body.is-phone:not(.mode-switcher-off) .mod-root .view-action,body.is-phone:not(.mode-switcher-off) .mod-root .view-actions{backdrop-filter:none}body.is-phone.auto-full-screen.is-hidden-nav .mod-root .view-header{transform:none;top:-32px}body.is-phone.auto-full-screen.is-hidden-nav .mobile-navbar,body.is-phone.auto-full-screen.is-hidden-nav:not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-header .view-actions button:nth-last-child(2){transform:none;margin-bottom:calc(-1*var(--navbar-bottom-offset))}body.is-phone.auto-full-screen.is-hidden-nav .mod-root .workspace-leaf-content[data-type=markdown]>.view-content::before,body.is-phone.auto-full-screen.is-hidden-nav .mod-root .workspace-leaf-content[data-type=markdown]>.view-content::after{opacity:0}body.is-phone.is-floating-nav:not(.mod-toolbar-open) .mod-root .workspace-leaf-content[data-type=markdown]>.view-content::before,body.is-phone.is-floating-nav:not(.mod-toolbar-open) .mod-root .workspace-leaf-content[data-type=markdown]>.view-content::after{position:absolute;z-index:1;backdrop-filter:blur(2px);inset-inline:0;pointer-events:none;content:"";transition:var(--anim-duration-moderate)}body.is-phone.is-floating-nav:not(.mod-toolbar-open) .mod-root .workspace-leaf-content[data-type=markdown]>.view-content::before{top:0;mask:linear-gradient(to bottom, black calc(var(--safe-area-inset-top) + var(--view-header-height) / 2), transparent);height:var(--view-top-spacing-markdown)}body.is-phone.is-floating-nav:not(.mod-toolbar-open) .mod-root .workspace-leaf-content[data-type=markdown]>.view-content::after{bottom:0;mask:linear-gradient(to top, black var(--navbar-bottom-offset), transparent);height:var(--view-bottom-spacing)}body.is-phone:not(html:where([style*="--keyboard-height: 0px"],:not([style*="--keyboard-height"])) body):not(.mod-toolbar-open) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2){opacity:0;pointer-events:none}body.is-phone:not(html:where([style*="--keyboard-height: 0px"],:not([style*="--keyboard-height"])) body):not(.mod-toolbar-open) .mod-root .workspace-leaf-content[data-type=markdown]>.view-content>div{mask-image:none}body.is-phone:not(html:where([style*="--keyboard-height: 0px"],:not([style*="--keyboard-height"])) body):not(.mod-toolbar-open) .mod-root .workspace-leaf-content[data-type=markdown]>.view-content::after{content:none !important}body.is-phone:not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2){position:fixed;transition:var(--anim-duration-moderate) var(--anim-motion-baseline),right 0s,bottom 0s,height 0s,opacity 0s !important;margin-right:var(--navbar-side-offset);margin-bottom:var(--navbar-bottom-offset);bottom:0;right:0;border-radius:100%;width:var(--touch-size-l);height:var(--touch-size-l);background-color:var(--background-secondary);border:var(--border-width) solid var(--background-modifier-border)}body.is-phone.mod-toolbar-open:not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2){width:var(--touch-size-m);height:var(--touch-size-m);margin-right:var(--keyboard-spacing);margin-bottom:var(--keyboard-spacing)}body.is-phone:not(.is-floating-nav):not(.mode-switcher-off):not(.mod-toolbar-open) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2){margin-right:16px;margin-bottom:16px}body.is-phone:not(.is-floating-nav).auto-full-screen:not(.mode-switcher-off):not(.mod-toolbar-open) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2){margin-bottom:calc(var(--navbar-height) + 16px)}body.is-phone>.app-container>.horizontal-main-container:has(.workspace>.mod-root>.workspace-tabs.mod-visible>.workspace-tab-container>.workspace-leaf.mod-active>.workspace-leaf-content:not([data-type=markdown])) .view-actions button:nth-last-child(2){opacity:0;pointer-events:none}body.is-phone.is-floating-nav.mode-switcher-off .mobile-navbar,body.is-phone.is-floating-nav>.app-container>.horizontal-main-container:has(.workspace>.mod-root>.workspace-tabs.mod-visible>.workspace-tab-container>.workspace-leaf.mod-active>.workspace-leaf-content:not([data-type=markdown]))~.mobile-navbar{margin-right:var(--navbar-side-offset)}body.is-phone.is-floating-nav .mobile-navbar{width:auto;margin:auto calc(8px + var(--touch-size-l) + var(--navbar-side-offset)) var(--navbar-bottom-offset) var(--navbar-side-offset);padding:8px;transition:var(--anim-duration-moderate) var(--anim-motion-baseline),background-color var(--anim-duration-moderate)}body.is-phone .mobile-navbar-action{min-width:0;margin-inline-start:0}body.is-phone .mobile-navbar-actions{--icon-size: var(--icon-l);--icon-stroke: var(--icon-l-stroke-width)}body.is-phone .mobile-navbar-tabs-action{font-family:"Inter"}body.is-phone:not(.is-floating-nav) .mobile-navbar{border:none !important;background-color:var(--background-primary) !important;transition:var(--anim-duration-moderate) !important}body.is-phone.mode-switcher-off .mobile-toolbar{right:var(--keyboard-spacing)}body.is-phone.mod-toolbar-open .mod-root .view-content{margin-bottom:calc(var(--mobile-toolbar-height) + var(--keyboard-spacing))}body.is-phone .mobile-toolbar-spacer{display:none}body.is-phone .mobile-toolbar{top:auto;bottom:var(--keyboard-spacing);left:var(--keyboard-spacing);right:calc(var(--keyboard-spacing) + var(--touch-size-m) + 4px);width:auto}body.is-phone .mobile-toolbar-options-container{gap:4px;width:100%;margin:0;border-radius:0}body.is-tablet{--titlebar-background: var(--background-secondary) !important;--titlebar-background-focused: var(--background-secondary) !important;--mobile-sidebar-min-width: unset}body.is-tablet .workspace{background-color:var(--mobile-sidebar-background)}body.is-tablet .workspace-tab-header{padding-bottom:0 !important}body.is-tablet .workspace-tab-header-new-tab,body.is-tablet .workspace-tab-header-tab-list,body.is-tablet .sidebar-toggle-button,body.is-tablet .view-header-left,body.is-tablet .view-actions{padding:4px 0}body.is-tablet .workspace .mod-root .workspace-tab-header-container .clickable-icon,body.is-tablet .view-header .clickable-icon,body.is-tablet .workspace-drawer-header-icon{border-radius:100vh;padding:10px;position:relative;margin-left:0}body.is-tablet .workspace-drawer.is-pinned,body.is-tablet .workspace-split.mod-root,body.is-tablet .workspace-split.mod-root .workspace-split{background-color:rgba(0,0,0,0);border-width:0}body.is-tablet .workspace-drawer .workspace-drawer-ribbon .side-dock-actions{padding-block:12px}body.is-tablet .workspace-drawer .workspace-drawer-header-left{margin-left:12px}body.is-tablet .workspace-drawer .workspace-leaf-content .nav-header~div:last-child{mask:linear-gradient(to bottom, transparent, black 16px, black calc(100% - 16px), transparent)}body.is-tablet .workspace-drawer .workspace-drawer-tab-options-list{margin:var(--touch-size-l) 0 0}body.is-tablet .workspace-drawer:not(.is-pinned).mod-left{max-width:var(--mobile-left-sidebar-width, var(--mobile-sidebar-max-width))}body.is-tablet .workspace-drawer:not(.is-pinned).mod-right{max-width:var(--mobile-right-sidebar-width, var(--mobile-sidebar-max-width))}body.is-tablet .workspace-drawer.is-pinned.mod-left{width:var(--mobile-left-sidebar-width-pinned, var(--mobile-sidebar-width-pinned))}body.is-tablet .workspace-drawer.is-pinned.mod-right{width:var(--mobile-right-sidebar-width-pinned, var(--mobile-sidebar-width-pinned))}body.is-tablet .workspace-drawer:not(.is-pinned){margin:var(--safe-area-inset-top) 8px calc(var(--keyboard-height) + 8px);padding-top:0;border-radius:var(--mobile-sidebar-radius);height:auto}body.is-tablet .workspace-drawer:not(.is-pinned) .workspace-drawer-inner{padding-top:0px}body.is-tablet .workspace-drawer.is-pinned{flex-shrink:0;max-width:35%}body.is-tablet .workspace-drawer .workspace-drawer-tab-options{margin:8px}body.is-tablet .workspace-drawer .workspace-drawer-active-tab-container{background-color:rgba(0,0,0,0)}body.is-tablet .workspace-drawer-header-icon.mod-raised{backdrop-filter:none;box-shadow:none;background-color:rgba(0,0,0,0);border:none}body.is-tablet .workspace-drawer-header-icon::after{content:none !important}body:not(.is-mobile) .backlink-pane .search-result-file-match:not(:hover) .search-result-file-match-replace-button{display:none}body:not(.is-mobile) .backlink-pane .search-result-file-match-replace-button{padding:4px 8px}.embedded-backlinks .nav-header>.search-input-container{width:100%;margin:48px 0 16px;align-self:start}.markdown-embed[data-type=footnote]{background-color:rgba(0,0,0,0);overflow:visible}.workspace-leaf-content[data-type=webviewer] .view-header{gap:0}.workspace-leaf-content[data-type=webviewer] .view-header-left,.workspace-leaf-content[data-type=webviewer] .view-actions{flex:0}.workspace-leaf-content[data-type=webviewer] .webviewer-content{border-top:none}body:not(.is-mobile) .canvas-control-group:not(:hover),body:not(.is-mobile) .canvas-card-menu:not(:hover){opacity:.5}.canvas-control-group{border:none;transition:var(--anim-duration-fast)}.canvas-card-menu{transition:var(--anim-duration-fast);padding:8px;gap:4px}.canvas-card-menu .canvas-card-menu-button{--icon-size: 24px}.canvas-card-menu .canvas-card-menu-button svg{transition:var(--anim-duration-moderate) var(--anim-motion-baseline) !important}@media only screen and (max-width: 600px){.omnisearch-input-container__buttons{padding:0 8px}.omnisearch-input-field{padding:8px}}@media only screen and (min-width: 600px){.omnisearch-input-container__buttons{margin-inline-end:4px}}.omnisearch-input-field{display:flex;align-items:center;width:100%}.omnisearch-input-container__buttons button{box-shadow:none;border:var(--input-border-width) solid var(--background-modifier-border)}.omnisearch-result>div{gap:4px;width:100%}.omnisearch-result>div .omnisearch-result__title,.omnisearch-result>div .omnisearch-result__icon+span{flex:1}.omnisearch-result>div .omnisearch-result__title-container,.omnisearch-result>div .omnisearch-result__folder-path{margin-bottom:4px}.omnisearch-result>div .omnisearch-result__body{margin-inline:0}body:not(.is-mobile) .omnisearch-input-container__buttons{display:none}@media only screen and (max-width: 600px){body:is(.mod-macos,.adaptive-mode-off).is-phone .omnisearch-modal{--prompt-top: calc(var(--safe-area-inset-top) + var(--header-height)) !important;backdrop-filter:none !important;background-color:rgba(0,0,0,0) !important;height:calc(100vh - var(--prompt-top)) !important}body:is(.mod-macos,.adaptive-mode-off).is-phone .omnisearch-modal::before{position:fixed;z-index:-1;backdrop-filter:var(--blur-l);inset:0;pointer-events:none;content:""}body:is(.mod-macos,.adaptive-mode-off).is-phone .omnisearch-modal .prompt-results{backdrop-filter:var(--blur-l);mask:none !important;border-radius:var(--modal-radius) var(--modal-radius) 0 0;background-color:var(--modal-background);padding-top:var(--safe-area-inset-side) !important;padding-bottom:var(--safe-area-inset-bottom)}body:is(.mod-macos,.adaptive-mode-off).is-phone .omnisearch-modal .omnisearch-input-container{gap:8px;margin-bottom:var(--safe-area-inset-side);padding-inline:var(--safe-area-inset-side)}body:is(.mod-macos,.adaptive-mode-off).is-phone .omnisearch-modal .prompt-input{width:100%}body:is(.mod-macos,.adaptive-mode-off).is-phone .omnisearch-modal .omnisearch-input-container__buttons{padding:0}}body{--nn-theme-mobile-nav-bg: transparent;--nn-theme-nav-header-bg: transparent;--nn-theme-nav-bg: transparent;--nn-theme-list-header-bg: transparent;--nn-theme-list-bg: transparent;--nn-theme-navitem-selected-bg: var(--background-modifier-hover);--nn-theme-navitem-selected-inactive-bg: var(--background-modifier-hover);--nn-theme-file-tag-bg: var(--tag-background);--nn-theme-file-tag-color: var(--tag-color);--nn-theme-mobile-list-header-link-color: var(--text-normal);--nn-theme-mobile-toolbar-button-icon-color: var(--text-normal);--nn-theme-mobile-toolbar-button-active-icon-color: var(--text-on-accent);--nn-theme-mobile-toolbar-button-active-bg: var(--interactive-accent);--nn-theme-navitem-border-radius: var(--radius-m);--nn-theme-file-border-radius: var(--radius-m)}.notebook-navigator{background-color:rgba(0,0,0,0)}body:not(.is-mobile) .view-content.notebook-navigator{padding:0 !important}body:not(.is-mobile) .view-content.notebook-navigator .nn-single-pane .nn-navigation-pane{border-right:none}body:not(.is-mobile) .view-content.notebook-navigator .nn-pane-header{padding:8px 12px}body:not(.is-mobile) .view-content.notebook-navigator .nn-header-actions button.nn-icon-button{padding:8px;min-width:unset;height:auto}body.is-mobile .view-content.notebook-navigator-mobile .nn-pane-header,body.is-mobile .view-content.notebook-navigator-mobile .nn-mobile-title{padding:0}.hider-sidebar-buttons.mod-macos{--frame-left-space: calc(80px - var(--ribbon-width))}.hider-sidebar-buttons .sidebar-toggle-button.mod-left,.hider-sidebar-buttons .sidebar-toggle-button.mod-right{display:flex;visibility:hidden;width:0 !important;opacity:0}body.is-phone.hider-sidebar-buttons .view-header-left{display:none}body.is-phone.hider-sidebar-buttons .view-header-title-container{margin-left:8px !important}.obsidian-themepocalypse:not(.qe-hide-breadcrumbs){--status-bar-radius: 0;--status-bar-border-width: 0;--status-bar-background: transparent}.obsidian-themepocalypse:not(.qe-hide-breadcrumbs) #quick-explorer .explorable{color:var(--text-faint);transition:var(--anim-duration-fast)}.obsidian-themepocalypse:not(.qe-hide-breadcrumbs) #quick-explorer .explorable.selected,.obsidian-themepocalypse:not(.qe-hide-breadcrumbs) #quick-explorer .explorable:hover{background-color:rgba(0,0,0,0);color:var(--text-normal)}.obsidian-themepocalypse:not(.qe-hide-breadcrumbs) .status-bar{width:100%;transform:none !important;opacity:1 !important}.obsidian-themepocalypse:not(.qe-hide-breadcrumbs) .status-bar::before{content:none !important}.obsidian-themepocalypse:not(.qe-hide-breadcrumbs):not(.status-bar-baseline) .status-bar{margin:4px 0}.obsidian-themepocalypse:not(.qe-hide-breadcrumbs):not(.status-bar-baseline) .status-bar:hover{margin:0;box-shadow:none;backdrop-filter:none;border:none}body:not(.is-mobile):not(.nav-action-center) .mod-sidedock .workspace-leaf-content.novel-word-count--active>.nav-header:not(:hover) .nav-buttons-container .nav-action-button{opacity:0}body:not(.is-mobile):not(.nav-action-center) .mod-sidedock .workspace-leaf-content.novel-word-count--active>.nav-header:not(:hover) .nav-buttons-container::after{opacity:1}body:not(.is-mobile):not(.nav-action-center) .mod-sidedock .workspace-leaf-content.novel-word-count--active>.nav-header .nav-buttons-container{flex-wrap:nowrap !important}body:not(.is-mobile):not(.nav-action-center) .mod-sidedock .workspace-leaf-content.novel-word-count--active>.nav-header .nav-buttons-container::after{position:absolute;overflow:visible;opacity:0;transition:var(--anim-duration-moderate);color:var(--text-faint)}body:is(.mod-macos,.adaptive-mode-off).is-mobile .workspace-drawer .novel-word-count--active .nav-buttons-container{overflow:visible}body:is(.mod-macos,.adaptive-mode-off).is-mobile .workspace-drawer .novel-word-count--active .nav-buttons-container::after{position:absolute;transform:translateY(-24px)}body:is(.mod-macos,.adaptive-mode-off).is-mobile .workspace-drawer .novel-word-count--active.novel-word-count--note-right .nav-files-container .nav-folder-title::after,body:is(.mod-macos,.adaptive-mode-off).is-mobile .workspace-drawer .novel-word-count--active.novel-word-count--note-right .nav-files-container .nav-file-title::after{flex:unset;order:0}body:is(.mod-macos,.adaptive-mode-off).is-mobile .workspace-drawer .novel-word-count--active.novel-word-count--note-inline .nav-files-container .tree-item .tree-item-inner{flex:unset;padding:0 8px}body:is(.mod-macos,.adaptive-mode-off).is-mobile .workspace-drawer .novel-word-count--active.novel-word-count--note-inline .nav-files-container .nav-folder-title::after,body:is(.mod-macos,.adaptive-mode-off).is-mobile .workspace-drawer .novel-word-count--active.novel-word-count--note-inline .nav-files-container .nav-file-title::after{order:0}body:is(.mod-macos,.adaptive-mode-off).is-mobile .workspace-drawer .novel-word-count--active.novel-word-count--folder-below .nav-files-container .nav-folder-title::after,body:is(.mod-macos,.adaptive-mode-off).is-mobile .workspace-drawer .novel-word-count--active.novel-word-count--folder-below .nav-files-container .nav-file-title::after{flex-basis:100%}.field-btn-container{margin-inline-start:8px}.field-btn-container button.property-metadata-menu,.plugin-metadata-menu .status-item-bt{padding:0 !important;background-color:rgba(0,0,0,0);align-self:center}.metadata-menu .suggester-input{margin-top:0}.metadata-menu .prompt-input-container{height:var(--prompt-input-height);position:absolute;inset:0 0 auto;pointer-events:none}.metadata-menu .search-input-clear-button{display:none}.metadata-menu .value-container.value-checked.is-selected{color:var(--text-on-accent)}.relative-line-numbers-mono{position:absolute;width:100%}body:not(.is-phone) .pixel-banner>.markdown-source-view>.cm-editor:first-child .pixel-banner-image,body:not(.is-phone) .pixel-banner>.markdown-reading-view>.markdown-preview-view:first-child>.pixel-banner-image{top:var(--view-header-height, var(--header-height))}body.is-phone.is-mobile .pixel-banner .select-image-icon{display:none}body.is-phone.is-mobile .pixel-banner .pixel-banner-image{top:var(--view-top-spacing-markdown)}body.is-mobile .kanban-plugin__item,body.is-mobile .kanban-plugin__item-input-wrapper{border-radius:var(--radius-s)}body.minimal-theme .workspace::before{content:"Cupertino is not compatible with Minimal Theme Settings.\a\aTo use this theme, disable Minimal Theme Settings in Community plugins.";text-align:center;white-space:pre-wrap;position:fixed;inset:0;color:var(--text-muted);font-size:var(--font-ui-medium);z-index:49;pointer-events:none;background-color:var(--background-primary);align-self:center;justify-self:center;padding:32px;border-radius:var(--radius-l);box-shadow:var(--shadow-l)}.excalidraw{--input-height: 32px}/*!
+@charset "UTF-8";
+body,
+.theme-light,
+.theme-dark {
+  --font-interface-theme: "SF Pro";
+  --font-text-theme: "SF Pro";
+  --font-ui-modifier: 0px;
+  --font-ui-smaller: calc(12px + var(--font-ui-modifier));
+  --font-ui-small: calc(13px + var(--font-ui-modifier));
+  --font-ui-medium: calc(15px + var(--font-ui-modifier));
+  --font-ui-large: calc(20px + var(--font-ui-modifier));
+  --bold-modifier: 300;
+  --icon-size-modifier: 0px;
+  --icon-opacity: 1;
+  --titlebar-background: transparent;
+  --titlebar-background-focused: transparent;
+  --divider-color-hover: var(--color-base-50);
+  --corner-shape: superellipse(1.1);
+  --shadow-s: rgba(0, 0, 0, 0.08) 0px 12px 24px -4px, rgba(0, 0, 0, 0.04) 0px 8px 16px -4px;
+  --shadow-l: 0 14px 62px #00000040;
+  --shadow-tactile: rgba(0, 0, 0, 0.04) 0px 2px 8px -2px, rgba(var(--mono-rgb-100), 0.04) 0px 2px 4px -2px;
+  --anim-speed-modifier: 1;
+  --anim-motion-baseline: cubic-bezier(0.32, 0.72, 0, 1);
+  --anim-duration-superfast: calc(80ms * var(--anim-speed-modifier));
+  --anim-duration-fast: calc(160ms * var(--anim-speed-modifier));
+  --anim-duration-moderate: calc(320ms * var(--anim-speed-modifier));
+  --anim-duration-slow: calc(480ms * var(--anim-speed-modifier));
+  --icon-stroke-modifier: 1;
+  --icon-xs-stroke-width: calc(2.25px * var(--icon-stroke-modifier));
+  --icon-s-stroke-width: calc(2px * var(--icon-stroke-modifier));
+  --icon-m-stroke-width: calc(2px * var(--icon-stroke-modifier));
+  --icon-l-stroke-width: calc(2px * var(--icon-stroke-modifier));
+  --icon-xl-stroke-width: calc(1.25px * var(--icon-stroke-modifier));
+  --density-modifier: 1;
+  --translucent-light-opacity: 0%;
+  --translucent-dark-opacity: 0%;
+  --color-red: rgb(var(--color-red-rgb));
+  --color-orange: rgb(var(--color-orange-rgb));
+  --color-yellow: rgb(var(--color-yellow-rgb));
+  --color-green: rgb(var(--color-green-rgb));
+  --color-cyan: rgb(var(--color-cyan-rgb));
+  --color-blue: rgb(var(--color-blue-rgb));
+  --color-purple: rgb(var(--color-purple-rgb));
+  --color-pink: rgb(var(--color-pink-rgb));
+  --background-modifier-cover: rgba(0, 0, 0, 0.35);
+}
+
+.theme-light {
+  --workspace-background-translucent: rgb(from var(--background-secondary) r g b / var(--translucent-light-opacity));
+  --color-red-rgb: 254, 112, 112;
+  --color-orange-rgb: 242, 154, 100;
+  --color-yellow-rgb: 224, 205, 99;
+  --color-green-rgb: 74, 213, 95;
+  --color-cyan-rgb: 56, 219, 214;
+  --color-blue-rgb: 106, 173, 250;
+  --color-purple-rgb: 187, 158, 245;
+  --color-pink-rgb: 243, 125, 183;
+  --code-normal: #383a42;
+  --code-comment: #b6b9c5;
+  --code-function: #b76b02;
+  --code-important: #b76b02;
+  --code-keyword: #e45749;
+  --code-property: #62afef;
+  --code-punctuation: #383a42;
+  --code-string: #0d97b3;
+  --code-tag: #e45749;
+  --code-value: #a626a4;
+}
+
+.theme-dark {
+  --workspace-background-translucent: rgb(from var(--background-secondary) r g b / var(--translucent-dark-opacity));
+  --color-red-rgb: 217, 90, 95;
+  --color-orange-rgb: 219, 134, 80;
+  --color-yellow-rgb: 196, 180, 94;
+  --color-green-rgb: 72, 196, 90;
+  --color-cyan-rgb: 63, 186, 182;
+  --color-blue-rgb: 86, 148, 218;
+  --color-purple-rgb: 142, 125, 194;
+  --color-pink-rgb: 222, 103, 147;
+  --code-normal: #abb2bf;
+  --code-comment: #5c6370;
+  --code-function: #d19a66;
+  --code-important: #d19a66;
+  --code-keyword: #e16d76;
+  --code-property: #62afef;
+  --code-punctuation: #abb2bf;
+  --code-string: #58b6c2;
+  --code-tag: #e16d76;
+  --code-value: #c678de;
+}
+
+body:not(.is-mobile) {
+  --icon-xs: calc(14px + var(--icon-size-modifier));
+  --icon-s: calc(16px + var(--icon-size-modifier));
+  --icon-m: calc(16px + var(--icon-size-modifier));
+  --icon-l: calc(16px + var(--icon-size-modifier));
+  --icon-xl: calc(32px + var(--icon-size-modifier));
+}
+body:not(.is-mobile) .app-container {
+  transition: var(--anim-duration-moderate);
+  align-items: center;
+}
+body:not(.is-mobile):not(.is-translucent) .workspace {
+  background: var(--background-secondary);
+}
+body:not(.is-mobile) .workspace {
+  transition: var(--anim-duration-moderate);
+}
+body:not(.is-mobile) .workspace-split {
+  transition: var(--anim-duration-moderate);
+  background-color: transparent;
+}
+
+@media (prefers-color-scheme: light) {
+  .theme-dark {
+    --workspace-background-translucent: var(--background-secondary);
+  }
+}
+@media (prefers-color-scheme: dark) {
+  .theme-light {
+    --workspace-background-translucent: var(--background-secondary);
+  }
+}
+.is-translucent {
+  --blur-s: none !important;
+  --blur-m: none !important;
+  --blur-l: none !important;
+  --divider-color: var(--background-modifier-border) !important;
+  --tab-outline-color: var(--background-modifier-border);
+}
+
+.is-popout-window {
+  --workspace-background-translucent: var(--background-secondary);
+  background-color: rgb(var(--mono-rgb-100));
+}
+
+body.is-frameless:not(.is-translucent, .is-hidden-frameless, .is-fullscreen) .titlebar {
+  background-color: var(--background-secondary);
+}
+
+body.titlebar-text-off .titlebar-text {
+  display: none;
+}
+
+body:not(.mod-macos):not(.is-mobile) {
+  --frame-right-space: 144px;
+}
+body:not(.mod-macos):not(.is-mobile).is-hidden-frameless .titlebar {
+  height: var(--header-height);
+}
+body:not(.mod-macos):not(.is-mobile) .titlebar-button-container.mod-right {
+  width: var(--frame-right-space);
+}
+body:not(.mod-macos):not(.is-mobile) .titlebar-button-container.mod-right .titlebar-button {
+  justify-content: center;
+  flex: 1;
+}
+body:not(.mod-macos):not(.is-mobile) .titlebar-button-container.mod-right .titlebar-button path,
+body:not(.mod-macos):not(.is-mobile) .titlebar-button-container.mod-right .titlebar-button rect,
+body:not(.mod-macos):not(.is-mobile) .titlebar-button-container.mod-right .titlebar-button circle {
+  visibility: hidden;
+}
+body:not(.mod-macos):not(.is-mobile) .titlebar-button-container.mod-right .titlebar-button svg {
+  -webkit-mask-size: 100% 100%;
+  background-color: currentcolor;
+  width: auto;
+  height: 10px;
+}
+body:not(.mod-macos):not(.is-mobile) .titlebar-button.mod-minimize svg {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='2' fill='none' viewBox='0 0 12 2'%3e%3cpath fill='black' d='M.598 1.201A.604.604 0 0 1 0 .604.61.61 0 0 1 .598 0h10.804c.324 0 .598.281.598.604a.605.605 0 0 1-.598.597H.598Z'/%3e%3c/svg%3e");
+}
+body:not(.mod-macos):not(.is-mobile) .titlebar-button.mod-maximize svg {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' viewBox='0 0 12 12'%3e%3cpath fill='black' d='M1.77 12C.825 12 0 11.175 0 10.23V1.77C0 .83.828 0 1.77 0h8.46C11.167 0 12 .833 12 1.77v8.46c0 .942-.83 1.77-1.77 1.77H1.77Zm8.431-1.201a.605.605 0 0 0 .598-.598V1.8a.606.606 0 0 0-.599-.6H1.8a.605.605 0 0 0-.6.6v8.4c0 .325.273.598.598.598H10.2Z'/%3e%3c/svg%3e");
+}
+body:not(.mod-macos):not(.is-mobile) .titlebar-button.mod-close svg {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' viewBox='0 0 12 12'%3e%3cpath fill='black' d='m6 6.848-4.975 4.974a.618.618 0 0 1-.856.006.618.618 0 0 1 .006-.855L5.15 5.998.175 1.024c-.226-.227-.24-.628 0-.85a.606.606 0 0 1 .85 0l4.974 4.975L10.974.174a.606.606 0 0 1 .85 0 .606.606 0 0 1 0 .85L6.848 5.998l4.974 4.975a.606.606 0 0 1 0 .85c-.222.239-.623.225-.85 0L6 6.847Z'/%3e%3c/svg%3e");
+}
+body:not(.mod-macos):not(.is-mobile).is-maximized .titlebar-button.mod-maximize svg {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' fill='none' viewBox='0 0 12 12'%3e%3cpath fill='black' d='M10.799 3.557C10.799 2.27 9.67 1.2 8.396 1.2H2.502a1.808 1.808 0 0 1 1.7-1.2h4.194C10.352 0 12 1.641 12 3.598v4.2c0 .758-.484 1.45-1.201 1.7V3.557ZM1.769 12C.826 12 0 11.175 0 10.23V4.172c0-.941.828-1.77 1.77-1.77h6.058c.945 0 1.77.825 1.77 1.77v6.058c0 .942-.829 1.77-1.77 1.77H1.77Zm6.03-1.201a.61.61 0 0 0 .603-.598v-6a.607.607 0 0 0-.603-.603h-6A.61.61 0 0 0 1.2 4.2v6c0 .325.273.598.598.598h6Z'/%3e%3c/svg%3e");
+}
+
+body.styled-scrollbars div:not(:hover)::-webkit-scrollbar-thumb {
+  background-color: transparent;
+}
+
+body.reduce-motion {
+  --anim-speed-modifier: 0 !important;
+}
+body.reduce-motion.is-mobile {
+  --mobile-sidebar-width: 90vw;
+}
+body.reduce-motion.is-mobile .workspace-drawer,
+body.reduce-motion.is-mobile .workspace-split,
+body.reduce-motion.is-mobile .mobile-tab-switcher,
+body.reduce-motion.is-mobile .menu,
+body.reduce-motion.is-mobile .suggestion-bg,
+body.reduce-motion.is-mobile .modal,
+body.reduce-motion.is-mobile .modal-bg,
+body.reduce-motion.is-mobile .mobile-navbar {
+  transform: none !important;
+  transition: none !important;
+}
+@starting-style {
+  body.reduce-motion.is-mobile .workspace-drawer,
+  body.reduce-motion.is-mobile .workspace-split,
+  body.reduce-motion.is-mobile .mobile-tab-switcher,
+  body.reduce-motion.is-mobile .menu,
+  body.reduce-motion.is-mobile .suggestion-bg,
+  body.reduce-motion.is-mobile .modal,
+  body.reduce-motion.is-mobile .modal-bg,
+  body.reduce-motion.is-mobile .mobile-navbar {
+    opacity: 0 !important;
+  }
+}
+
+@supports not (interpolate-size: allow-keywords) {
+  body:not(.is-mobile).obsidian-app.obsidian-app.obsidian-app {
+    --modal-background: var(--background-secondary) !important;
+  }
+  body:not(.is-mobile):not(.is-popout-window) .mod-root::before {
+    content: "Cupertino requires a newer Obsidian installer. Download and run the latest installer from obsidian.md to remove this message.";
+    display: flex;
+    position: absolute;
+    justify-content: center;
+    align-items: center;
+    z-index: var(--layer-cover);
+    inset: auto 0 0;
+    padding: 16px 48px;
+    background-color: var(--background-secondary);
+    color: var(--text-muted);
+    font-size: var(--font-ui-medium);
+    white-space: pre-wrap;
+  }
+}
+.lucide-folder-closed path[d="M2 10h20"] {
+  display: none;
+}
+
+.lucide-arrow-left path[d="M19 12H5"] {
+  display: none;
+}
+.lucide-arrow-left path[d="m12 19-7-7 7-7"] {
+  transform: translateX(2px);
+}
+
+.lucide-arrow-right path[d="M5 12h14"] {
+  display: none;
+}
+.lucide-arrow-right path[d="m12 5 7 7-7 7"] {
+  transform: translateX(-2px);
+}
+
+.lucide-edit-3 path[d="M13 21h8"] {
+  display: none;
+}
+
+body:not(.reduce-motion, .is-mobile) .workspace svg.svg-icon {
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline);
+}
+@starting-style {
+  body:not(.reduce-motion, .is-mobile) .workspace .clickable-icon:not(.workspace-ribbon > .sidebar-toggle-button > .clickable-icon) svg.svg-icon {
+    filter: blur(4px);
+    scale: 0.75;
+    opacity: 0;
+  }
+}
+body:not(.reduce-motion, .is-mobile) .workspace .clickable-icon:not([aria-disabled=true]):active svg.svg-icon,
+body:not(.reduce-motion, .is-mobile) .workspace .mod-sidedock .workspace-tab-header.tappable:active svg.svg-icon {
+  scale: 0.75;
+  opacity: 0.75;
+}
+body:not(.reduce-motion, .is-mobile) .workspace .workspace-tab-header-tab-list .clickable-icon:is(:hover, .has-active-menu) svg.svg-icon {
+  transform: translateY(1px);
+}
+body:not(.reduce-motion, .is-mobile) .workspace .view-header-nav-buttons .clickable-icon:not([aria-disabled=true]):first-child:hover svg.svg-icon {
+  transform: translateX(-1px);
+}
+body:not(.reduce-motion, .is-mobile) .workspace .view-header-nav-buttons .clickable-icon:not([aria-disabled=true]):last-child:hover svg.svg-icon {
+  transform: translateX(1px);
+}
+
+body {
+  --header-height: 48px;
+  --tab-max-width: var(--tab-width);
+  --tab-radius: var(--radius-s);
+  --tab-radius-active: var(--tab-radius) var(--tab-radius) 0 0;
+  --tab-curve: calc(var(--tab-radius) + 4px);
+  --tab-outline-width: 0px;
+  --tab-divider-color: var(--background-modifier-border);
+  --tab-text-align: left;
+  --tab-text-color-focused-active: var(--text-normal);
+  --tab-text-color-focused-active-current: unset;
+}
+
+body.mod-macos {
+  --header-height: 52px;
+}
+
+body:not(.is-mobile) {
+  --tab-action-width: 32px;
+}
+
+body.is-mobile {
+  --header-height: 44px !important;
+  --tab-text-color-active: var(--text-normal);
+  --tab-text-color-focused: var(--text-normal);
+}
+
+body.is-tablet {
+  --header-height: 52px !important;
+  --tab-action-width: 44px;
+}
+
+body:not(.is-phone) .workspace-tab-header-container {
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline);
+  background-color: transparent;
+  border-bottom: none;
+}
+
+.sidebar-toggle-button {
+  height: 100%;
+  padding-bottom: 8px;
+  align-items: center;
+}
+
+.sidebar-toggle-button .clickable-icon {
+  width: fit-content;
+  height: fit-content;
+}
+
+.workspace-tab-header-inner-icon {
+  color: inherit !important;
+}
+
+body:not(.is-phone) .workspace .mod-root .workspace-tab-header-container-inner {
+  padding: 8px var(--tab-curve) 0;
+  margin: 0 -4px 0 0;
+  gap: 8px;
+}
+body:not(.is-phone) .workspace .mod-root .workspace-tab-header {
+  --tab-outline-width: 0px;
+  padding: 0;
+}
+body:not(.is-phone) .workspace .mod-root .workspace-tab-header-inner {
+  padding-inline-start: 12px;
+  padding-inline-end: 8px;
+  margin-bottom: 8px;
+  height: auto;
+}
+body:not(.is-phone) .workspace .mod-root .workspace-tab-header-inner-title {
+  line-height: normal;
+  text-align: var(--tab-text-align);
+}
+body:not(.is-phone) .workspace .mod-root .workspace-tab-header-new-tab,
+body:not(.is-phone) .workspace .mod-root .workspace-tab-header-tab-list {
+  display: block;
+  align-content: center;
+  padding: 4px 0;
+  margin: 0;
+}
+body:not(.is-phone) .workspace .mod-root .workspace-tab-header-new-tab .clickable-icon,
+body:not(.is-phone) .workspace .mod-root .workspace-tab-header-tab-list .clickable-icon {
+  height: auto;
+  padding: 8px;
+}
+
+body:not(.is-phone) .workspace .mod-root .workspace-tabs:not(.mod-stacked) {
+  --tab-radius-active: var(--tab-radius);
+  --tab-curve: 0;
+}
+body:not(.is-phone) .workspace .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header-container-inner {
+  padding-bottom: 8px;
+  gap: 4px;
+  margin: 0;
+}
+body:not(.is-phone) .workspace .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header {
+  padding: 0;
+  background-color: var(--background-modifier-hover);
+}
+body:not(.is-phone) .workspace .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header:not(.is-active):not(:hover) {
+  opacity: 0.5;
+}
+body:not(.is-phone) .workspace .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header-inner {
+  padding-inline-start: 12px;
+  padding-inline-end: 8px;
+  margin-bottom: 0;
+}
+
+body.is-tablet {
+  --header-height: 60px !important;
+}
+body.is-tablet .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header-container-inner {
+  padding-block: 0 !important;
+}
+body.is-tablet .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header {
+  margin-block: 8px;
+}
+
+body:not(.is-phone):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked) {
+  container-type: inline-size;
+}
+@container (min-width: 560px) {
+  body:not(.is-phone):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header-container-inner {
+    flex: 1;
+    justify-content: safe center;
+    transition: padding-left var(--anim-duration-moderate) var(--anim-motion-baseline), padding-right var(--anim-duration-moderate) var(--anim-motion-baseline);
+  }
+  body:not(.is-phone):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header-spacer {
+    display: none;
+  }
+}
+
+@container (min-width: 560px) {
+  body.mod-macos:not(.is-mobile):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked):not(.mod-top-left-space).mod-top-right-space .workspace-tab-header-container-inner {
+    padding-left: calc(var(--tab-action-width) * 3);
+  }
+  body.mod-macos:not(.is-mobile):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked):not(.mod-top-left-space):not(.mod-top-right-space) .workspace-tab-header-container-inner {
+    padding-left: calc(var(--tab-action-width) * 2);
+  }
+}
+@container (min-width: 560px) {
+  body.mod-macos:not(.is-mobile):not(.tab-floating):not(.is-fullscreen) .mod-root .workspace-tabs:not(.mod-stacked).mod-top-left-space.mod-top-right-space .workspace-tab-header-container-inner {
+    padding-right: calc(var(--frame-left-space) + --tab-action-width * 2);
+  }
+  body.mod-macos:not(.is-mobile):not(.tab-floating):not(.is-fullscreen) .mod-root .workspace-tabs:not(.mod-stacked).mod-top-left-space:not(.mod-top-right-space) .workspace-tab-header-container-inner {
+    padding-right: calc(var(--frame-left-space) - var(--tab-action-width));
+  }
+}
+@container (min-width: 560px) {
+  body.mod-macos:not(.is-mobile):not(.tab-floating).is-fullscreen .mod-root .workspace-tabs:not(.mod-stacked).mod-top-left-space.mod-top-right-space .workspace-tab-header-container-inner {
+    padding-left: calc(var(--tab-action-width) * 2);
+  }
+  body.mod-macos:not(.is-mobile):not(.tab-floating).is-fullscreen .mod-root .workspace-tabs:not(.mod-stacked).mod-top-left-space:not(.mod-top-right-space) .workspace-tab-header-container-inner {
+    padding-left: var(--tab-action-width);
+  }
+}
+
+@container (min-width: 560px) {
+  body:not(.mod-macos):not(.is-mobile):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked).mod-top-left-space.mod-top-right-space .workspace-tab-header-container-inner {
+    padding-left: calc(var(--frame-right-space) + var(--tab-action-width) * 2);
+  }
+  body:not(.mod-macos):not(.is-mobile):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked).mod-top-left-space:not(.mod-top-right-space) .workspace-tab-header-container-inner {
+    padding-left: calc(var(--tab-action-width) * 2);
+  }
+  body:not(.mod-macos):not(.is-mobile):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked):not(.mod-top-left-space).mod-top-right-space .workspace-tab-header-container-inner {
+    padding-left: calc(var(--frame-right-space) + var(--tab-action-width) * 3);
+  }
+  body:not(.mod-macos):not(.is-mobile):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked):not(.mod-top-left-space):not(.mod-top-right-space).mod-top .workspace-tab-header-container-inner {
+    padding-left: calc(var(--tab-action-width) * 3);
+  }
+  body:not(.mod-macos):not(.is-mobile):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked):is(.mod-root > .workspace-tabs):not(:only-of-type).mod-top-left-space:not(.mod-top-right-space) .workspace-tab-header-container-inner {
+    padding-left: var(--tab-action-width);
+  }
+  body:not(.mod-macos):not(.is-mobile):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked):is(.mod-root > .workspace-tabs):not(:only-of-type):first-of-type:not(.mod-top-left-space):not(.mod-top-right-space) .workspace-tab-header-container-inner, body:not(.mod-macos):not(.is-mobile):not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked):not(.mod-top) .workspace-tab-header-container-inner {
+    padding-left: calc(var(--tab-action-width) * 2);
+  }
+}
+
+@container (min-width: 560px) {
+  body.is-tablet:not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked).mod-top-left-space.mod-top-right-space .workspace-tab-header-container-inner {
+    padding-left: calc(var(--tab-action-width) * 2);
+  }
+  body.is-tablet:not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked).mod-top-left-space:not(.mod-top-right-space) .workspace-tab-header-container-inner {
+    padding-left: var(--tab-action-width);
+  }
+  body.is-tablet:not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked):not(.mod-top-left-space).mod-top-right-space .workspace-tab-header-container-inner {
+    padding-left: calc(var(--tab-action-width) * 3);
+  }
+  body.is-tablet:not(.tab-floating) .mod-root .workspace-tabs:not(.mod-stacked):not(.mod-top-left-space):not(.mod-top-right-space) .workspace-tab-header-container-inner {
+    padding-left: calc(var(--tab-action-width) * 2);
+  }
+}
+@container (min-width: 560px) {
+  body.is-tablet:not(.tab-floating) .workspace-drawer.is-pinned.mod-left + .mod-root .workspace-tabs:not(.mod-stacked).mod-top-left-space.mod-top-right-space .workspace-tab-header-container-inner {
+    padding-left: calc(var(--tab-action-width) * 3);
+  }
+  body.is-tablet:not(.tab-floating) .workspace-drawer.is-pinned.mod-left + .mod-root .workspace-tabs:not(.mod-stacked).mod-top-left-space:not(.mod-top-right-space) .workspace-tab-header-container-inner {
+    padding-left: calc(var(--tab-action-width) * 2);
+  }
+}
+@container (min-width: 560px) {
+  body.is-tablet:not(.tab-floating) .mod-root:has(+ .workspace-drawer.is-pinned.mod-right) .workspace-tabs:not(.mod-stacked).mod-top-left-space.mod-top-right-space .workspace-tab-header-container-inner {
+    padding-left: var(--tab-action-width);
+  }
+  body.is-tablet:not(.tab-floating) .mod-root:has(+ .workspace-drawer.is-pinned.mod-right) .workspace-tabs:not(.mod-stacked):not(.mod-top-left-space).mod-top-right-space .workspace-tab-header-container-inner {
+    padding-left: calc(var(--tab-action-width) * 2);
+  }
+}
+
+.mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header-inner::after {
+  content: none;
+}
+
+.mod-root .workspace-tabs.mod-stacked .workspace-tab-header-container-inner {
+  display: none;
+}
+
+body.is-tablet .workspace .mod-root .sidebar-toggle-button {
+  padding-left: 0;
+}
+body.is-tablet .workspace .mod-root .sidebar-toggle-button .clickable-icon {
+  margin: auto 0;
+}
+body.is-tablet .workspace .mod-root .workspace-tab-header-tab-list .clickable-icon,
+body.is-tablet .workspace .mod-root .workspace-tab-header-new-tab .clickable-icon {
+  --icon-size: var(--icon-l);
+  --icon-stroke: var(--icon-l-stroke-width);
+}
+
+.workspace .mod-sidedock .workspace-tab-header-container,
+.workspace .mod-sidedock .workspace-tab-header,
+.workspace .mod-sidedock .workspace-tab-header div {
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline);
+}
+.workspace .mod-sidedock .workspace-tab-header-container {
+  padding-block: 8px;
+  align-items: center;
+}
+.workspace .mod-sidedock .workspace-tab-header-container-inner {
+  -webkit-app-region: no-drag;
+  padding: 0 8px 0 0;
+  margin: 0;
+  gap: calc(8px * var(--density-modifier));
+  height: 100%;
+}
+.workspace .mod-sidedock .sidebar-toggle-button {
+  position: relative !important;
+  padding: 0 !important;
+  height: fit-content;
+}
+.workspace .mod-sidedock .workspace-tab-header {
+  height: calc-size(auto, size);
+  line-height: normal;
+}
+.workspace .mod-sidedock .workspace-tab-header.is-active {
+  background-color: inherit;
+  box-shadow: none;
+}
+.workspace .mod-sidedock .workspace-tab-header.is-active:hover {
+  background-color: inherit;
+}
+.workspace .mod-sidedock .workspace-tab-header:not(.is-active):not(:hover) {
+  opacity: 0.5;
+}
+.workspace .mod-sidedock .workspace-tab-header:not(.is-active):hover .workspace-tab-header-inner {
+  background-color: inherit;
+}
+.workspace .mod-sidedock .workspace-tab-header-inner {
+  gap: 8px;
+}
+
+body:not(.tab-icon) .mod-sidedock .workspace-tabs:not(.mod-top) .workspace-tab-header-container:not(:hover) {
+  height: calc-size(auto, size);
+}
+body:not(.tab-icon) .mod-sidedock .workspace-tabs:not(.mod-top) .workspace-tab-header-container:not(:hover) .workspace-tab-header {
+  background-color: var(--background-modifier-hover);
+  height: 4px;
+}
+body:not(.tab-icon) .mod-sidedock .workspace-tabs:not(.mod-top) .workspace-tab-header-container:not(:hover) .workspace-tab-header-inner-icon,
+body:not(.tab-icon) .mod-sidedock .workspace-tabs:not(.mod-top) .workspace-tab-header-container:not(:hover) .workspace-tab-header-inner-title {
+  opacity: 0;
+}
+
+body:not(.mod-macos).is-hidden-frameless .mod-sidedock .workspace-tabs.mod-top-right-space .workspace-tab-header-container {
+  padding-right: var(--frame-right-space);
+}
+
+body.mod-macos.is-frameless:not(.is-popout-window) .workspace .workspace-tabs.mod-top-right-space .workspace-tab-header-container {
+  padding-right: 8px;
+}
+body.mod-macos.is-frameless:not(.is-popout-window) .workspace .mod-root .sidebar-toggle-button.mod-right {
+  position: relative;
+  padding-right: 0;
+}
+
+body {
+  --nav-item-padding: calc(8px * var(--density-modifier)) 16px calc(8px * var(--density-modifier)) 32px;
+  --nav-indentation-guide-width: 0px;
+  --nav-item-children-margin-start: calc(20px - var(--nav-indentation-guide-width) / 2);
+  --ribbon-background: transparent;
+  --ribbon-background-collapsed: var(--ribbon-background);
+  --divider-vertical-height: 100% !important;
+}
+
+body.is-mobile {
+  --nav-item-padding: calc(10px * var(--density-modifier)) 24px;
+  --nav-item-color: var(--text-muted);
+  --nav-item-size: var(--font-ui-small);
+  --nav-item-weight-active: var(--font-medium);
+  --nav-item-children-margin-start: 12px;
+}
+
+@keyframes workspaceLeafIn {
+  from {
+    opacity: 0;
+    transform: scale(0.95);
+  }
+}
+.sidebar-toggle-icon-inner {
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline);
+}
+
+.sidebar-toggle-button .clickable-icon:hover .sidebar-toggle-icon-inner {
+  width: 24%;
+}
+
+.workspace.is-left-sidedock-open .sidebar-toggle-button.mod-left .clickable-icon:hover .sidebar-toggle-icon-inner,
+.workspace.is-right-sidedock-open .sidebar-toggle-button.mod-right .clickable-icon:hover .sidebar-toggle-icon-inner {
+  width: revert-layer;
+}
+
+body.full-item-name {
+  --nav-item-white-space: none;
+}
+
+body.bold-folders .nav-folder-title {
+  --nav-item-weight: calc(var(--font-weight) + var(--bold-modifier));
+  --nav-item-weight-hover: calc(var(--font-weight) + var(--bold-modifier));
+}
+
+.tree-item-self,
+.tree-item-inner {
+  align-items: center;
+}
+
+.nav-header {
+  display: flex;
+  justify-content: center;
+  flex-direction: column;
+  align-items: center;
+  padding: 8px 16px;
+}
+
+.nav-header .nav-buttons-container {
+  flex-wrap: nowrap;
+}
+
+.nav-header .search-input-container {
+  margin: 8px 0;
+  width: 100%;
+}
+
+.nav-action-button,
+.nav-action-button[aria-disabled=true] {
+  position: relative;
+  height: 100%;
+}
+
+body.mod-macos.is-hidden-frameless .workspace-ribbon.mod-left {
+  padding-top: 0;
+}
+
+.workspace-ribbon.mod-left {
+  border-right: none;
+  z-index: 11;
+  transition: var(--anim-duration-moderate) !important;
+  position: relative;
+}
+
+.workspace-ribbon.mod-left:not(.is-collapsed) {
+  padding-left: 12px;
+}
+
+.workspace-ribbon.mod-left:before {
+  content: none;
+}
+
+.workspace-ribbon.mod-left .sidebar-toggle-button {
+  position: relative;
+  display: flex;
+  height: var(--header-height);
+  padding: 8px;
+  width: unset;
+  align-items: center;
+  justify-content: center;
+}
+
+.workspace-ribbon.mod-left .sidebar-toggle-button .clickable-icon {
+  pointer-events: auto;
+  z-index: 1;
+}
+
+.workspace-ribbon.mod-left .side-dock-actions {
+  gap: 4px;
+  transition: var(--anim-duration-moderate);
+  z-index: 1;
+  color: var(--icon-color);
+}
+
+.workspace-ribbon.mod-left .sidebar-toggle-button .clickable-icon,
+.workspace-ribbon.mod-left .side-dock-actions .side-dock-ribbon-action {
+  width: var(--tab-action-width);
+}
+
+body:not(.mod-macos):not(.is-mobile) .workspace-ribbon.mod-left,
+body.mod-macos:not(.is-hidden-frameless):not(.is-mobile) .workspace-ribbon.mod-left {
+  margin-top: 0;
+}
+
+body:not(.mod-macos):not(.is-mobile) .workspace-ribbon.mod-left .sidebar-toggle-button,
+body.mod-macos:not(.is-hidden-frameless):not(.is-mobile) .workspace-ribbon.mod-left .sidebar-toggle-button {
+  height: auto;
+  padding: 0;
+  margin: 0 auto;
+}
+
+body:not(.mod-macos):not(.is-mobile) .workspace-ribbon.mod-left .sidebar-toggle-button {
+  height: calc(var(--header-height) - 16px);
+}
+
+body:not(.is-mobile) .mod-sidedock > .workspace-leaf-resize-handle:not(:hover) {
+  border-color: transparent;
+}
+body:not(.is-mobile) .mod-sidedock .workspace-leaf {
+  background-color: transparent;
+}
+body:not(.is-mobile) .mod-sidedock .workspace-leaf:not([style*="display: none"]) {
+  animation: workspaceLeafIn var(--anim-duration-moderate) var(--anim-motion-baseline) forwards;
+}
+body:not(.is-mobile) .mod-sidedock .workspace-leaf-content > .node-insert-event,
+body:not(.is-mobile) .mod-sidedock .workspace-leaf-content > .view-content {
+  padding: 2px 8px;
+}
+body:not(.is-mobile) .mod-sidedock .workspace-leaf-content > .node-insert-event > .node-insert-event,
+body:not(.is-mobile) .mod-sidedock .workspace-leaf-content > .view-content > .node-insert-event {
+  padding: 0;
+}
+
+.nav-header,
+.nav-buttons-container,
+.nav-action-button,
+.nav-action-button::after,
+.nav-header svg {
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline), background-color var(--anim-duration-fast);
+}
+
+body:not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child:not(:hover) .nav-buttons-container {
+  gap: 4px !important;
+  padding: 0 !important;
+  background-color: transparent !important;
+  box-shadow: none !important;
+}
+body:not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child:not(:hover) .nav-buttons-container .nav-action-button {
+  padding: 2px !important;
+  width: 0 !important;
+  flex: 0;
+  background-color: var(--background-modifier-hover);
+  box-shadow: none !important;
+  min-width: 0;
+}
+body:not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child:not(:hover) .nav-buttons-container .nav-action-button::after {
+  font-size: 0;
+  opacity: 0;
+}
+body:not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child:not(:hover) .nav-buttons-container .nav-action-button.is-active {
+  background-color: var(--background-modifier-hover) !important;
+}
+body:not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child:not(:hover) .nav-buttons-container .nav-action-button.clickable-icon[aria-disabled=true] {
+  opacity: var(--icon-opacity);
+}
+body:not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child:not(:hover) .nav-buttons-container svg {
+  width: 0px;
+  height: 0px;
+}
+
+body:not(.is-mobile) .workspace-split.mod-left-split .workspace-drawer-vault-actions .clickable-icon:first-child {
+  display: none;
+}
+
+body:not(.is-mobile) .mod-sidedock.mod-left-split .workspace-sidedock-vault-profile {
+  background-color: transparent;
+}
+
+body:not(.is-mobile) .mod-sidedock.mod-left-split .workspace-sidedock-vault-profile {
+  border-top: none;
+  position: absolute;
+  inset: auto 0 0;
+  z-index: 1;
+  align-items: unset;
+  width: auto;
+}
+body:not(.is-mobile) .mod-sidedock.mod-left-split .workspace-sidedock-vault-profile:hover ~ .workspace-tabs:last-child {
+  mask: linear-gradient(to top, transparent, black 64px);
+}
+body:not(.is-mobile) .mod-sidedock.mod-left-split .workspace-sidedock-vault-profile .workspace-drawer-vault-switcher.has-active-menu {
+  background-color: var(--interactive-normal);
+}
+body:not(.is-mobile) .mod-sidedock.mod-left-split .workspace-sidedock-vault-profile:not(:hover) {
+  pointer-events: none;
+}
+body:not(.is-mobile) .mod-sidedock.mod-left-split .workspace-sidedock-vault-profile:not(:hover) .workspace-drawer-vault-switcher:not(.has-active-menu) {
+  opacity: 0;
+  filter: blur(4px);
+  pointer-events: none;
+  transform: scale(0.95);
+}
+body:not(.is-mobile) .mod-sidedock.mod-left-split .workspace-drawer-vault-switcher,
+body:not(.is-mobile) .mod-sidedock.mod-left-split .workspace-drawer-vault-actions .clickable-icon {
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline);
+  pointer-events: visible;
+}
+body:not(.is-mobile) .mod-sidedock.mod-left-split .workspace-leaf-content > .node-insert-event,
+body:not(.is-mobile) .mod-sidedock.mod-left-split .workspace-leaf-content > .view-content {
+  padding-bottom: 64px;
+}
+
+@keyframes menuIn {
+  from {
+    opacity: 0;
+    transform: translateY(-8px);
+  }
+}
+.menu,
+.suggestion-container {
+  border-radius: var(--menu-radius);
+  padding: 0;
+}
+.menu .menu-item,
+.menu .suggestion-item,
+.suggestion-container .menu-item,
+.suggestion-container .suggestion-item {
+  padding: calc(6px * var(--density-modifier)) 8px;
+  border-radius: calc(var(--menu-radius) - var(--menu-padding));
+  margin-bottom: 0;
+}
+.menu .menu-item-icon,
+.suggestion-container .menu-item-icon {
+  order: unset !important;
+  color: var(--text-normal);
+}
+.menu .menu-item-icon .svg-icon,
+.suggestion-container .menu-item-icon .svg-icon {
+  --icon-size: var(--icon-xs);
+  --icon-stroke: var(--icon-xs-stroke-width);
+}
+.menu .menu-separator,
+.suggestion-container .menu-separator {
+  margin: 4px 0;
+}
+
+body:not(.is-phone) {
+  --menu-padding: 4px;
+  --menu-border-color: var(--background-modifier-border);
+}
+body:not(.is-phone) > .menu, body:not(.is-phone) > .suggestion-container {
+  animation: menuIn var(--anim-duration-moderate) var(--anim-motion-baseline) forwards;
+}
+body:not(.is-phone) .menu,
+body:not(.is-phone) .suggestion-container div:is(.suggestion-item, .suggestion-empty) {
+  font-size: var(--font-ui-small);
+  align-items: center;
+}
+
+body.is-mobile .menu .menu-item-icon .svg-icon,
+body.is-mobile .suggestion-container .menu-item-icon .svg-icon {
+  --icon-size: var(--icon-s);
+  --icon-stroke: var(--icon-s-stroke-width);
+}
+
+body.is-phone {
+  --menu-padding: 32px 16px;
+}
+body.is-phone .menu {
+  border-radius: var(--radius-l) var(--radius-l) 0 0;
+  overflow: hidden;
+}
+body.is-phone .menu .menu-grabber {
+  margin: 8px auto;
+  position: absolute;
+  inset: 0;
+}
+body.is-phone .menu .menu-scroll {
+  max-height: 80vh;
+}
+body.is-phone .menu .menu-item {
+  padding: calc(16px * var(--density-modifier)) 20px;
+  font-size: var(--nav-item-size);
+  gap: 16px;
+  border-radius: 0;
+}
+body.is-phone .menu .menu-item:only-child {
+  border-radius: var(--radius-s);
+}
+body.is-phone .menu .menu-separator {
+  margin: calc(12px * var(--density-modifier)) 16px;
+}
+body.is-phone .suggestion-container {
+  border-radius: var(--radius-l);
+}
+body.is-phone .suggestion-container .suggestion-item {
+  border-radius: var(--radius-m);
+  padding: calc(8px * var(--density-modifier)) 16px;
+}
+
+body.is-tablet .menu,
+body.is-tablet .suggestion-container {
+  border: 1px solid var(--background-modifier-border-hover);
+  border-radius: var(--menu-radius);
+  overflow: auto;
+  max-height: 80vh;
+}
+body.is-tablet .menu .menu-scroll,
+body.is-tablet .suggestion-container .menu-scroll {
+  overflow: visible;
+}
+body.is-tablet .menu .menu-item,
+body.is-tablet .suggestion-container .menu-item {
+  padding: calc(8px * var(--density-modifier)) 12px;
+  font-size: var(--font-ui-small);
+}
+body.is-tablet .menu .menu-item-title,
+body.is-tablet .suggestion-container .menu-item-title {
+  max-width: 240px;
+}
+
+body {
+  --modal-background: var(--background-secondary);
+  --modal-border-color: var(--background-modifier-border);
+}
+body .modal-title {
+  font-family: var(--h1-font);
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline);
+  overflow: visible;
+  text-align: left;
+}
+body .modal-close-button {
+  border-radius: 100vh;
+  position: absolute;
+  top: 8px;
+  inset-inline-end: 8px !important;
+  height: unset;
+  width: unset;
+  padding: 8px;
+  line-height: 12px;
+  z-index: 1;
+}
+body .modal-close-button:empty::before {
+  content: "✕";
+  line-height: 1;
+  display: block;
+  text-align: center;
+  width: var(--icon-l);
+  height: var(--icon-l);
+  font-size: var(--icon-m);
+  font-weight: bold;
+}
+
+@keyframes modalIn {
+  from {
+    opacity: 0;
+    transform: scale(0.975);
+  }
+}
+body:not(.is-mobile) .modal-bg {
+  opacity: 0.2 !important;
+}
+body:not(.is-mobile) .modal {
+  animation: modalIn var(--anim-duration-moderate) var(--anim-motion-baseline) forwards;
+}
+body:not(.is-mobile) .modal-title {
+  margin-left: 0;
+}
+
+body.is-phone .modal-container.mod-confirmation .modal:not(.mod-sidebar-layout) {
+  --modal-radius: var(--radius-l) var(--radius-l) 0 0;
+}
+body.is-phone .modal:not(.mod-sidebar-layout) .modal-header {
+  border-bottom: none;
+  padding-top: 24px;
+}
+body.is-phone .modal:not(.mod-sidebar-layout) .modal-content {
+  padding: var(--safe-area-inset-side);
+}
+body.is-phone .modal:not(.mod-sidebar-layout) .modal-nav-action {
+  position: relative;
+  background-color: var(--interactive-normal);
+  margin: 0 var(--safe-area-inset-side) 8px;
+}
+body.is-phone .modal:not(.mod-sidebar-layout) > button:last-child {
+  margin-bottom: var(--safe-area-inset-bottom) !important;
+}
+
+body.is-tablet {
+  --modal-radius: var(--radius-l);
+}
+
+.notice-container {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  overflow: visible;
+}
+
+.notice {
+  padding: calc(12px * var(--density-modifier)) 16px;
+  margin-bottom: 0;
+  border: none !important;
+}
+
+body {
+  --prompt-input-height: 64px;
+  --prompt-border-color: var(--background-modifier-border);
+}
+body .prompt {
+  background-color: var(--background-secondary);
+  animation: modalIn var(--anim-duration-moderate) var(--anim-motion-baseline) forwards;
+}
+body .prompt .prompt-input,
+body .prompt .prompt-input:hover,
+body .prompt .prompt-input:focus,
+body .prompt .prompt-input:focus-visible {
+  background-color: transparent;
+  border-bottom-color: var(--divider-color);
+}
+body .prompt .prompt-results {
+  flex: 1;
+}
+body .prompt .suggestion-item {
+  padding: 12px;
+}
+
+body.is-phone .prompt {
+  animation: none;
+  border-radius: var(--radius-l) var(--radius-l) 0 0;
+}
+body.is-phone .prompt .prompt-results {
+  padding: var(--safe-area-inset-side);
+}
+body.is-phone .prompt .prompt-input-container {
+  width: auto;
+  margin: auto var(--keyboard-spacing) var(--keyboard-spacing);
+}
+body.is-phone .prompt .prompt-input {
+  background-color: var(--background-primary);
+}
+body.is-phone .prompt .suggestion-item {
+  padding: calc(16px * var(--density-modifier)) 16px;
+}
+
+body.is-tablet {
+  --prompt-input-height: 64px;
+}
+body.is-tablet .prompt {
+  border-radius: var(--modal-radius);
+}
+body.is-tablet .prompt-input {
+  background-color: transparent;
+}
+
+body:not(.is-phone) {
+  --setting-items-radius: var(--radius-m);
+  --setting-items-padding: calc(16px * var(--density-modifier)) 16px;
+  --setting-group-heading-color: var(--text-faint);
+  --setting-group-heading-size: var(--font-ui-small);
+}
+body:not(.is-phone) .modal-sidebar {
+  --background-modifier-form-field: var(--interactive-normal);
+}
+body:not(.is-phone) .modal.mod-sidebar-layout .vertical-tab-header {
+  border-inline-end: none;
+}
+body:not(.is-phone) .modal.mod-sidebar-layout .vertical-tab-header-group-title,
+body:not(.is-phone) .modal.mod-sidebar-layout .vertical-tab-nav-item {
+  padding: calc(8px * var(--density-modifier)) 12px;
+  align-items: center;
+  font-size: var(--font-ui-small);
+}
+body:not(.is-phone) .modal.mod-sidebar-layout .vertical-tab-content {
+  background-color: var(--modal-sidebar-background);
+}
+body:not(.is-phone) .modal.mod-sidebar-layout .setting-group-search {
+  padding: 0 0 8px;
+  background-color: transparent;
+}
+body:not(.is-phone) .modal.mod-sidebar-layout .setting-item-name {
+  overflow: visible;
+}
+body:not(.is-phone) .installed-plugins-container .setting-item .setting-item-description div:last-child {
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+body:not(.is-phone) .installed-plugins-container .setting-items {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  grid-auto-rows: 1fr;
+  gap: 8px;
+  padding: 0;
+  background-color: transparent;
+}
+body:not(.is-phone) .installed-plugins-container .setting-items .setting-item {
+  display: flex;
+  flex-direction: column;
+  margin: 0px !important;
+  border: none;
+  border-radius: var(--setting-items-radius) !important;
+  background-color: var(--setting-items-background);
+  padding: calc(16px * var(--density-modifier)) !important;
+  overflow: hidden;
+}
+body:not(.is-phone) .installed-plugins-container .setting-items .setting-item-info {
+  margin-inline-end: 0;
+  width: 100%;
+}
+body:not(.is-phone) .installed-plugins-container .setting-items .setting-item-description > div:last-child {
+  display: -webkit-box;
+  overflow: hidden;
+  -webkit-line-clamp: 5;
+  -webkit-box-orient: vertical;
+}
+body:not(.is-phone) .installed-plugins-container .setting-items .setting-item-control {
+  flex: none;
+  flex-wrap: wrap;
+  align-self: flex-end;
+  width: 100%;
+}
+body:not(.is-phone) .installed-plugins-container .setting-items .setting-item-control button.mod-cta {
+  flex-grow: 1;
+  flex-basis: 100%;
+}
+body:not(.is-phone) .installed-plugins-container .setting-items .setting-item:has(button) {
+  order: -1;
+}
+body:not(.is-phone) .modal.mod-community-modal .modal-sidebar {
+  padding: 0;
+}
+body:not(.is-phone) .modal.mod-community-modal .community-modal-controls {
+  display: flex;
+  height: auto;
+  align-items: center;
+  padding: 0 8px;
+  width: 100%;
+  flex-wrap: wrap;
+}
+body:not(.is-phone) .modal.mod-community-modal .modal-sidebar:not(:only-child) .community-modal-controls .setting-item {
+  width: 100%;
+  margin-right: 0;
+}
+body:not(.is-phone) .modal.mod-community-modal .community-modal-controls .setting-item {
+  margin: 0;
+  padding: 8px 0;
+  display: flex;
+  align-items: center;
+}
+body:not(.is-phone) .modal.mod-community-modal .community-modal-controls .setting-item:first-child {
+  margin-right: auto;
+}
+body:not(.is-phone) .modal.mod-community-modal .community-modal-controls .setting-item.mod-toggle {
+  margin-right: 48px;
+}
+body:not(.is-phone) .modal.mod-community-modal .community-modal-controls .setting-item:first-child .setting-item-info,
+body:not(.is-phone) .modal.mod-community-modal .community-modal-search-summary {
+  display: none;
+}
+body:not(.is-phone) .modal.mod-community-modal .community-modal-search-results {
+  gap: 8px;
+  padding: 8px;
+}
+body:not(.is-phone) .modal.mod-community-modal .community-item:not(.is-selected) {
+  background-color: var(--setting-items-background);
+}
+
+body.is-phone .modal.mod-sidebar-layout {
+  box-shadow: none;
+}
+body.is-phone .modal.mod-sidebar-layout .modal-header {
+  padding: 0;
+  align-items: center;
+  display: inline;
+  z-index: 1;
+}
+body.is-phone .modal.mod-sidebar-layout .modal-title {
+  display: flex;
+  align-items: center;
+  min-width: fit-content;
+  max-width: 0;
+}
+body.is-phone .modal.mod-sidebar-layout .modal-title:not(:has(.modal-setting-back-button)) {
+  font-size: 1.5rem;
+  font-weight: calc(var(--font-weight) + var(--bold-modifier));
+  max-width: 100%;
+  padding-left: 20px;
+}
+body.is-phone .modal.mod-sidebar-layout .modal-setting-back-button {
+  inset-inline-start: 8px;
+  bottom: unset;
+}
+body.is-phone .modal.mod-sidebar-layout .vertical-tab-header-group-title {
+  display: none;
+}
+body.is-phone .modal.mod-settings .modal-title {
+  margin-top: var(--safe-area-inset-top);
+  height: var(--touch-size-m);
+}
+body.is-phone .modal.mod-community-modal .modal-title {
+  height: calc(var(--touch-size-m) + 16px);
+}
+
+body.is-tablet.theme-dark {
+  --settings-background: var(--background-secondary);
+  --setting-items-background: var(--background-primary);
+}
+body.is-tablet .modal.mod-sidebar-layout .vertical-tab-header-group-title,
+body.is-tablet .modal.mod-sidebar-layout .vertical-tab-nav-item {
+  padding: calc(12px * var(--density-modifier)) 16px;
+}
+
+body:is(.mod-macos, .adaptive-mode-off, .is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=editor] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-background: var(--color-blue);
+}
+body:is(.mod-macos, .adaptive-mode-off, .is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=mobile] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-background: var(--color-blue);
+}
+body:is(.mod-macos, .adaptive-mode-off, .is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=file] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-background: var(--color-orange);
+}
+body:is(.mod-macos, .adaptive-mode-off, .is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=appearance] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-background: var(--color-accent);
+}
+body:is(.mod-macos, .adaptive-mode-off, .is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=hotkeys] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-background: var(--color-pink);
+}
+body:is(.mod-macos, .adaptive-mode-off, .is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=keychain] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-background: var(--color-green);
+}
+body:is(.mod-macos, .adaptive-mode-off, .is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=plugins] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-background: var(--color-cyan);
+}
+body:is(.mod-macos, .adaptive-mode-off, .is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=community-plugins] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-background: var(--color-purple);
+}
+body:is(.mod-macos, .adaptive-mode-off, .is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=backlink] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-background: var(--color-purple);
+}
+body:is(.mod-macos, .adaptive-mode-off, .is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=canvas] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-background: var(--color-red);
+}
+body:is(.mod-macos, .adaptive-mode-off, .is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=daily-notes] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-background: var(--color-red);
+}
+body:is(.mod-macos, .adaptive-mode-off, .is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=file-recovery] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-background: var(--color-green);
+}
+body:is(.mod-macos, .adaptive-mode-off, .is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=note-composer] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-background: var(--color-cyan);
+}
+body:is(.mod-macos, .adaptive-mode-off, .is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=page-preview] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-background: var(--color-blue);
+}
+body:is(.mod-macos, .adaptive-mode-off, .is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=switcher] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-background: var(--color-purple);
+}
+body:is(.mod-macos, .adaptive-mode-off, .is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=sync] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-background: var(--color-green);
+}
+body:is(.mod-macos, .adaptive-mode-off, .is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=templates] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-background: var(--color-blue);
+}
+body:is(.mod-macos, .adaptive-mode-off, .is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=zk-prefixer] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-background: var(--color-orange);
+}
+body:is(.mod-macos, .adaptive-mode-off, .is-android:not(.adaptive-mode-off)) .modal.mod-settings .vertical-tab-nav-item[data-setting-id=webviewer] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-background: var(--color-blue);
+}
+
+body.status-bar-baseline .status-bar {
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline);
+  border: none;
+  transform-origin: bottom right;
+  background-color: transparent;
+  min-height: 8px;
+  height: calc-size(auto, size);
+}
+
+body.status-bar-baseline .status-bar::before {
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline);
+  content: "";
+  position: absolute;
+  bottom: 0;
+  right: 0;
+  width: 150%;
+  height: 200%;
+  z-index: -1;
+  pointer-events: none;
+  background: radial-gradient(farthest-side at right bottom, var(--background-primary), rgba(var(--mono-rgb-0), 0));
+}
+
+body.status-bar-baseline .status-bar:not(:hover) {
+  transform: scale(0.8);
+  opacity: 0.5;
+}
+
+body.status-bar-baseline .status-bar:not(:hover)::before {
+  opacity: 0;
+}
+
+body:not(.status-bar-baseline) .status-bar {
+  --status-bar-border-width: var(--border-width);
+  right: unset;
+  justify-content: center;
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline), background-color var(--anim-duration-moderate) ease;
+  border: none;
+  border-radius: 100vh;
+  max-width: 100%;
+  min-height: unset;
+}
+body:not(.status-bar-baseline) .status-bar > div {
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline);
+}
+body:not(.status-bar-baseline) .status-bar:not(:hover) {
+  bottom: 2px;
+  border-width: 0;
+  background-color: rgba(var(--mono-rgb-100), 0.2);
+  padding-block: 0;
+  max-width: 160px;
+  height: 4px;
+}
+body:not(.status-bar-baseline) .status-bar:not(:hover) > div {
+  transform: scale(0.9);
+  opacity: 0;
+  filter: blur(16px);
+  white-space: nowrap;
+}
+body:not(.status-bar-baseline) .status-bar:hover {
+  bottom: 4px;
+  box-shadow: var(--shadow-s);
+  border-color: var(--background-modifier-border);
+  padding: 8px;
+  height: 40px;
+}
+body:not(.status-bar-baseline) .status-bar:hover::before {
+  transform: scaleY(1);
+}
+body:not(.status-bar-baseline) .status-bar::before {
+  position: absolute;
+  transform: scaleY(10);
+  z-index: -1;
+  transition: var(--anim-duration-fast) var(--anim-duration-fast);
+  width: 100%;
+  height: 100%;
+  content: "";
+}
+
+body:not(.status-bar-baseline):not(.is-grabbing) .app-container.no-transition .status-bar {
+  bottom: 4px;
+  border-color: transparent;
+  background-color: var(--color-accent);
+  color: var(--text-on-accent);
+  max-width: 100% !important;
+  height: 40px !important;
+}
+body:not(.status-bar-baseline):not(.is-grabbing) .app-container.no-transition .status-bar > div {
+  transform: none !important;
+  opacity: 1 !important;
+  filter: none !important;
+}
+
+.workspace-leaf-content[data-type=empty] .empty-state-container {
+  max-height: unset;
+}
+.workspace-leaf-content[data-type=empty] .empty-state-title {
+  display: none;
+}
+.workspace-leaf-content[data-type=empty] .empty-state-action-list {
+  margin-top: 0;
+}
+.workspace-leaf-content[data-type=empty] .empty-state-action-list::before {
+  -webkit-mask-size: contain;
+  -webkit-mask-position: center;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-image: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" width="140" height="180" viewBox="0 0 140 180" fill="none"><path d="M49.775 105.089C54.3828 103.715 61.8069 101.605 70.3434 101.082C65.2222 88.1449 63.986 76.8242 64.9803 66.7442C66.1285 55.1033 70.23 45.3874 74.228 37.1201C75.0811 35.3561 75.9012 33.7135 76.6879 32.1378C77.8017 29.9069 78.8486 27.81 79.8278 25.6916C81.4579 22.1652 82.6674 19.051 83.2791 16.1576C83.8806 13.3125 83.8838 10.7715 83.1727 8.3342C82.4607 5.89352 80.9475 3.26635 78.0704 0.386692C74.3134 -0.587559 70.1448 0.267767 67.0197 3.08162L29.9298 36.4772C27.861 38.34 26.503 40.8642 26.0879 43.6182L22.8899 64.8384C27.9185 69.2873 40.33 82.2201 47.8789 100.165C48.5525 101.766 49.1875 103.408 49.775 105.089Z" fill="white"/><path d="M21.3902 74.5293C21.2153 75.2761 20.9692 76.0051 20.6549 76.7063L1.05225 120.436C-0.961131 124.928 -0.0336421 130.194 3.39276 133.726L34.2418 165.523C49.9952 142.262 47.6984 120.379 40.5026 103.274C35.0465 90.3037 26.777 80.1526 21.3902 74.5293Z" fill="white"/><path d="M41.3687 169.269C41.9093 169.355 42.4575 169.407 43.0096 169.424C48.864 169.6 58.7098 170.109 66.6947 171.582C73.2088 172.783 86.1213 176.397 96.747 179.505C104.855 181.877 113.211 175.396 114.387 167.024C115.245 160.917 116.855 154.009 119.821 147.677L119.753 147.702C114.73 133.682 108.34 124.629 101.641 118.849C94.9619 113.086 87.7708 110.397 80.8276 109.42C69.2835 107.795 58.7071 110.832 52.0453 112.791C56.0353 129.428 54.8074 149.004 41.3687 169.269Z" fill="white"/><path d="M124.96 139.034C131.626 128.965 136.375 121.134 138.881 116.888C140.135 114.764 139.907 112.102 138.423 110.133C134.554 105.002 127.152 94.5755 123.12 84.9218C118.973 74.9962 118.355 59.5866 118.319 52.081C118.306 49.2279 117.402 46.4413 115.639 44.1994L91.6762 13.73C91.5918 15.1034 91.3946 16.4659 91.1093 17.8158C90.3118 21.5882 88.8073 25.3437 87.0916 29.0552C86.086 31.2306 84.9238 33.5612 83.7497 35.9157C82.9682 37.4827 82.1814 39.0607 81.432 40.6102C77.5579 48.6212 73.9528 57.3151 72.9451 67.5313C72.011 77.0006 73.2894 88.014 79.0482 101.162C80.0074 101.243 80.9727 101.351 81.9422 101.487C90.2067 102.651 98.8807 105.891 106.866 112.781C113.73 118.704 119.932 127.19 124.96 139.034Z" fill="white"/></svg>');
+  background-color: var(--background-modifier-hover);
+  height: 80px;
+  content: "";
+  display: flex;
+  margin-bottom: 20px;
+  pointer-events: none;
+}
+
+body:not(.is-phone) .workspace-leaf-content[data-type=empty] .view-header {
+  justify-content: flex-end;
+}
+body:not(.is-phone) .workspace-leaf-content[data-type=empty] .view-header .view-header-left,
+body:not(.is-phone) .workspace-leaf-content[data-type=empty] .view-header .view-header-title-container {
+  display: none;
+}
+body:not(.is-phone) .workspace-leaf-content[data-type=empty] .empty-state-action.mod-close {
+  visibility: hidden;
+}
+
+body.is-mobile {
+  --touch-radius-xxs: var(--radius-s);
+  --touch-radius-xs: var(--radius-s);
+  --touch-radius-s: var(--radius-s);
+  --touch-radius-m: var(--radius-m);
+  --touch-radius-l: var(--radius-l);
+  --touch-radius-xl: var(--radius-xl);
+  --radius-s: calc(16px * var(--radius-modifier));
+  --radius-m: calc(16px * var(--radius-modifier));
+  --radius-l: calc(24px * var(--radius-modifier));
+  --radius-xl: calc(32px * var(--radius-modifier));
+  --tab-radius: var(--radius-s);
+  --tab-curve: var(--tab-radius);
+  --font-ui-smaller: calc(var(--font-text-size) * 0.8 + var(--font-ui-modifier));
+  --font-ui-small: calc(var(--font-text-size) * 0.937 + var(--font-ui-modifier));
+  --font-ui-medium: calc(var(--font-text-size) + var(--font-ui-modifier));
+  --font-ui-large: calc(var(--font-text-size) * 1.2 + var(--font-ui-modifier));
+  --interactive-normal: var(--background-primary);
+  --mobile-sidebar-width: 100%;
+  --view-header-height: var(--header-height);
+  --keyboard-spacing: 8px;
+  --touch-size-l: 48px;
+  --touch-size-xl: 52px;
+  --border-width: 1pt;
+  --divider-width: 1pt;
+  --tab-outline-width: 1pt;
+  --file-margins-y: 8px;
+  --file-margins-x: 24px;
+  --view-top-fade-opacity: 0;
+  --view-bottom-fade-opacity: 0;
+  --mobile-sidebar-background: var(--background-secondary);
+  --tab-switcher-menubar-background: transparent;
+  --tab-switcher-preview-radius: var(--radius-m);
+  --icon-opacity-hover: var(--icon-opacity);
+  --input-border-width-focus: 0;
+  --navbar-max-width: auto !important;
+  --navbar-bottom-offset: max(var(--safe-area-inset-bottom), var(--safe-area-inset-side));
+  --navbar-side-offset: min(var(--navbar-bottom-offset), 32px);
+  --safe-area-inset-side: 16px;
+  --mobile-left-sidebar-width: 360px;
+  --mobile-right-sidebar-width: 360px;
+  --mobile-left-sidebar-width-pinned: 300px;
+  --mobile-right-sidebar-width-pinned: 300px;
+}
+body.is-mobile.theme-dark {
+  --color-base-00: #1e1e1e;
+  --color-base-10: #242424;
+  --color-base-20: #262626;
+}
+body.is-mobile:not(.mod-macos):not(.dynamic-type-off) {
+  --font-ui-smaller: calc(12px + var(--font-ui-modifier));
+  --font-ui-small: calc(14px + var(--font-ui-modifier));
+  --font-ui-medium: calc(16px + var(--font-ui-modifier));
+  --font-ui-large: calc(24px + var(--font-ui-modifier));
+}
+body.is-mobile:not(.mod-macos):not(.dynamic-type-off) .markdown-preview-view,
+body.is-mobile:not(.mod-macos):not(.dynamic-type-off) .markdown-source-view {
+  font-size: calc(var(--font-text-size) * 1.0625);
+}
+body.is-mobile.mod-macos:not(.dynamic-type-off) {
+  --font-ui-smaller: calc(13px + var(--font-ui-modifier));
+  --font-ui-small: calc(15px + var(--font-ui-modifier));
+  --font-ui-medium: calc(17px + var(--font-ui-modifier));
+  --font-ui-large: calc(20px + var(--font-ui-modifier));
+}
+body.is-mobile:not(.mod-macos, .adaptive-mode-off) .mod-raised {
+  backdrop-filter: none;
+  box-shadow: none;
+  background-color: transparent;
+  background-image: none;
+  border: none;
+}
+body.is-mobile:not(.mod-macos, .adaptive-mode-off) .mod-raised::after {
+  content: none !important;
+}
+body.is-mobile:not(.mod-macos, .adaptive-mode-off) .mobile-navbar {
+  background-color: var(--background-secondary) !important;
+  border: var(--border-width) solid var(--background-modifier-border) !important;
+}
+body.is-mobile:not(.mod-macos, .adaptive-mode-off) .mobile-tab-preview:before {
+  content: none;
+}
+body.is-mobile:not(.mod-macos, .adaptive-mode-off).is-mobile .prompt {
+  background-color: var(--prompt-background);
+}
+body.is-mobile .workspace-drawer .workspace-leaf-content > .node-insert-event,
+body.is-mobile .workspace-drawer .workspace-leaf-content > .view-content > .node-insert-event {
+  padding-inline: var(--safe-area-inset-side);
+}
+body.is-mobile .workspace-drawer .workspace-leaf-content:after {
+  content: none !important;
+}
+body.is-mobile .workspace-drawer .workspace-drawer-inner {
+  background-color: transparent;
+}
+body.is-mobile .workspace-drawer .workspace-drawer-header {
+  padding-top: 8px;
+  padding-inline: var(--safe-area-inset-side);
+  z-index: 1;
+  min-height: var(--touch-size-m);
+  box-sizing: content-box;
+}
+body.is-mobile .workspace-drawer .workspace-drawer-header-name-text {
+  font-family: var(--h1-font);
+}
+body.is-mobile .workspace-drawer .workspace-drawer-active-tab-chevron {
+  margin-inline-start: 0;
+}
+body.is-mobile .workspace-drawer .workspace-drawer-tab-options.is-collapsed::before {
+  background-color: transparent;
+  pointer-events: none;
+}
+body.is-mobile .workspace-drawer .workspace-drawer-tab-options::before {
+  position: fixed;
+  z-index: 1;
+  transition: var(--anim-duration-fast);
+  inset: 0;
+  background-color: var(--mobile-sidebar-background);
+  content: "";
+}
+body.is-mobile .workspace-drawer .workspace-drawer-tab-options-list {
+  background-color: transparent;
+  padding: 0;
+}
+body.is-mobile .workspace-drawer .workspace-drawer-tab-options .workspace-tab-header-inner {
+  padding: calc(12px * var(--density-modifier)) 16px;
+  font-weight: var(--font-normal);
+}
+body.is-mobile .workspace-drawer .workspace-drawer-tab-options .workspace-drawer-tab-select .workspace-tab-header-inner {
+  background-color: transparent;
+}
+body.is-mobile .workspace-drawer .nav-header {
+  padding: 0;
+}
+body.is-mobile .workspace-drawer .search-row,
+body.is-mobile .workspace-drawer .nav-header .search-input-container {
+  margin: 8px var(--safe-area-inset-side) 0;
+  width: stretch;
+}
+body.is-mobile .workspace-drawer .nav-buttons-container {
+  padding: 0 var(--safe-area-inset-side);
+}
+body.is-mobile .workspace-drawer .nav-buttons-container::after {
+  content: none !important;
+}
+body.is-mobile .workspace-drawer .nav-action-button {
+  background-color: transparent;
+  min-width: 0;
+}
+body.is-mobile .workspace-drawer .nav-action-button svg.svg-icon {
+  flex-shrink: 0;
+}
+body.is-mobile .workspace-drawer .nav-action-button.is-active {
+  color: var(--interactive-accent);
+}
+body.is-mobile.horizontal-tab-options .workspace-drawer-tab-options-list {
+  flex-direction: row;
+  overflow: visible;
+}
+body.is-mobile.horizontal-tab-options .workspace-drawer-tab-options-list .workspace-tab-header {
+  flex: 1;
+  animation: none !important;
+}
+body.is-mobile.horizontal-tab-options .workspace-drawer-tab-options-list .workspace-tab-header-inner {
+  padding-inline: 0 !important;
+}
+body.is-mobile.horizontal-tab-options .workspace-drawer-tab-options-list .workspace-tab-header:not(.is-swiping) .workspace-tab-header-inner-title {
+  opacity: 0;
+}
+body.is-mobile.horizontal-tab-options .workspace-drawer-tab-options-list .workspace-tab-header-inner-title {
+  position: fixed;
+  align-self: center;
+  inset: 0;
+  width: 100%;
+  color: var(--text-muted);
+  text-align: center;
+}
+body.is-mobile .mobile-toolbar-spacer {
+  background-color: transparent;
+}
+body.is-mobile .mobile-toolbar {
+  box-shadow: none;
+}
+body.is-mobile .pull-action {
+  border-radius: 100vh;
+  background-color: var(--background-secondary);
+  background-image: none;
+  border: var(--border-width) solid var(--background-modifier-border);
+  padding: 16px;
+  width: auto;
+  color: var(--text-normal);
+  font-size: var(--font-ui-small);
+  transition: var(--anim-duration-fast), opacity var(--anim-duration-slow), transform 0s !important;
+}
+@starting-style {
+  body.is-mobile .pull-action {
+    opacity: 0;
+  }
+}
+body.is-mobile .pull-action.pull-action.mod-activated {
+  font-weight: calc(var(--font-weight) + var(--bold-modifier));
+  background-color: var(--interactive-accent);
+  color: var(--text-on-accent);
+  border-color: transparent;
+}
+body.is-mobile .pull-down-action {
+  inset: calc(var(--safe-area-inset-top) + 8px) 8px auto;
+  max-width: 480px;
+}
+
+body.is-phone {
+  --mobile-sidebar-radius: 0;
+}
+body.is-phone .workspace-drawer {
+  width: var(--mobile-sidebar-width-override, var(--mobile-sidebar-width));
+}
+body.is-phone .workspace-drawer-header {
+  z-index: 1;
+  justify-content: flex-end;
+}
+body.is-phone .workspace-drawer-header-left {
+  position: absolute;
+  flex-direction: row;
+  align-items: center;
+  margin: 8px;
+  inset: var(--safe-area-inset-top) var(--safe-area-inset-side) auto;
+  gap: 8px;
+}
+body.is-phone .workspace-drawer-header-name {
+  white-space: nowrap;
+  min-width: 0;
+}
+body.is-phone .workspace-drawer-header-info {
+  margin-top: 0;
+  margin-left: auto;
+  color: var(--text-faint);
+  white-space: nowrap;
+}
+body.is-phone .workspace-drawer-tab-options {
+  position: fixed;
+  bottom: var(--navbar-bottom-offset);
+  z-index: 2;
+  width: stretch;
+  margin-inline: var(--safe-area-inset-side);
+  height: var(--touch-size-m);
+}
+body.is-phone .workspace-drawer-tab-options.is-collapsed {
+  margin-right: calc(var(--safe-area-inset-side) + var(--touch-size-m));
+}
+body.is-phone .workspace-drawer-tab-select {
+  height: 100%;
+}
+body.is-phone .workspace-drawer-tab-select .workspace-tab-header-inner {
+  justify-content: flex-start;
+}
+body.is-phone .workspace-drawer-tab-select .workspace-tab-header-inner-title {
+  flex: unset;
+  width: auto;
+}
+body.is-phone .workspace-drawer-tab-options-list {
+  margin: 0 0 var(--touch-size-m);
+}
+body.is-phone .workspace-drawer .workspace-leaf-content .nav-header ~ div:last-child {
+  padding-top: 16px !important;
+  mask: linear-gradient(to top, hsla(0, 0%, 0%, 0) 0px, hsla(0, 0%, 0%, 0.013) 5px, hsla(0, 0%, 0%, 0.049) 10px, hsla(0, 0%, 0%, 0.104) 14px, hsla(0, 0%, 0%, 0.175) 18px, hsla(0, 0%, 0%, 0.259) 22px, hsla(0, 0%, 0%, 0.352) 26px, hsla(0, 0%, 0%, 0.45) 30px, hsla(0, 0%, 0%, 0.55) 34px, hsla(0, 0%, 0%, 0.648) 38px, hsla(0, 0%, 0%, 0.741) 42px, hsla(0, 0%, 0%, 0.825) 46px, hsla(0, 0%, 0%, 0.896) 50px, hsla(0, 0%, 0%, 0.951) 54px, hsla(0, 0%, 0%, 0.987) 59px, hsl(0, 0%, 0%) 64px, black calc(100% - 16px), transparent);
+}
+body.is-phone .workspace-drawer-inner {
+  padding-top: calc(var(--safe-area-inset-top) + 32px);
+}
+body.is-phone .mod-root {
+  mask-image: none !important;
+}
+body.is-phone .mod-root .view-header {
+  top: 0;
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline);
+  will-change: top;
+  z-index: 3;
+  padding-inline: var(--safe-area-inset-side);
+}
+body.is-phone .mod-root .view-actions {
+  padding: 0;
+}
+body.is-phone .mod-root .workspace-leaf-content[data-type=markdown] > .view-content > div {
+  mask-image: var(--view-bottom-fade-mask);
+}
+body.is-phone:not(.mode-switcher-off) .mod-root .view-action,
+body.is-phone:not(.mode-switcher-off) .mod-root .view-actions {
+  backdrop-filter: none;
+}
+body.is-phone.auto-full-screen.is-hidden-nav .mod-root .view-header {
+  transform: none;
+  top: -32px;
+}
+body.is-phone.auto-full-screen.is-hidden-nav .mobile-navbar, body.is-phone.auto-full-screen.is-hidden-nav:not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-header .view-actions button:nth-last-child(2) {
+  transform: none;
+  margin-bottom: calc(-1 * var(--navbar-bottom-offset));
+}
+body.is-phone.auto-full-screen.is-hidden-nav .mod-root .workspace-leaf-content[data-type=markdown] > .view-content::before,
+body.is-phone.auto-full-screen.is-hidden-nav .mod-root .workspace-leaf-content[data-type=markdown] > .view-content::after {
+  opacity: 0;
+}
+body.is-phone.is-floating-nav:not(.mod-toolbar-open) .mod-root .workspace-leaf-content[data-type=markdown] > .view-content::before, body.is-phone.is-floating-nav:not(.mod-toolbar-open) .mod-root .workspace-leaf-content[data-type=markdown] > .view-content::after {
+  position: absolute;
+  z-index: 1;
+  backdrop-filter: blur(2px);
+  inset-inline: 0;
+  pointer-events: none;
+  content: "";
+  transition: var(--anim-duration-moderate);
+}
+body.is-phone.is-floating-nav:not(.mod-toolbar-open) .mod-root .workspace-leaf-content[data-type=markdown] > .view-content::before {
+  top: 0;
+  mask: linear-gradient(to bottom, black calc(var(--safe-area-inset-top) + var(--view-header-height) / 2), transparent);
+  height: var(--view-top-spacing-markdown);
+}
+body.is-phone.is-floating-nav:not(.mod-toolbar-open) .mod-root .workspace-leaf-content[data-type=markdown] > .view-content::after {
+  bottom: 0;
+  mask: linear-gradient(to top, black var(--navbar-bottom-offset), transparent);
+  height: var(--view-bottom-spacing);
+}
+body.is-phone:not(html:where([style*="--keyboard-height: 0px"], :not([style*="--keyboard-height"])) body):not(.mod-toolbar-open) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2) {
+  opacity: 0;
+  pointer-events: none;
+}
+body.is-phone:not(html:where([style*="--keyboard-height: 0px"], :not([style*="--keyboard-height"])) body):not(.mod-toolbar-open) .mod-root .workspace-leaf-content[data-type=markdown] > .view-content > div {
+  mask-image: none;
+}
+body.is-phone:not(html:where([style*="--keyboard-height: 0px"], :not([style*="--keyboard-height"])) body):not(.mod-toolbar-open) .mod-root .workspace-leaf-content[data-type=markdown] > .view-content::after {
+  content: none !important;
+}
+body.is-phone:not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2) {
+  position: fixed;
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline), right 0s, bottom 0s, height 0s, opacity 0s !important;
+  margin-right: var(--navbar-side-offset);
+  margin-bottom: var(--navbar-bottom-offset);
+  bottom: 0;
+  right: 0;
+  border-radius: 100%;
+  width: var(--touch-size-l);
+  height: var(--touch-size-l);
+  background-color: var(--background-secondary);
+  border: var(--border-width) solid var(--background-modifier-border);
+}
+body.is-phone.mod-toolbar-open:not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2) {
+  width: var(--touch-size-m);
+  height: var(--touch-size-m);
+  margin-right: var(--keyboard-spacing);
+  margin-bottom: var(--keyboard-spacing);
+}
+body.is-phone:not(.is-floating-nav):not(.mode-switcher-off):not(.mod-toolbar-open) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2) {
+  margin-right: 16px;
+  margin-bottom: 16px;
+}
+body.is-phone:not(.is-floating-nav).auto-full-screen:not(.mode-switcher-off):not(.mod-toolbar-open) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2) {
+  margin-bottom: calc(var(--navbar-height) + 16px);
+}
+body.is-phone > .app-container > .horizontal-main-container:has(.workspace > .mod-root > .workspace-tabs.mod-visible > .workspace-tab-container > .workspace-leaf.mod-active > .workspace-leaf-content:not([data-type=markdown])) .view-actions button:nth-last-child(2) {
+  opacity: 0;
+  pointer-events: none;
+}
+body.is-phone.is-floating-nav.mode-switcher-off .mobile-navbar, body.is-phone.is-floating-nav > .app-container > .horizontal-main-container:has(.workspace > .mod-root > .workspace-tabs.mod-visible > .workspace-tab-container > .workspace-leaf.mod-active > .workspace-leaf-content:not([data-type=markdown])) ~ .mobile-navbar {
+  margin-right: var(--navbar-side-offset);
+}
+body.is-phone.is-floating-nav .mobile-navbar {
+  width: auto;
+  margin: auto calc(8px + var(--touch-size-l) + var(--navbar-side-offset)) var(--navbar-bottom-offset) var(--navbar-side-offset);
+  padding: 8px;
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline), background-color var(--anim-duration-moderate);
+}
+body.is-phone .mobile-navbar-action {
+  min-width: 0;
+  margin-inline-start: 0;
+}
+body.is-phone .mobile-navbar-actions {
+  --icon-size: var(--icon-l);
+  --icon-stroke: var(--icon-l-stroke-width);
+}
+body.is-phone .mobile-navbar-tabs-action {
+  font-family: "Inter";
+}
+body.is-phone:not(.is-floating-nav) .mobile-navbar {
+  border: none !important;
+  background-color: var(--background-primary) !important;
+  transition: var(--anim-duration-moderate) !important;
+}
+body.is-phone.mode-switcher-off .mobile-toolbar {
+  right: var(--keyboard-spacing);
+}
+body.is-phone.mod-toolbar-open .mod-root .view-content {
+  margin-bottom: calc(var(--mobile-toolbar-height) + var(--keyboard-spacing));
+}
+body.is-phone .mobile-toolbar-spacer {
+  display: none;
+}
+body.is-phone .mobile-toolbar {
+  top: auto;
+  bottom: var(--keyboard-spacing);
+  left: var(--keyboard-spacing);
+  right: calc(var(--keyboard-spacing) + var(--touch-size-m) + 4px);
+  width: auto;
+}
+body.is-phone .mobile-toolbar-options-container {
+  gap: 4px;
+  width: 100%;
+  margin: 0;
+  border-radius: 0;
+}
+
+body.is-tablet {
+  --titlebar-background: var(--background-secondary) !important;
+  --titlebar-background-focused: var(--background-secondary) !important;
+  --mobile-sidebar-min-width: unset;
+}
+body.is-tablet .workspace {
+  background-color: var(--mobile-sidebar-background);
+}
+body.is-tablet .workspace-tab-header {
+  padding-bottom: 0 !important;
+}
+body.is-tablet .workspace-tab-header-new-tab,
+body.is-tablet .workspace-tab-header-tab-list,
+body.is-tablet .sidebar-toggle-button,
+body.is-tablet .view-header-left,
+body.is-tablet .view-actions {
+  padding: 4px 0;
+}
+body.is-tablet .workspace .mod-root .workspace-tab-header-container .clickable-icon,
+body.is-tablet .view-header .clickable-icon,
+body.is-tablet .workspace-drawer-header-icon {
+  border-radius: 100vh;
+  padding: 10px;
+  position: relative;
+  margin-left: 0;
+}
+body.is-tablet .workspace-drawer.is-pinned,
+body.is-tablet .workspace-split.mod-root,
+body.is-tablet .workspace-split.mod-root .workspace-split {
+  background-color: transparent;
+  border-width: 0;
+}
+body.is-tablet .workspace-drawer .workspace-drawer-ribbon .side-dock-actions {
+  padding-block: 12px;
+}
+body.is-tablet .workspace-drawer .workspace-drawer-header-left {
+  margin-left: 12px;
+}
+body.is-tablet .workspace-drawer .workspace-leaf-content .nav-header ~ div:last-child {
+  mask: linear-gradient(to bottom, transparent, black 16px, black calc(100% - 16px), transparent);
+}
+body.is-tablet .workspace-drawer .workspace-drawer-tab-options-list {
+  margin: var(--touch-size-l) 0 0;
+}
+body.is-tablet .workspace-drawer:not(.is-pinned).mod-left {
+  max-width: var(--mobile-left-sidebar-width, var(--mobile-sidebar-max-width));
+}
+body.is-tablet .workspace-drawer:not(.is-pinned).mod-right {
+  max-width: var(--mobile-right-sidebar-width, var(--mobile-sidebar-max-width));
+}
+body.is-tablet .workspace-drawer.is-pinned.mod-left {
+  width: var(--mobile-left-sidebar-width-pinned, var(--mobile-sidebar-width-pinned));
+}
+body.is-tablet .workspace-drawer.is-pinned.mod-right {
+  width: var(--mobile-right-sidebar-width-pinned, var(--mobile-sidebar-width-pinned));
+}
+body.is-tablet .workspace-drawer:not(.is-pinned) {
+  margin: var(--safe-area-inset-top) 8px calc(var(--keyboard-height) + 8px);
+  padding-top: 0;
+  border-radius: var(--mobile-sidebar-radius);
+  height: auto;
+}
+body.is-tablet .workspace-drawer:not(.is-pinned) .workspace-drawer-inner {
+  padding-top: 0px;
+}
+body.is-tablet .workspace-drawer.is-pinned {
+  flex-shrink: 0;
+  max-width: 35%;
+}
+body.is-tablet .workspace-drawer .workspace-drawer-tab-options {
+  margin: 8px;
+}
+body.is-tablet .workspace-drawer .workspace-drawer-active-tab-container {
+  background-color: transparent;
+}
+body.is-tablet .workspace-drawer-header-icon.mod-raised {
+  backdrop-filter: none;
+  box-shadow: none;
+  background-color: transparent;
+  border: none;
+}
+body.is-tablet .workspace-drawer-header-icon::after {
+  content: none !important;
+}
+
+body:not(.is-mobile) .backlink-pane .search-result-file-match:not(:hover) .search-result-file-match-replace-button {
+  display: none;
+}
+body:not(.is-mobile) .backlink-pane .search-result-file-match-replace-button {
+  padding: 4px 8px;
+}
+
+.embedded-backlinks .nav-header > .search-input-container {
+  width: 100%;
+  margin: 48px 0 16px;
+  align-self: start;
+}
+
+.markdown-embed[data-type=footnote] {
+  background-color: transparent;
+  overflow: visible;
+}
+
+.workspace-leaf-content[data-type=webviewer] .view-header {
+  gap: 0;
+}
+.workspace-leaf-content[data-type=webviewer] .view-header-left,
+.workspace-leaf-content[data-type=webviewer] .view-actions {
+  flex: 0;
+}
+.workspace-leaf-content[data-type=webviewer] .webviewer-content {
+  border-top: none;
+}
+
+body:not(.is-mobile) .canvas-control-group:not(:hover),
+body:not(.is-mobile) .canvas-card-menu:not(:hover) {
+  opacity: 0.5;
+}
+
+.canvas-control-group {
+  border: none;
+  transition: var(--anim-duration-fast);
+}
+
+.canvas-card-menu {
+  transition: var(--anim-duration-fast);
+  padding: 8px;
+  gap: 4px;
+}
+
+.canvas-card-menu .canvas-card-menu-button {
+  --icon-size: 24px;
+}
+
+.canvas-card-menu .canvas-card-menu-button svg {
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline) !important;
+}
+
+@media only screen and (max-width: 600px) {
+  .omnisearch-input-container__buttons {
+    padding: 0 8px;
+  }
+  .omnisearch-input-field {
+    padding: 8px;
+  }
+}
+@media only screen and (min-width: 600px) {
+  .omnisearch-input-container__buttons {
+    margin-inline-end: 4px;
+  }
+}
+.omnisearch-input-field {
+  display: flex;
+  align-items: center;
+  width: 100%;
+}
+
+.omnisearch-input-container__buttons button {
+  box-shadow: none;
+  border: var(--input-border-width) solid var(--background-modifier-border);
+}
+
+.omnisearch-result > div {
+  gap: 4px;
+  width: 100%;
+}
+.omnisearch-result > div .omnisearch-result__title,
+.omnisearch-result > div .omnisearch-result__icon + span {
+  flex: 1;
+}
+.omnisearch-result > div .omnisearch-result__title-container,
+.omnisearch-result > div .omnisearch-result__folder-path {
+  margin-bottom: 4px;
+}
+.omnisearch-result > div .omnisearch-result__body {
+  margin-inline: 0;
+}
+
+body:not(.is-mobile) .omnisearch-input-container__buttons {
+  display: none;
+}
+
+@media only screen and (max-width: 600px) {
+  body:is(.mod-macos, .adaptive-mode-off).is-phone .omnisearch-modal {
+    --prompt-top: calc(var(--safe-area-inset-top) + var(--header-height)) !important;
+    backdrop-filter: none !important;
+    background-color: transparent !important;
+    height: calc(100vh - var(--prompt-top)) !important;
+  }
+  body:is(.mod-macos, .adaptive-mode-off).is-phone .omnisearch-modal::before {
+    position: fixed;
+    z-index: -1;
+    backdrop-filter: var(--blur-l);
+    inset: 0;
+    pointer-events: none;
+    content: "";
+  }
+  body:is(.mod-macos, .adaptive-mode-off).is-phone .omnisearch-modal .prompt-results {
+    backdrop-filter: var(--blur-l);
+    mask: none !important;
+    border-radius: var(--modal-radius) var(--modal-radius) 0 0;
+    background-color: var(--modal-background);
+    padding-top: var(--safe-area-inset-side) !important;
+    padding-bottom: var(--safe-area-inset-bottom);
+  }
+  body:is(.mod-macos, .adaptive-mode-off).is-phone .omnisearch-modal .omnisearch-input-container {
+    gap: 8px;
+    margin-bottom: var(--safe-area-inset-side);
+    padding-inline: var(--safe-area-inset-side);
+  }
+  body:is(.mod-macos, .adaptive-mode-off).is-phone .omnisearch-modal .prompt-input {
+    width: 100%;
+  }
+  body:is(.mod-macos, .adaptive-mode-off).is-phone .omnisearch-modal .omnisearch-input-container__buttons {
+    padding: 0;
+  }
+}
+
+body {
+  --nn-theme-mobile-nav-bg: transparent;
+  --nn-theme-nav-header-bg: transparent;
+  --nn-theme-nav-bg: transparent;
+  --nn-theme-list-header-bg: transparent;
+  --nn-theme-list-bg: transparent;
+  --nn-theme-navitem-selected-bg: var(--background-modifier-hover);
+  --nn-theme-navitem-selected-inactive-bg: var(--background-modifier-hover);
+  --nn-theme-file-tag-bg: var(--tag-background);
+  --nn-theme-file-tag-color: var(--tag-color);
+  --nn-theme-mobile-list-header-link-color: var(--text-normal);
+  --nn-theme-mobile-toolbar-button-icon-color: var(--text-normal);
+  --nn-theme-mobile-toolbar-button-active-icon-color: var(--text-on-accent);
+  --nn-theme-mobile-toolbar-button-active-bg: var(--interactive-accent);
+  --nn-theme-navitem-border-radius: var(--radius-m);
+  --nn-theme-file-border-radius: var(--radius-m);
+}
+
+.notebook-navigator {
+  background-color: transparent;
+}
+
+body:not(.is-mobile) .view-content.notebook-navigator {
+  padding: 0 !important;
+}
+body:not(.is-mobile) .view-content.notebook-navigator .nn-single-pane .nn-navigation-pane {
+  border-right: none;
+}
+body:not(.is-mobile) .view-content.notebook-navigator .nn-pane-header {
+  padding: 8px 12px;
+}
+body:not(.is-mobile) .view-content.notebook-navigator .nn-header-actions button.nn-icon-button {
+  padding: 8px;
+  min-width: unset;
+  height: auto;
+}
+
+body.is-mobile .view-content.notebook-navigator-mobile .nn-pane-header,
+body.is-mobile .view-content.notebook-navigator-mobile .nn-mobile-title {
+  padding: 0;
+}
+
+.hider-sidebar-buttons.mod-macos {
+  --frame-left-space: calc(80px - var(--ribbon-width));
+}
+
+.hider-sidebar-buttons .sidebar-toggle-button.mod-left,
+.hider-sidebar-buttons .sidebar-toggle-button.mod-right {
+  display: flex;
+  visibility: hidden;
+  width: 0 !important;
+  opacity: 0;
+}
+
+body.is-phone.hider-sidebar-buttons .view-header-left {
+  display: none;
+}
+body.is-phone.hider-sidebar-buttons .view-header-title-container {
+  margin-left: 8px !important;
+}
+
+.obsidian-themepocalypse:not(.qe-hide-breadcrumbs) {
+  --status-bar-radius: 0;
+  --status-bar-border-width: 0;
+  --status-bar-background: transparent;
+}
+.obsidian-themepocalypse:not(.qe-hide-breadcrumbs) #quick-explorer .explorable {
+  color: var(--text-faint);
+  transition: var(--anim-duration-fast);
+}
+.obsidian-themepocalypse:not(.qe-hide-breadcrumbs) #quick-explorer .explorable.selected,
+.obsidian-themepocalypse:not(.qe-hide-breadcrumbs) #quick-explorer .explorable:hover {
+  background-color: transparent;
+  color: var(--text-normal);
+}
+.obsidian-themepocalypse:not(.qe-hide-breadcrumbs) .status-bar {
+  width: 100%;
+  transform: none !important;
+  opacity: 1 !important;
+}
+.obsidian-themepocalypse:not(.qe-hide-breadcrumbs) .status-bar::before {
+  content: none !important;
+}
+.obsidian-themepocalypse:not(.qe-hide-breadcrumbs):not(.status-bar-baseline) .status-bar {
+  margin: 4px 0;
+}
+.obsidian-themepocalypse:not(.qe-hide-breadcrumbs):not(.status-bar-baseline) .status-bar:hover {
+  margin: 0;
+  box-shadow: none;
+  backdrop-filter: none;
+  border: none;
+}
+
+body:not(.is-mobile):not(.nav-action-center) .mod-sidedock .workspace-leaf-content.novel-word-count--active > .nav-header:not(:hover) .nav-buttons-container .nav-action-button {
+  opacity: 0;
+}
+body:not(.is-mobile):not(.nav-action-center) .mod-sidedock .workspace-leaf-content.novel-word-count--active > .nav-header:not(:hover) .nav-buttons-container::after {
+  opacity: 1;
+}
+body:not(.is-mobile):not(.nav-action-center) .mod-sidedock .workspace-leaf-content.novel-word-count--active > .nav-header .nav-buttons-container {
+  flex-wrap: nowrap !important;
+}
+body:not(.is-mobile):not(.nav-action-center) .mod-sidedock .workspace-leaf-content.novel-word-count--active > .nav-header .nav-buttons-container::after {
+  position: absolute;
+  overflow: visible;
+  opacity: 0;
+  transition: var(--anim-duration-moderate);
+  color: var(--text-faint);
+}
+
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .workspace-drawer .novel-word-count--active .nav-buttons-container {
+  overflow: visible;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .workspace-drawer .novel-word-count--active .nav-buttons-container::after {
+  position: absolute;
+  transform: translateY(-24px);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .workspace-drawer .novel-word-count--active.novel-word-count--note-right .nav-files-container .nav-folder-title::after, body:is(.mod-macos, .adaptive-mode-off).is-mobile .workspace-drawer .novel-word-count--active.novel-word-count--note-right .nav-files-container .nav-file-title::after {
+  flex: unset;
+  order: 0;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .workspace-drawer .novel-word-count--active.novel-word-count--note-inline .nav-files-container .tree-item .tree-item-inner {
+  flex: unset;
+  padding: 0 8px;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .workspace-drawer .novel-word-count--active.novel-word-count--note-inline .nav-files-container .nav-folder-title::after, body:is(.mod-macos, .adaptive-mode-off).is-mobile .workspace-drawer .novel-word-count--active.novel-word-count--note-inline .nav-files-container .nav-file-title::after {
+  order: 0;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .workspace-drawer .novel-word-count--active.novel-word-count--folder-below .nav-files-container .nav-folder-title::after, body:is(.mod-macos, .adaptive-mode-off).is-mobile .workspace-drawer .novel-word-count--active.novel-word-count--folder-below .nav-files-container .nav-file-title::after {
+  flex-basis: 100%;
+}
+
+.field-btn-container {
+  margin-inline-start: 8px;
+}
+
+.field-btn-container button.property-metadata-menu,
+.plugin-metadata-menu .status-item-bt {
+  padding: 0 !important;
+  background-color: transparent;
+  align-self: center;
+}
+
+.metadata-menu .suggester-input {
+  margin-top: 0;
+}
+.metadata-menu .prompt-input-container {
+  height: var(--prompt-input-height);
+  position: absolute;
+  inset: 0 0 auto;
+  pointer-events: none;
+}
+.metadata-menu .search-input-clear-button {
+  display: none;
+}
+.metadata-menu .value-container.value-checked.is-selected {
+  color: var(--text-on-accent);
+}
+
+.relative-line-numbers-mono {
+  position: absolute;
+  width: 100%;
+}
+
+body:not(.is-phone) .pixel-banner > .markdown-source-view > .cm-editor:first-child .pixel-banner-image,
+body:not(.is-phone) .pixel-banner > .markdown-reading-view > .markdown-preview-view:first-child > .pixel-banner-image {
+  top: var(--view-header-height, var(--header-height));
+}
+
+body.is-phone.is-mobile .pixel-banner .select-image-icon {
+  display: none;
+}
+body.is-phone.is-mobile .pixel-banner .pixel-banner-image {
+  top: var(--view-top-spacing-markdown);
+}
+
+body.is-mobile .kanban-plugin__item,
+body.is-mobile .kanban-plugin__item-input-wrapper {
+  border-radius: var(--radius-s);
+}
+
+body.minimal-theme .workspace::before {
+  content: "Cupertino is not compatible with Minimal Theme Settings.\a\aTo use this theme, disable Minimal Theme Settings in Community plugins.";
+  text-align: center;
+  white-space: pre-wrap;
+  position: fixed;
+  inset: 0;
+  color: var(--text-muted);
+  font-size: var(--font-ui-medium);
+  z-index: 49;
+  pointer-events: none;
+  background-color: var(--background-primary);
+  align-self: center;
+  justify-self: center;
+  padding: 32px;
+  border-radius: var(--radius-l);
+  box-shadow: var(--shadow-l);
+}
+
+.excalidraw {
+  --input-height: 32px;
+}
+
+/*!
 /* @settings
 
 name: Cupertino
@@ -95,6 +2313,23 @@ settings:
         title: Disable full-width elements
         type: class-toggle
     -
+        id: image-align
+        title: Image alignment
+        description: Set default image alignment in editor and reading view.
+        type: class-select
+        allowEmpty: false
+        default: image-align-center
+        options:
+            -
+                label: Left
+                value: image-align-left
+            -
+                label: Center
+                value: image-align-center
+            -
+                label: Right
+                value: image-align-right
+    -
         id: mode-switcher-off
         title: Disable quick mode switcher
         type: class-toggle
@@ -144,4 +2379,5091 @@ settings:
         title: Underlined links
         description: Always underline links for improved visibility.
         type: class-toggle
-*/.view-content .style-settings-container .style-settings-container .setting-item{align-items:center;padding:16px}.view-content .style-settings-container .style-settings-container .setting-item:not(.setting-item-heading){flex-direction:row}.view-content .style-settings-container .style-settings-container .setting-item .setting-item-control{padding-top:0}.style-settings-heading:not(.is-collapsed){border-bottom:none}.style-settings-heading,.style-settings-container{margin-block:0 !important;padding-left:32px}.style-settings-heading{border-radius:0;padding:16px !important}.style-settings-heading .setting-item-name{color:var(--text-normal) !important}.style-settings-container .setting-item{margin-bottom:0;border-radius:0;gap:4px !important}.style-settings-container .setting-item-description>div:last-child{display:none}.style-settings-container .setting-item:not(.style-settings-heading)>.setting-item-control{min-height:var(--input-height)}.style-settings-container .setting-item:nth-child(1 of .setting-item:not(.setting-item-heading)){border-top-right-radius:var(--setting-items-radius);border-top-left-radius:var(--setting-items-radius)}.style-settings-container .setting-item:nth-last-child(1 of .setting-item:not(.setting-item-heading)){border-bottom-right-radius:var(--setting-items-radius);border-bottom-left-radius:var(--setting-items-radius)}body:not(.mod-macos,.adaptive-mode-off) .setting-item[data-id=colorful-frame],body:not(.is-android:not(.adaptive-mode-off)) .setting-item[data-id=material-color]{display:none}@media screen,print{body{--heading-spacing: 2em;--p-spacing: 1.75rem;--line-height-normal: 1.6;--list-spacing: 0.175em;--inline-title-margin-bottom: calc(0.5em * var(--readable-spacing-modifier, 1));--inline-title-color: inherit;--h1-size: 1.5em;--h2-size: 1.25em;--h3-size: 1.125em;--h4-size: 1em;--h5-size: 1em;--h6-size: 0.875em;--file-margins-y: 32px;--file-margins-x: 32px;--file-margins: var(--file-margins-y) var(--file-margins-x);--code-border-width: 1px;--code-size: var(--font-smallest);--embed-padding: 16px;--embed-max-height: none;--embed-background: var(--background-primary-alt);--embed-border-start: var(--embed-border-thickness, 2px) solid var(--embed-border-color, var(--color-base-50));--media-radius: var(--radius-s);--checkbox-radius: 100px;--metadata-gap: 8px;--tag-padding-x: 8px;--tag-padding-y: 4px;--tag-radius: 8px;--tag-weight: var(--font-medium);--indentation-guide-width: 0px;--file-header-border: none}body:is(.mod-macos,.adaptive-mode-off):not(.font-variant-off) .markdown-reading-view,body:is(.mod-macos,.adaptive-mode-off):not(.font-variant-off) .markdown-source-view{font-feature-settings:"ss01" 1,"ss07" 1,"cv07" 1}.workspace-split.mod-root .workspace-tab-container{border-radius:var(--tab-radius);transition:var(--anim-duration-moderate);overflow:hidden}body:not(.mod-macos,.adaptive-mode-off):not(.is-phone) .workspace-split.mod-vertical{gap:8px}body:not(.mod-macos,.adaptive-mode-off):not(.is-phone) .workspace-split:not(.mod-sidedock)>*>.workspace-leaf-resize-handle:not(:hover){border-color:rgba(0,0,0,0)}.markdown-preview-view,.markdown-source-view{color:var(--text-normal-editor, var(--text-normal))}.view-header{padding:0 8px;flex-shrink:0}.view-header-nav-buttons,.view-actions{--icon-size: var(--icon-m);--icon-stroke: var(--icon-m-stroke-width);gap:0 !important}.view-header-title-container{height:auto !important}.view-header-title-container>div{transition:var(--anim-duration-moderate) var(--anim-motion-baseline)}.view-header-title-parent{color:var(--text-faint)}.view-header-title{font-weight:max(var(--file-header-font-weight),var(--font-medium))}.view-header:not(.view-header-always-show):not(:hover) .view-header-title-container>div:not(:focus-within){opacity:0 !important}body.is-phone .view-header-title{font-size:inherit}.document-search-buttons,.document-replace-buttons{flex-grow:0 !important}body:not(.active-line-off) .view-content>.markdown-source-view .cm-line.cm-active:not(:has(.cm-fold-indicator):hover)::before{position:absolute;top:4px;bottom:4px;inset-inline-start:-16px;border-left:4px solid var(--background-modifier-border-hover);border-radius:var(--input-radius);content:""}.markdown-rendered pre{corner-shape:var(--corner-shape)}.markdown-rendered code{corner-shape:var(--corner-shape);padding:2px 4px}.markdown-rendered pre code{white-space:var(--code-white-space)}body:is(.mod-macos,.adaptive-mode-off) .markdown-rendered pre{background:linear-gradient(var(--background-primary-alt), var(--background-secondary));box-shadow:var(--shadow-tactile)}kbd{box-shadow:var(--shadow-tactile);border:1px solid var(--background-modifier-border);background-color:var(--background-secondary);padding:var(--tag-padding-y) var(--tag-padding-x);font-family:var(--font-text);color:var(--text-muted)}.dataview .inline-field-standalone-value,.dataview.inline-field-key,.dataview.inline-field-value{font-family:var(--font-text);font-size:var(--font-smaller);background:rgba(0,0,0,0);color:var(--text-faint);padding-inline:2px}.embed-strict{--embed-border-start: none;--embed-background: transparent;--embed-padding: 0}.embed-hide-title .embed-title,.embed-title:empty{display:none}.markdown-embed{corner-shape:var(--corner-shape)}.markdown-embed:not(.image-embed,.canvas-node-content){display:flex;flex-direction:column;max-height:var(--embed-max-height);overflow:hidden;border-start-end-radius:var(--media-radius);border-end-end-radius:var(--media-radius)}.inline-embed>.markdown-embed-title{padding-bottom:var(--inline-title-margin-bottom)}.inline-embed>.markdown-embed-content{max-height:100%}.block-language-chart{width:100% !important}body:not(.is-mobile) .inline-title:not([data-level]){position:relative}body:not(.is-mobile) .inline-title:not([data-level])::before{content:"";position:absolute;inset:-8px;border-radius:var(--radius-s);pointer-events:none;transition:var(--anim-duration-fast);border:var(--border-width) solid rgba(0,0,0,0)}body:not(.is-mobile) .inline-title:not([data-level]):hover::before,body:not(.is-mobile) .inline-title:not([data-level]):focus-within::before{border-color:var(--background-modifier-border)}body:not(.is-mobile) .inline-title:not([data-level]):not(:focus-within){cursor:pointer}.inline-title:not([data-level]),.markdown-rendered :is(h1,h2,h3,h4,h5,h6),.HyperMD-header{letter-spacing:normal !important;text-wrap:pretty}.markdown-reading-view mark,.markdown-source-view mark,.markdown-rendered mark{-webkit-box-decoration-break:clone;box-decoration-break:clone;border-radius:var(--radius-s);padding:2px 4px;color:var(--text-highlight, var(--text-normal));font-weight:var(--font-medium)}.cm-s-obsidian span.cm-highlight{-webkit-box-decoration-break:clone;box-decoration-break:clone;padding-block:2px}.cm-line .cm-highlight:nth-child(1 of .cm-highlight){border-top-left-radius:var(--radius-s);border-bottom-left-radius:var(--radius-s);padding-left:4px}.cm-line .cm-highlight:nth-last-child(1 of .cm-highlight){border-top-right-radius:var(--radius-s);border-bottom-right-radius:var(--radius-s);padding-right:4px}img:not(.link-favicon),iframe,video,.file-embed{corner-shape:var(--corner-shape);border-radius:var(--media-radius)}.image-embed{padding-bottom:0px;padding-inline-end:0px}body:not(.full-width-media-off) .workspace-leaf-content[data-type=markdown] img:not([width],.cm-widgetBuffer,.link-favicon,.emoji,[alt=banner]),body:not(.full-width-media-off) .workspace-leaf-content[data-type=markdown] iframe,body:not(.full-width-media-off) .workspace-leaf-content[data-type=markdown] video{width:100%;border-radius:var(--media-radius)}.img-grid .markdown-preview-section .el-p>p:has(>.image-embed):has(span:last-child),.img-grid .markdown-preview-section .el-p>p:has(>img):not(:has(>:not(img))){--p-spacing: 4px;display:flex;gap:var(--img-grid-gap, 4px);line-height:0}.img-grid .markdown-preview-section .el-p>p:has(>.image-embed):has(span:last-child) br,.img-grid .markdown-preview-section .el-p>p:has(>img):not(:has(>:not(img))) br{display:none}.img-grid .markdown-preview-section .el-p>p:has(>.image-embed):has(span:last-child)>img,.img-grid .markdown-preview-section .el-p>p:has(>.image-embed):has(span:last-child)>.image-embed,.img-grid .markdown-preview-section .el-p>p:has(>img):not(:has(>:not(img)))>img,.img-grid .markdown-preview-section .el-p>p:has(>img):not(:has(>:not(img)))>.image-embed{flex:1;object-fit:cover}.img-grid .markdown-preview-section .el-p>p:has(>.image-embed):has(span:last-child) img,.img-grid .markdown-preview-section .el-p>p:has(>img):not(:has(>:not(img))) img{height:-webkit-fill-available;overflow:auto;object-fit:cover}body.unstyled-tags{--tag-background: transparent;--tag-background-hover: transparent;--tag-border-width: 0px;--tag-padding-x: 0;--tag-padding-y: 0;--tag-size: inherit;--tag-color-hover: var(--text-accent-hover)}.task-list-item{--indentation-guide-reading-indent: -1.05em}.pdf-container .pdfViewer .canvasWrapper{contain:content;border-radius:var(--radius-s);overflow:hidden}body:not(.clean-link-off){--link-decoration: none;--link-external-decoration: none}}@media screen,print{body{--metadata-label-width: calc(9em * var(--metadata-label-width-modifier, 1))}body.is-phone{--metadata-label-width: calc(7.5em * var(--metadata-label-width-modifier, 1))}body.is-mobile .metadata-content{background-color:rgba(0,0,0,0);padding:0}.metadata-container{--metadata-divider-width: 0 !important}.metadata-properties-heading{padding-inline:0;width:100%}.metadata-property-icon::before{display:none}.metadata-property-key{padding-inline:8px}.metadata-property-key-input,.metadata-input{box-shadow:none !important;border-bottom:none !important}.metadata-input-longtext:not(:focus){overflow:hidden;text-overflow:ellipsis;white-space:nowrap}.metadata-link{width:100%}.metadata-property-value[data-property-type=tags] .multi-select-container{padding-block:0}.multi-select-pill{line-height:var(--line-height-tight) !important}.workspace>.workspace-split:not(.mod-root) .metadata-container .metadata-properties{--metadata-divider-width: 0px;--metadata-gap: 8px}.mod-root .metadata-container .text-icon-button{gap:8px;transition:var(--anim-duration-moderate) var(--anim-motion-baseline);margin-top:4px;background-color:rgba(0,0,0,0);padding-inline:8px;color:var(--text-faint);font-weight:normal;text-transform:lowercase}.mod-root .metadata-container .text-icon-button:hover{color:var(--text-muted)}.mod-root .metadata-content{transform:translateX(-8px) !important;width:calc(100% + 16px) !important}.metadata-properties-heading{display:none}.markdown-reading-view .metadata-container:not(:hover) .text-icon-button{opacity:0;height:0;padding-block:0px;margin-block:0px;display:flex}.markdown-source-view .metadata-container,.markdown-preview-view .metadata-container{transform:none}body .workspace-split{--metadata-gap: 0;--metadata-padding: 0;--metadata-property-radius: var(--radius-m);--metadata-property-radius-hover: var(--radius-m);--metadata-property-radius-focus: var(--radius-m)}body .workspace-split .metadata-container{--input-padding: 8px}body .workspace-split .metadata-container .metadata-properties-heading{padding-inline:0px}body .workspace-split .metadata-container .metadata-properties{border-radius:var(--radius-m);background-color:var(--background-primary-alt)}body .workspace-split .metadata-container .metadata-property{min-height:44px}body .workspace-split .metadata-container .metadata-property-icon,body .workspace-split .metadata-container .text-icon-button{--icon-size: var(--icon-s);--icon-stroke: var(--icon-s-stroke-width)}body .workspace-split .metadata-container .metadata-property-key,body .workspace-split .metadata-container .text-icon-button{padding:8px 16px}body .workspace-split.is-mobile .metadata-container .metadata-property-key,body .workspace-split.is-mobile .metadata-container .text-icon-button{padding-inline-end:4px}body .workspace-split .workspace-split:not(.mod-root) .metadata-container{padding:8px !important}}@media screen,print{body{--blockquote-background-color: var(--background-primary-alt);--blockquote-border-color: var(--color-base-50);--blockquote-border-thickness: 2px;--blockquote-size: var(--font-text-size)}.markdown-rendered blockquote,.HyperMD-quote{corner-shape:var(--corner-shape);font-size:var(--blockquote-size)}.cm-formatting-quote{margin-left:8px}.markdown-rendered blockquote{position:relative;border-radius:var(--radius-s);border-inline-start:none;padding-inline:calc(32px + var(--blockquote-border-thickness)) 16px;padding-block:16px}.markdown-rendered blockquote>blockquote{padding-inline-start:calc(16px + var(--blockquote-border-thickness));padding-block:0 !important}.markdown-rendered blockquote>blockquote::before{top:0;bottom:0;inset-inline-start:0}.markdown-rendered blockquote::before{position:absolute;top:16px;bottom:16px;inset-inline-start:16px;border-radius:var(--radius-s);background-color:var(--blockquote-border-color);width:var(--blockquote-border-thickness);pointer-events:none;content:""}.HyperMD-quote{border:solid var(--blockquote-background-color);border-width:0 16px 0 16px;background-color:var(--blockquote-background-color)}.HyperMD-quote::before{width:0 !important}.HyperMD-quote:first-child,.cm-sizer>div>div>*:not(.HyperMD-quote)+.HyperMD-quote{border-top-width:16px;border-start-start-radius:var(--radius-s);border-start-end-radius:var(--radius-s)}.HyperMD-quote:first-child::before,.cm-sizer>div>div>*:not(.HyperMD-quote)+.HyperMD-quote::before{border-start-start-radius:var(--radius-s);border-start-end-radius:var(--radius-s)}.HyperMD-quote:last-child,.cm-sizer>div>div>.HyperMD-quote:has(+*:not(.HyperMD-quote)){border-bottom-width:16px;border-end-start-radius:var(--radius-s);border-end-end-radius:var(--radius-s)}.HyperMD-quote:last-child::before,.cm-sizer>div>div>.HyperMD-quote:has(+*:not(.HyperMD-quote))::before{border-end-start-radius:var(--radius-s);border-end-end-radius:var(--radius-s)}}@media screen,print{body{--callout-blend-mode: normal;--callout-border-width: var(--divider-width);--callout-padding: 16px;--callout-size: var(--font-text-size)}.callout:not([data-callout=note-toolbar]){corner-shape:var(--corner-shape);font-size:var(--callout-size)}.callout:not([data-callout=note-toolbar]) .callout-content>*:first-child{margin-block-start:8px}.callout:not([data-callout=note-toolbar]) .callout-content>*:last-child{margin-block-end:0 !important}.callout:not([data-callout=note-toolbar]) pre{box-shadow:none;border:var(--border-width) solid var(--background-modifier-border)}.callout:not([data-callout=note-toolbar]) .callout-title{align-items:center;gap:8px}.callout:not([data-callout=note-toolbar]).is-collapsible .callout-title{cursor:pointer}.callout:not([data-callout=note-toolbar]) .callout-title-inner{--p-spacing: 0;color:color-mix(in srgb, rgb(var(--callout-color)), var(--text-normal) 15%)}.callout:not([data-callout=note-toolbar]) .callout-fold{padding-inline-end:0}.callout:not([data-callout=note-toolbar]) .callout-content{margin-left:calc(var(--icon-size) + 8px)}.callout:not([data-callout]){--callout-color: var(--color-accent);background-color:hsla(var(--color-accent-hsl), 0.15);border-color:hsla(var(--color-accent-hsl), var(--callout-border-opacity))}.callout:not([data-callout]) .callout-title{color:var(--callout-color)}body:is(.mod-macos,.adaptive-mode-off) .callout:not([data-callout=note-toolbar]){box-shadow:var(--shadow-tactile);background:linear-gradient(rgba(var(--callout-color), 0.1), rgba(var(--callout-color), 0.15))}}@media screen,print{body{--table-text-size: var(--font-small);--table-border-color: var(--background-modifier-border);--table-add-button-border-width: 0;--table-header-border-color: transparent;--embed-block-shadow-hover: none}body:not(.full-width-media-off) table,body:not(.full-width-media-off) .markdown-source-view.mod-cm6 .cm-table-widget .table-wrapper{min-width:100%}:root table{border-collapse:separate;border-spacing:0;word-break:break-word}div:is(.markdown-preview-view,.is-live-preview) table{position:relative}div:is(.markdown-preview-view,.is-live-preview) table .table-cell-wrapper:active,div:is(.markdown-preview-view,.is-live-preview) table .table-cell-wrapper:focus,div:is(.markdown-preview-view,.is-live-preview) table .table-cell-wrapper:focus-within{background-color:var(--background-modifier-hover)}div:is(.markdown-preview-view,.is-live-preview) table th,div:is(.markdown-preview-view,.is-live-preview) table td{corner-shape:var(--corner-shape)}div:is(.markdown-preview-view,.is-live-preview) table>thead:only-child,div:is(.markdown-preview-view,.is-live-preview) table>tbody{--table-header-border-color: var(--table-border-color);background-color:var(--background-primary-alt);position:relative}div:is(.markdown-preview-view,.is-live-preview) table>thead:not(:only-child)>tr>th,div:is(.markdown-preview-view,.is-live-preview) table>thead:not(:only-child)>tr>th .table-cell-wrapper{border-radius:var(--radius-s)}div:is(.markdown-preview-view,.is-live-preview) table>tbody>tr:not(:last-child)>th,div:is(.markdown-preview-view,.is-live-preview) table>tbody>tr:not(:last-child)>td{border-bottom:none}div:is(.markdown-preview-view,.is-live-preview) div:not([dir=rtl])>table:not([dir=rtl])>thead>tr>th:not(:last-child),div:is(.markdown-preview-view,.is-live-preview) div:not([dir=rtl])>table:not([dir=rtl])>tbody>tr>th:not(:last-child),div:is(.markdown-preview-view,.is-live-preview) div:not([dir=rtl])>table:not([dir=rtl])>tbody>tr>td:not(:last-child){border-right:none}div:is(.markdown-preview-view,.is-live-preview) div:not([dir=rtl])>table:not([dir=rtl])>:is(thead,tbody)>tr:first-child>:is(th,td):first-child,div:is(.markdown-preview-view,.is-live-preview) div:not([dir=rtl])>table:not([dir=rtl])>:is(thead,tbody)>tr:first-child>:is(th,td):first-child .table-cell-wrapper{border-top-left-radius:var(--radius-s)}div:is(.markdown-preview-view,.is-live-preview) div:not([dir=rtl])>table:not([dir=rtl])>:is(thead,tbody)>tr:first-child>:is(th,td):last-child,div:is(.markdown-preview-view,.is-live-preview) div:not([dir=rtl])>table:not([dir=rtl])>:is(thead,tbody)>tr:first-child>:is(th,td):last-child .table-cell-wrapper{border-top-right-radius:var(--radius-s)}div:is(.markdown-preview-view,.is-live-preview) div:not([dir=rtl])>table:not([dir=rtl])>:is(thead,tbody)>tr:last-child>:is(th,td):first-child,div:is(.markdown-preview-view,.is-live-preview) div:not([dir=rtl])>table:not([dir=rtl])>:is(thead,tbody)>tr:last-child>:is(th,td):first-child .table-cell-wrapper{border-bottom-left-radius:var(--radius-s)}div:is(.markdown-preview-view,.is-live-preview) div:not([dir=rtl])>table:not([dir=rtl])>:is(thead,tbody)>tr:last-child>:is(th,td):last-child,div:is(.markdown-preview-view,.is-live-preview) div:not([dir=rtl])>table:not([dir=rtl])>:is(thead,tbody)>tr:last-child>:is(th,td):last-child .table-cell-wrapper{border-bottom-right-radius:var(--radius-s)}div:is(.markdown-preview-view,.is-live-preview) div[dir=rtl]>table>thead>tr>th:not(:last-child),div:is(.markdown-preview-view,.is-live-preview) div[dir=rtl]>table>tbody>tr>th:not(:last-child),div:is(.markdown-preview-view,.is-live-preview) div[dir=rtl]>table>tbody>tr>td:not(:last-child),div:is(.markdown-preview-view,.is-live-preview) table[dir=rtl]>thead>tr>th:not(:last-child),div:is(.markdown-preview-view,.is-live-preview) table[dir=rtl]>tbody>tr>th:not(:last-child),div:is(.markdown-preview-view,.is-live-preview) table[dir=rtl]>tbody>tr>td:not(:last-child){border-left:none}div:is(.markdown-preview-view,.is-live-preview) div[dir=rtl]>table>:is(thead,tbody)>tr:first-child>:is(th,td):first-child,div:is(.markdown-preview-view,.is-live-preview) div[dir=rtl]>table>:is(thead,tbody)>tr:first-child>:is(th,td):first-child .table-cell-wrapper,div:is(.markdown-preview-view,.is-live-preview) table[dir=rtl]>:is(thead,tbody)>tr:first-child>:is(th,td):first-child,div:is(.markdown-preview-view,.is-live-preview) table[dir=rtl]>:is(thead,tbody)>tr:first-child>:is(th,td):first-child .table-cell-wrapper{border-top-right-radius:var(--radius-s)}div:is(.markdown-preview-view,.is-live-preview) div[dir=rtl]>table>:is(thead,tbody)>tr:first-child>:is(th,td):last-child,div:is(.markdown-preview-view,.is-live-preview) div[dir=rtl]>table>:is(thead,tbody)>tr:first-child>:is(th,td):last-child .table-cell-wrapper,div:is(.markdown-preview-view,.is-live-preview) table[dir=rtl]>:is(thead,tbody)>tr:first-child>:is(th,td):last-child,div:is(.markdown-preview-view,.is-live-preview) table[dir=rtl]>:is(thead,tbody)>tr:first-child>:is(th,td):last-child .table-cell-wrapper{border-top-left-radius:var(--radius-s)}div:is(.markdown-preview-view,.is-live-preview) div[dir=rtl]>table>:is(thead,tbody)>tr:last-child>:is(th,td):first-child,div:is(.markdown-preview-view,.is-live-preview) div[dir=rtl]>table>:is(thead,tbody)>tr:last-child>:is(th,td):first-child .table-cell-wrapper,div:is(.markdown-preview-view,.is-live-preview) table[dir=rtl]>:is(thead,tbody)>tr:last-child>:is(th,td):first-child,div:is(.markdown-preview-view,.is-live-preview) table[dir=rtl]>:is(thead,tbody)>tr:last-child>:is(th,td):first-child .table-cell-wrapper{border-bottom-right-radius:var(--radius-s)}div:is(.markdown-preview-view,.is-live-preview) div[dir=rtl]>table>:is(thead,tbody)>tr:last-child>:is(th,td):last-child,div:is(.markdown-preview-view,.is-live-preview) div[dir=rtl]>table>:is(thead,tbody)>tr:last-child>:is(th,td):last-child .table-cell-wrapper,div:is(.markdown-preview-view,.is-live-preview) table[dir=rtl]>:is(thead,tbody)>tr:last-child>:is(th,td):last-child,div:is(.markdown-preview-view,.is-live-preview) table[dir=rtl]>:is(thead,tbody)>tr:last-child>:is(th,td):last-child .table-cell-wrapper{border-bottom-left-radius:var(--radius-s)}.cm-html-embed th,.markdown-rendered th,.cm-html-embed td,.markdown-rendered td,.markdown-source-view.mod-cm6 .cm-table-widget .table-cell-wrapper{padding:8px}.cm-html-embed th,.markdown-rendered th{text-align:var(--table-text-align-header)}.cm-html-embed td,.markdown-rendered td{text-align:var(--table-text-align-body)}.dataview.table-view-table::before,.block-language-datacorejsx.table-view-table::before{border:none}.dataview.table-view-table tr:first-child>td,.block-language-datacorejsx.table-view-table tr:first-child>td{border-top:none}.dataview.table-view-table>thead>tr>th,.dataview .datacore-table-header-cell,.block-language-datacorejsx.table-view-table>thead>tr>th,.block-language-datacorejsx .datacore-table-header-cell{border-bottom:none;font-weight:var(--table-header-weight);font-size:var(--table-header-size)}.dataview.table-view-table>tbody>tr:not(:only-child)>td,.block-language-datacorejsx.table-view-table>tbody>tr:not(:only-child)>td{max-width:20em}.dataview.dataview-error-box,.block-language-datacorejsx.dataview-error-box{border:none;border-radius:var(--radius-s);background-color:var(--background-secondary);min-height:80px}.dataview .dc-paging-control-page,.block-language-datacorejsx .dc-paging-control-page{padding:0 !important}}body{--bases-header-border-width: 0;--bases-table-header-color: var(--text-faint)}.bases-view{border-radius:var(--radius-s)}.mod-sidedock .bases-table-container,.mod-sidedock .bases-tbody{background-color:rgba(0,0,0,0)}.bases-table-container.mod-multiline .bases-table-cell{align-items:var(--bases-table-align-items, start)}.bases-thead .bases-table-header{overflow:hidden}.bases-thead .bases-td{box-shadow:none;border-radius:var(--radius-s);overflow:visible}.bases-thead .bases-td:hover{--bases-table-header-color: var(--text-normal)}.bases-table-header-resizer{border-radius:var(--radius-s)}.bases-table-cell>*{text-overflow:ellipsis;overflow:hidden}body.bases-row-alt .bases-tbody .bases-tr:nth-child(odd){background-color:var(--background-secondary)}body.bases-col-alt .bases-tbody .bases-tr>.bases-td:nth-child(2n+2){background-color:var(--background-secondary)}.bases-cards-item{gap:2px}.bases-cards-label{color:var(--text-faint)}.workspace-leaf-content[data-type=markdown] .bases-embed .bases-view{border:none;border-radius:0}.workspace-leaf-content[data-type=markdown] .bases-embed .bases-view .bases-thead,.workspace-leaf-content[data-type=markdown] .bases-embed .bases-view .bases-tbody,.workspace-leaf-content[data-type=markdown] .bases-embed .bases-view .bases-tbody>.bases-tr:first-child,.workspace-leaf-content[data-type=markdown] .bases-embed .bases-view .bases-tbody>.bases-tr>.bases-td:first-child{box-shadow:none}.workspace-leaf-content[data-type=markdown] .bases-embed .bases-view .bases-tbody{border:var(--bases-embed-border-width) solid var(--bases-embed-border-color);border-radius:var(--bases-embed-border-radius);overflow:hidden}.query-toolbar-menu,.bases-toolbar-menu,.cm-tooltip{animation:none !important;min-width:unset}.text-icon-button{border-radius:var(--clickable-icon-radius)}body:not(.is-phone) .menu.bases-toolbar-menu{align-items:unset}body:not(.is-phone) .menu.bases-toolbar-menu .search-input-container{margin:var(--menu-padding) var(--menu-padding) 0;padding-bottom:0;background:var(--background-modifier-form-field);border:var(--input-border-width) solid var(--background-modifier-border);border-radius:var(--input-radius)}body.is-phone{--bases-embed-width: unset;--bases-embed-transform: none}body.is-phone .markdown-preview-sizer>.el-pre .bases-embed,body.is-phone .markdown-preview-sizer>.el-p .bases-embed,body.is-phone .cm-content>.bases-embed,body.is-phone .cm-content>.cm-lang-base{max-width:100cqw !important;width:100cqw !important;justify-self:center;margin-inline:calc(-1*var(--file-margins-x)) !important}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .workspace-split.mod-root .workspace-tab-container{border-radius:0}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile){--titlebar-border-width: 1px;--tab-outline-width: 1px}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .workspace-tab-header-container{border-bottom:var(--tab-outline-width) solid var(--tab-outline-color)}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .mod-sidedock>.workspace-leaf-resize-handle{border-color:var(--divider-color)}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-left-split>.workspace-leaf-resize-handle{border-color:var(--divider-color-alt)}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile):not(.hover-ribbon) .workspace-ribbon.mod-left.is-collapsed{border-right:var(--divider-width) solid var(--divider-color)}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .workspace-ribbon.mod-left::before{content:"";height:var(--tab-outline-width);background-color:var(--tab-outline-color);position:absolute;inset:calc(var(--header-height) - 1px) 0 auto}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .workspace-ribbon.mod-left .side-dock-actions{margin-top:12px}body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-tablet .workspace-drawer.is-pinned{border-width:var(--divider-width)}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-translucent) .workspace{background-color:var(--background-primary)}body.mod-linux:not(.is-android):not(.adaptive-mode-off).show-ribbon:not(.is-translucent):not(.is-mobile) .workspace-ribbon:not(.is-collapsed){background-color:var(--background-secondary);box-shadow:0 calc(-1*var(--header-height)) var(--background-secondary)}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .mod-sidedock .workspace-tabs:not(.mod-top) .workspace-tab-header-container{border-bottom:none}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .mod-sidedock.mod-left-split,body.mod-linux:not(.is-android):not(.adaptive-mode-off) .workspace-drawer.mod-left{background-color:var(--background-secondary)}body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-tablet .workspace{background-color:rgba(0,0,0,0)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile){--radius-window: 8px}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open){background-color:var(--background-primary)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile){--ribbon-background: transparent;--ribbon-background-collapsed: var(--ribbon-background)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header{height:32px;margin:auto 0}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display]{box-shadow:var(--shadow-s);border-radius:var(--radius-window, var(--radius-m));background-color:var(--modal-background) !important;backdrop-filter:var(--blur-m);height:-webkit-fill-available}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display].mod-left-split{margin:8px 0 8px 8px;overflow:visible}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display].mod-right-split{margin:8px 8px 8px 0}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display]::before{background:none;margin-inline:-8px;pointer-events:auto;width:8px}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root{padding-bottom:0}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile):not(.show-ribbon:not(.hover-ribbon)) .workspace:not(.is-left-sidedock-open).is-right-sidedock-open .mod-root{margin-left:8px}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .workspace.is-left-sidedock-open:not(.is-right-sidedock-open) .mod-root{margin-right:8px}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-root{padding-bottom:8px}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile):not(.mod-macos).is-hidden-frameless .workspace.is-left-sidedock-open:not(.is-right-sidedock-open) .mod-root .workspace-tabs.mod-top-right-space .workspace-tab-header-container{padding-right:var(--frame-right-space)}body:is(.mod-macos,.adaptive-mode-off):not(.is-phone) .workspace:is(.is-left-sidedock-open,.is-right-sidedock-open) .workspace-split.mod-vertical{gap:8px}body:is(.mod-macos,.adaptive-mode-off):not(.is-phone) .workspace:is(.is-left-sidedock-open,.is-right-sidedock-open) .workspace-split:not(.mod-sidedock)>*>.workspace-leaf-resize-handle:not(:hover){border-color:rgba(0,0,0,0)}body:is(.mod-macos,.adaptive-mode-off).is-tablet .workspace-drawer.mod-left.is-pinned+.mod-root:has(+.workspace-drawer.mod-right:not(.is-pinned)) .workspace-tabs:last-of-type .workspace-tab-container{margin-right:8px}body:is(.mod-macos,.adaptive-mode-off).is-tablet .workspace-drawer.mod-left:not(.is-pinned)+.mod-root:has(+.workspace-drawer.mod-right.is-pinned) .workspace-tabs:first-of-type .workspace-tab-container{margin-left:8px}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile){--shadow-sidedock-spread: -32px 0 0 32px var(--background-primary);--shadow-surface: 0 0 0 1px var(--background-modifier-hover);--tab-outline-width: 1px}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile):not(.is-focused):not(.reduce-contrast-change){--workspace-background-translucent: var(--background-secondary);--tab-outline-color: transparent}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile):not(.is-focused):not(.reduce-contrast-change) .modal.mod-settings .vertical-tab-header>div,body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile):not(.is-focused):not(.reduce-contrast-change) .workspace-ribbon,body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile):not(.is-focused):not(.reduce-contrast-change) .mod-sidedock>div{opacity:.5}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile):not(.is-focused):not(.reduce-contrast-change) .modal.mod-settings .vertical-tab-header,body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile):not(.is-focused):not(.reduce-contrast-change) .mod-sidedock.mod-left-split,body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile):not(.is-focused):not(.reduce-contrast-change) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header{background-color:var(--background-modifier-hover) !important;box-shadow:none !important;transition:none}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile).is-fullscreen .mod-sidedock.mod-left-split{border-radius:var(--radius-m)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile).is-fullscreen .mod-sidedock.mod-left-split .mod-sidedock.mod-left-split .mod-top-left-space .workspace-tab-header-container{height:calc(var(--header-height) - 8px);padding-left:var(--frame-left-space)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile).show-ribbon:not(.mod-macos) .workspace-ribbon.mod-left:not(.is-collapsed),body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile).show-ribbon.mod-macos.is-frameless:not(.is-hidden-frameless) .workspace-ribbon.mod-left:not(.is-collapsed){margin-block:8px}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile).show-ribbon:not(.mod-macos) .workspace-ribbon.mod-left:not(.is-collapsed) .sidebar-toggle-button{height:calc(var(--header-height) - 24px)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile).show-ribbon:not(.hover-ribbon) .workspace-ribbon.mod-left:not(.is-collapsed){padding-left:16px}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile).show-ribbon:not(.hover-ribbon) .mod-sidedock.mod-left-split:not(.is-sidedock-collapsed){margin-left:calc(-1*var(--ribbon-width) + 8px);padding-left:var(--ribbon-width)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile).show-ribbon .workspace-ribbon.mod-left .sidebar-toggle-button .clickable-icon:hover,body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile).show-ribbon .workspace-ribbon.mod-left .side-dock-actions .side-dock-ribbon-action:hover{box-shadow:none !important;background-color:rgba(0,0,0,0) !important;color:var(--text-normal)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile):not(.is-translucent).theme-dark .mod-sidedock{background-color:hsl(from var(--background-primary) h s calc(l - 2))}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile).is-translucent .mod-sidedock.mod-left-split{background-color:rgba(from var(--background-primary) r g b/50%) !important}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock{transition:var(--anim-duration-moderate),background-color 0s,box-shadow 0s}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-left-split{corner-shape:var(--corner-shape);z-index:var(--layer-sidedock);margin:8px 0 8px 8px;box-shadow:var(--shadow-surface),var(--shadow-sidedock-spread);border-radius:var(--radius-window, var(--radius-m));height:-webkit-fill-available;overflow:hidden}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-left-split .mod-top-left-space .workspace-tab-header-container{padding-block:0px}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-left-split .mod-top-left-space .workspace-tab-header-container,body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-left-split .mod-top-left-space .workspace-tab-header-container .sidebar-toggle-button{min-height:calc(var(--header-height) - 16px);max-height:calc(var(--header-height) - 16px)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-left-split .mod-top-left-space .workspace-tab-header-container div:is(.workspace-tab-header-inner,.clickable-icon),body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-left-split .mod-top-left-space .workspace-tab-header-container .sidebar-toggle-button div:is(.workspace-tab-header-inner,.clickable-icon){padding-block:4px}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-right-split>.workspace-leaf-resize-handle{border-color:var(--divider-color)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .modal.mod-settings .vertical-tab-header{margin:8px 0 8px 8px;box-shadow:var(--shadow-surface);border-radius:max(var(--modal-radius) - 8px,var(--radius-s));background-color:rgba(from var(--background-primary) r g b/75%)}body:is(.mod-macos,.adaptive-mode-off).is-tablet.theme-light{--shadow-surface: inset 1px 1px 2px rgba(255, 255, 255, 0.5), inset -1px -1px 2px rgba(255, 255, 255, 0.5), inset 0 4px 16px rgba(255, 255, 255, 0.025), 0 0 1px rgba(0, 0, 0, 0.25), 0 8px 16px 0 rgba(0, 0, 0, 0.05)}body:is(.mod-macos,.adaptive-mode-off).is-tablet.theme-dark{--shadow-surface: 0 0 1px rgba(255, 255, 255, 0.3), 0 0 1px rgba(255, 255, 255, 0.5)}body:is(.mod-macos,.adaptive-mode-off).is-tablet .workspace{background-color:var(--background-primary)}body:is(.mod-macos,.adaptive-mode-off).is-tablet .workspace-drawer .workspace-drawer-header-name-text{font-size:var(--font-ui-small)}body:is(.mod-macos,.adaptive-mode-off).is-tablet .workspace-drawer .workspace-drawer-header-info{color:var(--text-faint)}body:is(.mod-macos,.adaptive-mode-off).is-tablet .workspace-drawer:not(.is-pinned){background-color:var(--modal-background);box-shadow:var(--shadow-xs);backdrop-filter:var(--blur-l)}body:is(.mod-macos,.adaptive-mode-off).is-tablet .workspace-drawer.is-pinned.mod-left{background-color:var(--raised-background);box-shadow:var(--shadow-surface);border:none;margin:calc(var(--safe-area-inset-top) + 8px) 0 8px 8px;border-radius:calc(env(safe-area-inset-bottom) - 8px);height:auto}body:is(.mod-macos,.adaptive-mode-off).is-tablet .workspace-drawer.is-pinned.mod-left .workspace-drawer-ribbon,body:is(.mod-macos,.adaptive-mode-off).is-tablet .workspace-drawer.is-pinned.mod-left .workspace-drawer-inner{padding-block:0px 16px}body:is(.mod-macos,.adaptive-mode-off).is-tablet .modal.mod-settings .vertical-tab-header{margin:8px 0 8px 8px;border-radius:var(--radius-m);border:none;z-index:1;background-color:var(--raised-background);box-shadow:var(--shadow-surface)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-root{z-index:5}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .workspace-tabs{overflow:visible}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile){--shadow-sidedock-spread: 0 0 transparent}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-left-split{margin-right:8px}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-right-split{background-color:rgba(0,0,0,0) !important}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-right-split>.workspace-leaf-resize-handle{border-color:rgba(0,0,0,0)}body:is(.mod-macos,.adaptive-mode-off):not(.is-phone).theme-light{--shadow-tab: var(--shadow-base), 0 0 1px rgba(0, 0, 0, 0.2), inset 0 -8px 48px rgba(0, 0, 0, 0.02), 0 2px 4px rgba(0, 0, 0, 0.025), 0 2px 4px rgba(0, 0, 0, 0.025)}body:is(.mod-macos,.adaptive-mode-off):not(.is-phone).theme-dark{--shadow-tab: var(--shadow-base), 0 4px 8px rgba(0, 0, 0, 0.1)}body:is(.mod-macos,.adaptive-mode-off):not(.is-phone) .mod-root .workspace-tab-container{background-color:rgba(from var(--background-primary) r g b/75%)}body:is(.mod-macos,.adaptive-mode-off):not(.is-phone) .mod-root .view-header,body:is(.mod-macos,.adaptive-mode-off):not(.is-phone) .mod-root .view-content,body:is(.mod-macos,.adaptive-mode-off):not(.is-phone) .mod-root .document-search-container{background-color:rgba(0,0,0,0)}@starting-style{body:is(.mod-macos,.adaptive-mode-off):not(.is-phone):is(.mod-macos,.adaptive-mode-off) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header{filter:blur(4px);scale:.75;opacity:0}}body:is(.mod-macos,.adaptive-mode-off):not(.is-phone):is(.mod-macos,.adaptive-mode-off) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header{corner-shape:var(--corner-shape);border-radius:100vh;transition:opacity var(--anim-duration-moderate),filter var(--anim-duration-moderate),background-color 0s}body:is(.mod-macos,.adaptive-mode-off):not(.is-phone):is(.mod-macos,.adaptive-mode-off) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header:first-child{margin-inline-start:2px}body:is(.mod-macos,.adaptive-mode-off):not(.is-phone):is(.mod-macos,.adaptive-mode-off) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header:last-child{margin-inline-end:2px}body:is(.mod-macos,.adaptive-mode-off):not(.is-phone):is(.mod-macos,.adaptive-mode-off) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header:not(.is-active){background-color:rgba(0,0,0,0)}body:is(.mod-macos,.adaptive-mode-off):not(.is-phone):is(.mod-macos,.adaptive-mode-off) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header-inner{border-radius:inherit}body:is(.mod-macos,.adaptive-mode-off):not(.is-phone):is(.mod-macos,.adaptive-mode-off) .workspace:is(.is-left-sidedock-open,.is-right-sidedock-open) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header.is-active{background-color:rgba(from var(--background-primary) r g b/75%);box-shadow:var(--shadow-tab)}body:is(.mod-macos,.adaptive-mode-off).is-tablet .workspace-drawer.mod-left.is-pinned{margin-right:8px}body:is(.mod-macos,.adaptive-mode-off).is-tablet .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header.is-active{background-color:var(--raised-background) !important;box-shadow:var(--shadow-tab)}body{--input-height: 32px;--radius-modifier: 1;--input-radius: var(--radius-s);--radius-s: calc(8px * var(--radius-modifier));--radius-m: calc(12px * var(--radius-modifier));--radius-l: calc(20px * var(--radius-modifier));--radius-xl: calc(28px * var(--radius-modifier));--background-modifier-form-field: var(--interactive-normal);--button-radius: calc(8px * var(--radius-modifier))}.theme-light{--input-shadow: inset 0 0 0 var(--input-border-width) var(--background-modifier-border);--input-shadow-hover: inset 0 0 0 var(--input-border-width) var(--background-modifier-border-hover)}.theme-dark{--input-shadow: inset 0 0 0 var(--input-border-width) var(--background-modifier-border);--input-shadow-hover: inset 0 0 0 var(--input-border-width) var(--background-modifier-border-hover);--background-modifier-form-field: var(--interactive-normal)}button,.clickable-icon,select,.dropdown{transition:var(--anim-duration-moderate) var(--anim-motion-baseline),background-color var(--anim-duration-fast)}button:where(:not(.clickable-icon,.ant-switch,.workspace-leaf-content:not([data-type=markdown]) button,.copy-code-button)){padding:16px;display:inline-flex}.clickable-icon{corner-shape:round;padding:8px;max-height:100%}body.obsidian-app .checkbox-container{transition:var(--anim-duration-moderate);box-shadow:none}body.obsidian-app .checkbox-container:focus-within{outline:none}body.obsidian-app .checkbox-container::after{transition:var(--anim-duration-moderate) var(--anim-motion-baseline),background-color 0s}body.obsidian-app .checkbox-container:active:after{box-shadow:none;width:calc(var(--toggle-thumb-width) + var(--toggle-border-width));height:var(--toggle-thumb-height);margin-top:var(--toggle-border-width)}body.obsidian-app .checkbox-container.is-enabled:active:after{left:calc(var(--toggle-border-width)*-1)}input[type=range]::-webkit-slider-thumb{box-shadow:none}body:is(.mod-macos,.adaptive-mode-off){--side-padding: 20px;--p-spacing: 1rem;--input-shadow: none;--input-shadow-hover: none;--blur-s: blur(2px) saturate(1.5) brightness(1.025);--blur-m: blur(4px) saturate(1.5) brightness(1.025);--blur-l: blur(8px) saturate(1.5) brightness(1.025);--clickable-icon-radius: 100vh;--button-radius: var(--input-radius);--input-radius: var(--radius-s);--input-height: 24px;--interactive-hover: var(--interactive-normal);--background-modifier-border: rgba(var(--mono-rgb-100), 0.075);--background-modifier-border-hover: var(--background-modifier-border);--background-modifier-border-focus: hsla(var(--interactive-accent-hsl), 0.5)}body:is(.mod-macos,.adaptive-mode-off).is-mobile{--titlebar-background: transparent;--titlebar-background-focused: transparent;--background-modifier-form-field: var(--interactive-normal);--radius-s: calc(16px * var(--radius-modifier));--radius-m: calc(24px * var(--radius-modifier));--radius-l: calc(32px * var(--radius-modifier));--radius-xl: calc(40px * var(--radius-modifier));--input-radius: var(--radius-l);--input-height: 48px;--input-padding: 0 var(--side-padding)}body:is(.mod-macos,.adaptive-mode-off).is-phone{--nav-item-padding: calc(16px * var(--density-modifier)) var(--side-padding)}body:is(.mod-macos,.adaptive-mode-off).is-mobile.theme-light{--background-modifier-form-field: var(--interactive-normal);--interactive-normal: var(--background-secondary)}body:is(.mod-macos,.adaptive-mode-off).is-mobile.theme-dark{--settings-background: var(--background-secondary);--setting-items-background: var(--background-secondary-alt)}body:is(.mod-macos,.adaptive-mode-off).is-mobile.theme-dark .modal.mod-sidebar-layout{--background-modifier-border: color-mix(in srgb, var(--background-secondary), white 15%)}body:is(.mod-macos,.adaptive-mode-off).is-phone.theme-dark{--modal-sidebar-background: var(--background-secondary);--mobile-sidebar-background: var(--background-primary)}body:is(.mod-macos,.adaptive-mode-off).theme-light{--divider-color: color-mix(in srgb, var(--background-secondary), black 7.5%);--blur-background: rgba(255, 255, 255, 0.5);--shadow-base: inset 1px 1px 2px rgba(255, 255, 255, 0.5), inset -1px -1px 2px rgba(255, 255, 255, 0.5), inset 0 4px 16px rgba(255, 255, 255, 0.025);--shadow-edges: 0 0 1px rgba(0, 0, 0, 0.4);--shadow-surface: 0 0 1px rgba(0, 0, 0, 0.4), inset 0 0 1px 1px rgba(255, 255, 255, 0.8), 0 4px 24px rgba(0, 0, 0, 0.075);--shadow-xs: var(--shadow-base), inset 0 -8px 48px rgba(0, 0, 0, 0.02), 0 0 8px rgba(0, 0, 0, 0.025), 0 4px 24px rgba(0, 0, 0, 0.075);--shadow-s: var(--shadow-base), inset 0 0 1px 1px white, var(--shadow-edges), 0 8px 16px rgba(0, 0, 0, 0.2);--shadow-l: var(--shadow-edges), inset 0 0 1px 1px white, 0 16px 64px rgba(0, 0, 0, 0.15)}body:is(.mod-macos,.adaptive-mode-off).theme-dark{--divider-color: color-mix(in srgb, var(--background-secondary), white 7.5%);--blur-background: rgba(255, 255, 255, 0.075);--shadow-base: inset 1px 1.5px 1px -1px rgba(255, 255, 255, 0.2), inset -1px -1.5px 1px -1px rgba(255, 255, 255, 0.15), inset 0 4px 16px rgba(255, 255, 255, 0.025);--shadow-edges: 0 0 1px rgba(255, 255, 255, 0.3);--shadow-surface: 0 0 1px rgba(255, 255, 255, 0.5), 0 0 1px rgba(0, 0, 0, 0.4), 0 8px 16px rgba(0, 0, 0, 0.2);--shadow-xs: var(--shadow-base), 0 4px 8px rgba(0, 0, 0, 0.1);--shadow-s: var(--shadow-edges), 0 0 1px rgba(255, 255, 255, 0.5), 0 0 1px rgba(0, 0, 0, 0.4), 0 8px 16px rgba(0, 0, 0, 0.2);--shadow-l: var(--shadow-edges), 0 0 1px rgba(255, 255, 255, 0.5), 0 0 1px rgba(0, 0, 0, 0.7), 0 16px 64px rgba(0, 0, 0, 0.3)}body:is(.mod-macos,.adaptive-mode-off) button:where(:not(.clickable-icon,.ant-switch,.workspace-leaf-content:not([data-type=markdown]) button,.copy-code-button)){padding:4px 12px}body:is(.mod-macos,.adaptive-mode-off).is-phone button:where(:not(.clickable-icon,.ant-switch,.workspace-leaf-content:not([data-type=markdown]) button,.copy-code-button)){padding:0 var(--side-padding)}body:is(.mod-macos,.adaptive-mode-off).is-tablet button:where(:not(.clickable-icon,.ant-switch,.workspace-leaf-content:not([data-type=markdown]) button,.copy-code-button)){padding:4px var(--side-padding)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile){--tab-action-width: 40px}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .clickable-icon{min-width:var(--tab-action-width)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .clickable-icon:not([aria-disabled=true]):hover,body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .clickable-icon.has-active-menu,body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .modal-close-button:hover{box-shadow:var(--shadow-xs);background-color:var(--raised-background)}body:is(.mod-macos,.adaptive-mode-off){--slider-thumb-border-width: 0;--slider-thumb-y: -5px;--slider-thumb-height: 16px;--slider-thumb-width: 20px;--slider-thumb-radius: var(--toggle-thumb-radius);--slider-track-height: 6px;--slider-track-background: var(--background-modifier-border-hover)}body:is(.mod-macos,.adaptive-mode-off).is-mobile{--slider-thumb-y: -9px;--slider-thumb-height: 24px;--slider-thumb-width: 37px}body:is(.mod-macos,.adaptive-mode-off).is-mobile input[type=range]::-webkit-slider-thumb:active{scale:1.4}body:is(.mod-macos,.adaptive-mode-off) input[type=range]::-webkit-slider-thumb{-webkit-transition:var(--anim-duration-moderate) var(--anim-motion-baseline) !important;transition:var(--anim-duration-moderate) var(--anim-motion-baseline) !important;box-shadow:0 1px 4px rgba(0,0,0,.075),0 1px 16px rgba(0,0,0,.1) !important}body:is(.mod-macos,.adaptive-mode-off) input[type=range]::-webkit-slider-thumb:active{scale:1.2;box-shadow:inset 1px 1px 2px -2px rgba(var(--mono-rgb-100), 1),inset -1px -1px 2px -2px rgba(var(--mono-rgb-100), 1),var(--shadow-xs) !important;background-color:var(--raised-background)}body:is(.mod-macos,.adaptive-mode-off){--toggle-border-width: 1.5px;--toggle-thumb-height: 13px;--toggle-thumb-width: 21px;--toggle-width: 36px;--toggle-s-border-width: var(--toggle-border-width);--toggle-s-thumb-height: var(--toggle-thumb-height);--toggle-s-thumb-width: var(--toggle-thumb-width);--toggle-s-width: var(--toggle-width)}body:is(.mod-macos,.adaptive-mode-off).is-mobile{--toggle-border-width: 2px;--toggle-thumb-height: 24px;--toggle-thumb-width: 37px;--toggle-width: 68px}body:is(.mod-macos,.adaptive-mode-off).is-mobile .checkbox-container{--interactive-accent: var(--color-green)}body:is(.mod-macos,.adaptive-mode-off) .checkbox-container{box-shadow:none}body:is(.mod-macos,.adaptive-mode-off) .checkbox-container:not(:active){overflow:hidden}body:is(.mod-macos,.adaptive-mode-off) .checkbox-container::after{transition:var(--anim-duration-moderate) var(--anim-motion-baseline) !important;box-shadow:0 1px 4px rgba(0,0,0,.075),0 1px 16px rgba(0,0,0,.1)}body:is(.mod-macos,.adaptive-mode-off) .checkbox-container:active:after{--toggle-border-width: -2.5px;--toggle-thumb-height: 21px;--toggle-thumb-width: 35.5px;--toggle-s-border-width: var(--toggle-border-width);--toggle-s-thumb-height: var(--toggle-thumb-height);--toggle-s-thumb-width: var(--toggle-thumb-width);box-shadow:inset 1px 1px 2px -2px rgba(var(--mono-rgb-100), 1),inset -1px -1px 2px -2px rgba(var(--mono-rgb-100), 1),var(--shadow-xs);background-color:var(--raised-background)}body:is(.mod-macos,.adaptive-mode-off).is-mobile .checkbox-container:active:after{--toggle-border-width: -6px;--toggle-thumb-height: 40px;--toggle-thumb-width: 59px;--toggle-s-border-width: var(--toggle-border-width);--toggle-s-thumb-height: var(--toggle-thumb-height);--toggle-s-thumb-width: var(--toggle-thumb-width)}body:is(.mod-macos,.adaptive-mode-off).is-mobile{--dropdown-padding-start: var(--side-padding)}body:is(.mod-macos,.adaptive-mode-off) select:focus,body:is(.mod-macos,.adaptive-mode-off) .combobox-button:focus,body:is(.mod-macos,.adaptive-mode-off) .dropdown:focus{box-shadow:none}body:is(.mod-macos,.adaptive-mode-off) .search-input-container{display:flex;align-items:center;overflow:visible}body:is(.mod-macos,.adaptive-mode-off) .search-input-container:before{top:unset !important;inset-inline-start:calc((var(--input-height) - var(--icon-s))/2);height:var(--icon-s);width:var(--icon-s)}body:is(.mod-macos,.adaptive-mode-off) .search-input-container input{padding-inline-start:var(--input-height) !important}body:is(.mod-macos,.adaptive-mode-off) .mod-sidedock .search-input-container,body:is(.mod-macos,.adaptive-mode-off) .mod-sidedock input[type=search],body:is(.mod-macos,.adaptive-mode-off) .vertical-tab-header .search-input-container,body:is(.mod-macos,.adaptive-mode-off) .vertical-tab-header input[type=search],body:is(.mod-macos,.adaptive-mode-off) .community-modal-controls .search-input-container,body:is(.mod-macos,.adaptive-mode-off) .community-modal-controls input[type=search]{--input-height: 32px}body:is(.mod-macos,.adaptive-mode-off) .mod-sidedock .search-input-container input[type=search],body:is(.mod-macos,.adaptive-mode-off) .vertical-tab-header .search-input-container input[type=search],body:is(.mod-macos,.adaptive-mode-off) .community-modal-controls .search-input-container input[type=search]{border:none;border-radius:100vh;background-color:var(--background-modifier-hover)}body:is(.mod-macos,.adaptive-mode-off).is-mobile .search-input-container::before{inset-inline-start:12px}body:is(.mod-macos,.adaptive-mode-off) .workspace-ribbon.mod-left .sidebar-toggle-button .clickable-icon:hover,body:is(.mod-macos,.adaptive-mode-off) .workspace-ribbon.mod-left .side-dock-actions .side-dock-ribbon-action:hover{box-shadow:none !important;background-color:rgba(0,0,0,0) !important;color:var(--text-normal)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header-container-inner{-webkit-app-region:no-drag;gap:0px;transition:var(--anim-duration-moderate);border-radius:var(--clickable-icon-radius);padding:0;outline:2px solid rgba(0,0,0,0);background-clip:content-box;height:auto;z-index:1}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header-container-inner:hover{background-color:var(--background-modifier-hover);outline-color:var(--background-modifier-hover)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header-container-inner:hover .workspace-tab-header.is-active{background-color:var(--background-primary);box-shadow:var(--shadow-xs)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header-container-inner:hover .workspace-tab-header.is-active .workspace-tab-header-inner-icon{color:var(--text-normal) !important}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header{border-radius:var(--clickable-icon-radius)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header-inner{padding:8px}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header:not(.is-active):hover .workspace-tab-header-inner{background-color:var(--background-modifier-hover)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .sidebar-toggle-button,body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header-inner{border-radius:var(--clickable-icon-radius);width:var(--tab-action-width);height:fit-content;z-index:1}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header-status-container{margin-left:-8px}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header-status-icon,body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header-inner-close-button{--icon-size: 12px;color:var(--text-muted)}body:is(.mod-macos,.adaptive-mode-off):not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child .nav-buttons-container{border-radius:var(--clickable-icon-radius);background-color:var(--background-modifier-hover);padding:2px;gap:0}body:is(.mod-macos,.adaptive-mode-off):not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child .nav-buttons-container .nav-action-button{position:relative;padding:8px;border-radius:var(--clickable-icon-radius)}body:is(.mod-macos,.adaptive-mode-off):not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child .nav-buttons-container .nav-action-button:hover:not([aria-disabled=true]){background-color:var(--background-modifier-hover);box-shadow:none}body:is(.mod-macos,.adaptive-mode-off) .mod-sidedock .workspace-tab-container,body:is(.mod-macos,.adaptive-mode-off) .mod-sidedock .workspace-leaf,body:is(.mod-macos,.adaptive-mode-off) .mod-sidedock .workspace-leaf-content{contain:size !important;overflow:visible}body:is(.mod-macos,.adaptive-mode-off) .markdown-source-view,body:is(.mod-macos,.adaptive-mode-off) .markdown-preview-view{transition:transform var(--anim-duration-slow) var(--anim-motion-baseline)}body:is(.mod-macos,.adaptive-mode-off) .workspace-leaf-content[data-mode=source]>.view-content>.markdown-reading-view>.markdown-preview-view{transform:scale(0.995);opacity:0}body:is(.mod-macos,.adaptive-mode-off) .workspace-leaf-content[data-mode=preview]>.view-content>.markdown-source-view{transform:scale(0.995);opacity:0}body:is(.mod-macos,.adaptive-mode-off):not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown][data-mode=source] .view-header .view-actions button:nth-last-child(2){background-color:rgb(from var(--interactive-accent) r g b/95%);color:oklch(from var(--interactive-accent) 0.95 c h);box-shadow:var(--shadow-xs)}body:is(.mod-macos,.adaptive-mode-off):not(.tab-icon) .mod-sidedock .workspace-tabs:not(.mod-top) .workspace-tab-header-container:not(:hover) .workspace-tab-header-container-inner{gap:calc(8px*var(--density-modifier))}body:is(.mod-macos,.adaptive-mode-off){--background-modifier-message: var(--modal-background);--modal-background: rgb(from var(--background-secondary) r g b / 75%) !important}body:is(.mod-macos,.adaptive-mode-off).is-translucent{--modal-background: var(--background-primary) !important}body:is(.mod-macos,.adaptive-mode-off) .menu,body:is(.mod-macos,.adaptive-mode-off) .prompt,body:is(.mod-macos,.adaptive-mode-off) .modal:not(.mod-sidebar-layout){backdrop-filter:var(--blur-l);border:none;background-color:var(--modal-background)}body:is(.mod-macos,.adaptive-mode-off) .suggestion-container,body:is(.mod-macos,.adaptive-mode-off) .popover{backdrop-filter:var(--blur-m);border:none;background-color:var(--modal-background)}body:is(.mod-macos,.adaptive-mode-off) .cm-tooltip,body:is(.mod-macos,.adaptive-mode-off) .notice{backdrop-filter:var(--raised-blur);border:none;background-color:var(--modal-background)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .menu,body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .suggestion-container{animation:none}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .menu svg.svg-icon,body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .suggestion-container svg.svg-icon{transition:none}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .menu .menu-item,body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .menu .suggestion-item,body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .suggestion-container .menu-item,body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .suggestion-container .suggestion-item{padding:calc(4px*var(--density-modifier)) 12px}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .menu .suggestion-item,body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .suggestion-container .suggestion-item{min-height:32px}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .menu .menu-separator,body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .suggestion-container .menu-separator{margin:6px 8px}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .menu:hover .menu-item.selected:not(.is-label):not(.is-disabled),body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .suggestion-container:hover .menu-item.selected:not(.is-label):not(.is-disabled){background-color:var(--interactive-accent);color:var(--text-on-accent)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .menu:hover .menu-item.selected:not(.is-label):not(.is-disabled) .menu-item-icon,body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .suggestion-container:hover .menu-item.selected:not(.is-label):not(.is-disabled) .menu-item-icon{color:var(--text-on-accent)}body:is(.mod-macos,.adaptive-mode-off).is-mobile .menu .menu-scroll,body:is(.mod-macos,.adaptive-mode-off).is-mobile .suggestion-container .menu-scroll{background-color:rgba(0,0,0,0)}body:is(.mod-macos,.adaptive-mode-off).is-mobile .menu .menu-item,body:is(.mod-macos,.adaptive-mode-off).is-mobile .menu .suggestion-item,body:is(.mod-macos,.adaptive-mode-off).is-mobile .suggestion-container .menu-item,body:is(.mod-macos,.adaptive-mode-off).is-mobile .suggestion-container .suggestion-item{padding:calc(8px*var(--density-modifier)) var(--side-padding)}body:is(.mod-macos,.adaptive-mode-off).is-mobile .menu .menu-item:not([class*=is-]) .menu-item-icon,body:is(.mod-macos,.adaptive-mode-off).is-mobile .menu .suggestion-item:not([class*=is-]) .menu-item-icon,body:is(.mod-macos,.adaptive-mode-off).is-mobile .suggestion-container .menu-item:not([class*=is-]) .menu-item-icon,body:is(.mod-macos,.adaptive-mode-off).is-mobile .suggestion-container .suggestion-item:not([class*=is-]) .menu-item-icon{color:var(--text-normal)}body:is(.mod-macos,.adaptive-mode-off).is-mobile .menu .menu-item .menu-item-icon .svg-icon,body:is(.mod-macos,.adaptive-mode-off).is-mobile .menu .suggestion-item .menu-item-icon .svg-icon,body:is(.mod-macos,.adaptive-mode-off).is-mobile .suggestion-container .menu-item .menu-item-icon .svg-icon,body:is(.mod-macos,.adaptive-mode-off).is-mobile .suggestion-container .suggestion-item .menu-item-icon .svg-icon{--icon-size: var(--icon-m);--icon-stroke: var(--icon-m-stroke-width)}body:is(.mod-macos,.adaptive-mode-off).is-phone{--menu-shadow: var(--shadow-s);--menu-padding: 32px var(--safe-area-inset-side)}body:is(.mod-macos,.adaptive-mode-off).is-phone .menu{margin:8px;border-radius:var(--modal-radius) var(--modal-radius) calc(var(--safe-area-inset-top) - 8px) calc(var(--safe-area-inset-top) - 8px)}body:is(.mod-macos,.adaptive-mode-off).is-phone .menu .menu-item{min-height:48px;font-size:var(--font-ui-medium)}body:is(.mod-macos,.adaptive-mode-off).is-phone .menu .menu-item::after{content:none}body:is(.mod-macos,.adaptive-mode-off).is-phone .menu .menu-item:not(:last-child){border-bottom:none}body:is(.mod-macos,.adaptive-mode-off).is-phone .menu .menu-item:not(:last-child) .menu-item-title{position:relative;overflow:visible}body:is(.mod-macos,.adaptive-mode-off).is-phone .menu .menu-item:not(:last-child) .menu-item-title::after{position:absolute;inset:auto 0 -14px;background-color:rgba(var(--mono-rgb-100), 0.1);height:var(--border-width);content:""}body:is(.mod-macos,.adaptive-mode-off).is-phone .menu-group .menu-item.is-label+.menu-item:not(.is-label),body:is(.mod-macos,.adaptive-mode-off).is-phone .menu-group .menu-item:first-child{border-top-left-radius:var(--radius-m);border-top-right-radius:var(--radius-m)}body:is(.mod-macos,.adaptive-mode-off).is-phone .menu-group .menu-item:last-child{border-bottom-left-radius:var(--radius-m);border-bottom-right-radius:var(--radius-m)}body:is(.mod-macos,.adaptive-mode-off).is-phone .suggestion-container{border-radius:var(--radius-m)}body:is(.mod-macos,.adaptive-mode-off).is-tablet{--menu-shadow: var(--shadow-l)}body:is(.mod-macos,.adaptive-mode-off).is-tablet .menu .menu-separator,body:is(.mod-macos,.adaptive-mode-off).is-tablet .suggestion-container .menu-separator{margin:4px 16px}body:is(.mod-macos,.adaptive-mode-off).is-tablet .menu .menu-item,body:is(.mod-macos,.adaptive-mode-off).is-tablet .menu .suggestion-item,body:is(.mod-macos,.adaptive-mode-off).is-tablet .suggestion-container .menu-item,body:is(.mod-macos,.adaptive-mode-off).is-tablet .suggestion-container .suggestion-item{gap:16px;padding:calc(12px*var(--density-modifier)) var(--side-padding)}body:is(.mod-macos,.adaptive-mode-off).is-tablet .suggestion-container{border-radius:var(--radius-m)}@keyframes modalInCupertino{from{opacity:1;filter:none;transform:scale(0.99)}}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .modal{animation:modalInCupertino var(--anim-duration-moderate) var(--anim-motion-baseline) forwards}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .modal:not(.mod-sidebar-layout) .modal-title{width:100%}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .modal:not(.mod-sidebar-layout) .modal-button-container button{flex:1;margin:0;border-radius:100vh;min-height:32px}body:is(.mod-macos,.adaptive-mode-off).is-mobile .modal-setting-back-button,body:is(.mod-macos,.adaptive-mode-off).is-mobile .modal-close-button{--icon-size: var(--icon-xl);padding:6px}body:is(.mod-macos,.adaptive-mode-off).is-phone{--modal-radius: var(--radius-xl)}body:is(.mod-macos,.adaptive-mode-off).is-phone .modal-container.mod-confirmation .modal{border-radius:var(--radius-xl) var(--radius-xl) calc(var(--safe-area-inset-top) - 8px) calc(var(--safe-area-inset-top) - 8px)}body:is(.mod-macos,.adaptive-mode-off).is-phone .modal:not(.mod-sidebar-layout){--modal-radius: var(--radius-xl);margin:0 8px 8px;width:calc(100vw - 16px) !important;left:0 !important}body:is(.mod-macos,.adaptive-mode-off).is-phone .modal:not(.mod-sidebar-layout) .modal-close-button{top:16px !important;inset-inline-end:16px !important}body:is(.mod-macos,.adaptive-mode-off).is-phone .modal:not(.mod-sidebar-layout) .modal-content{padding:0 var(--safe-area-inset-side)}body:is(.mod-macos,.adaptive-mode-off).is-phone .modal:not(.mod-sidebar-layout) .modal-button-container{gap:8px;padding:16px var(--safe-area-inset-side) 0}body:is(.mod-macos,.adaptive-mode-off).is-phone .modal:not(.mod-sidebar-layout) .modal-button-container button{margin-top:0}body:is(.mod-macos,.adaptive-mode-off) .notice{box-shadow:var(--shadow-l);border-radius:var(--radius-m);padding:calc(16px*var(--density-modifier)) var(--side-padding);color:var(--text-muted)}body:is(.mod-macos,.adaptive-mode-off) .tooltip{--background-modifier-message: var(--background-primary);filter:drop-shadow(0 0 16px var(--background-modifier-box-shadow));animation:none;box-shadow:none;border-radius:var(--radius-l);padding:8px 16px;color:var(--text-muted);font-weight:var(--font-normal)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .notice{transition:var(--anim-duration-moderate) !important}body:is(.mod-macos,.adaptive-mode-off).is-mobile .notice{box-shadow:var(--shadow-xs)}body:is(.mod-macos,.adaptive-mode-off).is-mobile .notice:last-child{transition:var(--anim-duration-slow) var(--anim-motion-baseline) !important}@starting-style{body:is(.mod-macos,.adaptive-mode-off).is-mobile .notice:last-child{transform:translateY(-50%) scaleX(0.5) !important;filter:blur(4px);opacity:0}}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile){--drag-ghost-background: var(--background-primary);--drag-ghost-text-color: var(--text-normal)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .drag-ghost{box-shadow:var(--shadow-l);padding:8px 12px;border-radius:var(--radius-m)}body:is(.mod-macos,.adaptive-mode-off){--setting-nav-icon-background: var(--color-base-50)}body:is(.mod-macos,.adaptive-mode-off) .modal.mod-sidebar-layout.mod-settings .vertical-tab-nav-item .vertical-tab-nav-item-icon{--icon-size: var(--icon-xs);--icon-stroke: var(--icon-xs-stroke-width);box-shadow:inset .5px .5px .5px hsla(0,0%,100%,.25),inset -0.5px -0.5px .5px hsla(0,0%,100%,.25),0 0 2px rgba(0,0,0,.25),0 1px 4px rgba(0,0,0,.15);border-radius:6px;background-image:linear-gradient(oklch(from var(--setting-nav-icon-background) calc(l * 1.125) c h), oklch(from var(--setting-nav-icon-background) calc(l * 0.975) c h));background-color:var(--setting-nav-icon-background);padding:4px;color:var(--setting-nav-icon-color, white)}body:is(.mod-macos,.adaptive-mode-off) .modal.mod-sidebar-layout.mod-settings .vertical-tab-nav-item[data-setting-id=canvas] .vertical-tab-nav-item-icon{--setting-nav-icon-color: var(--color-red);--setting-nav-icon-background: var(--color-base-10)}body:is(.mod-macos,.adaptive-mode-off) .modal.mod-sidebar-layout.mod-settings .vertical-tab-nav-item[data-setting-id=command-palette] .vertical-tab-nav-item-icon{--setting-nav-icon-background: #242424}body:is(.mod-macos,.adaptive-mode-off) .modal.mod-sidebar-layout.mod-settings .vertical-tab-nav-item[data-setting-id=sync] .vertical-tab-nav-item-icon{--setting-nav-icon-color: var(--color-green);--setting-nav-icon-background: var(--color-base-10)}body:is(.mod-macos,.adaptive-mode-off) .modal.mod-sidebar-layout.mod-settings .vertical-tab-nav-item[data-setting-id=webviewer] .vertical-tab-nav-item-icon{--setting-nav-icon-color: var(--color-blue);--setting-nav-icon-background: var(--color-base-10)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile){--setting-items-padding: calc(12px * var(--density-modifier)) var(--side-padding);--setting-group-heading-color: var(--text-normal)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .modal.mod-sidebar-layout{background-color:var(--background-primary);border:none}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .modal.mod-settings .vertical-tab-nav-item.is-active{--text-normal: var(--text-on-accent);color:var(--text-on-accent);background-color:var(--interactive-accent)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .modal.mod-settings .vertical-tab-nav-item:not(.is-active):hover{background-color:rgba(0,0,0,0)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .modal.mod-settings .vertical-tab-header-group-title,body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .modal.mod-settings .vertical-tab-nav-item{padding:6px 8px}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .modal.mod-settings .setting-group-search+.setting-items{border-radius:var(--setting-items-radius)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .modal.mod-settings .setting-items .setting-item{padding:12px 0}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .modal.mod-settings .setting-items .setting-item:first-child{padding-top:0}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .modal.mod-settings .setting-items .setting-item:last-child{padding-bottom:0}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .modal.mod-settings .setting-item:not(.setting-item-heading,.setting-items .setting-item){padding:var(--setting-items-padding)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .modal.mod-settings .installed-plugins-container .extra-setting-button{min-width:unset}body:is(.mod-macos,.adaptive-mode-off).is-mobile .modal.mod-settings .vertical-tab-nav-item .vertical-tab-nav-item-icon{padding:5px;border-radius:8px;box-shadow:0 0 0 .5px var(--background-modifier-border);margin-left:-4px}body:is(.mod-macos,.adaptive-mode-off).is-phone{--setting-items-radius: var(--radius-m);--setting-group-heading-size: var(--font-ui-medium)}body:is(.mod-macos,.adaptive-mode-off).is-phone .modal.mod-sidebar-layout{--modal-radius: var(--radius-xl) var(--radius-xl) 0 0;max-height:calc(100% - var(--safe-area-inset-top))}body:is(.mod-macos,.adaptive-mode-off).is-phone .modal.mod-sidebar-layout .modal-setting-back-button{inset-inline-start:var(--safe-area-inset-side)}body:is(.mod-macos,.adaptive-mode-off).is-phone .modal.mod-sidebar-layout .modal-close-button{top:var(--safe-area-inset-side);inset-inline-end:var(--safe-area-inset-side) !important}body:is(.mod-macos,.adaptive-mode-off).is-phone .modal.mod-sidebar-layout .vertical-tab-header,body:is(.mod-macos,.adaptive-mode-off).is-phone .modal.mod-sidebar-layout .vertical-tab-content{padding-top:var(--modal-header-height)}body:is(.mod-macos,.adaptive-mode-off).is-phone .modal.mod-sidebar-layout .vertical-tab-nav-item{height:var(--touch-size-xl)}body:is(.mod-macos,.adaptive-mode-off).is-phone .modal.mod-settings{--modal-header-height: 76px}body:is(.mod-macos,.adaptive-mode-off).is-phone .modal.mod-settings .modal-title{margin-top:16px}body:is(.mod-macos,.adaptive-mode-off).is-phone .modal.mod-community-modal .modal-header{position:absolute}body:is(.mod-macos,.adaptive-mode-off).is-phone .modal.mod-community-modal .modal-title{height:calc(var(--touch-size-m) + 32px)}body:is(.mod-macos,.adaptive-mode-off).is-phone .modal.mod-community-modal .modal-content .modal-sidebar,body:is(.mod-macos,.adaptive-mode-off).is-phone .modal.mod-community-modal .modal-content .community-modal-info{padding-top:calc(var(--touch-size-m) + 32px);border-radius:var(--modal-radius)}body:is(.mod-macos,.adaptive-mode-off).is-tablet{--setting-items-padding: calc(16px * var(--density-modifier)) var(--side-padding)}body:is(.mod-macos,.adaptive-mode-off).is-tablet .modal.mod-settings .vertical-tab-header-group-title{display:none}body:is(.mod-macos,.adaptive-mode-off).is-tablet .modal.mod-settings .vertical-tab-nav-item{padding:calc(12px*var(--density-modifier)) var(--side-padding)}body:is(.mod-macos,.adaptive-mode-off).is-tablet .modal.mod-settings .vertical-tab-nav-item.is-active{color:var(--interactive-accent);background-color:var(--background-modifier-hover)}body:is(.mod-macos,.adaptive-mode-off) .prompt-input-container{align-items:center}body:is(.mod-macos,.adaptive-mode-off) .prompt-input-container::before,body:is(.mod-macos,.adaptive-mode-off) .omnisearch-input-field::before{position:absolute;left:var(--side-padding);-webkit-mask-position:50% 50%;-webkit-mask-size:100% 100%;-webkit-mask-repeat:no-repeat;background-color:var(--search-icon-color);width:var(--search-icon-size);height:var(--search-icon-size);content:"";-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cg clip-path='url(%23a)'%3e%3cpath fill='white' d='M0 7.793c0 4.297 3.496 7.793 7.793 7.793 1.7 0 3.252-.547 4.531-1.465l4.805 4.815c.224.224.517.332.83.332.664 0 1.123-.498 1.123-1.153a1.118 1.118 0 0 0-.322-.8l-4.776-4.805a7.703 7.703 0 0 0 1.602-4.717C15.586 3.496 12.09 0 7.793 0 3.496 0 0 3.496 0 7.793Zm1.67 0A6.127 6.127 0 0 1 7.793 1.67a6.127 6.127 0 0 1 6.123 6.123 6.127 6.127 0 0 1-6.123 6.123A6.127 6.127 0 0 1 1.67 7.793Z'/%3e%3c/g%3e%3cdefs%3e%3cclipPath id='a'%3e%3cpath fill='white' d='M0 0h20v20H0z'/%3e%3c/clipPath%3e%3c/defs%3e%3c/svg%3e");z-index:1}body:is(.mod-macos,.adaptive-mode-off) .prompt-input{border-bottom:none;padding-inline-start:calc(var(--search-icon-size) + var(--side-padding) + 12px) !important}body:is(.mod-macos,.adaptive-mode-off) .prompt .suggestion-item{border-radius:var(--radius-m);padding:calc(12px*var(--density-modifier)) var(--side-padding)}body:is(.mod-macos,.adaptive-mode-off) .prompt-instructions{border-top:none}body:is(.mod-macos,.adaptive-mode-off):not(.is-phone){--prompt-input-height: 56px}@keyframes bounceInScale{from{transform:scale(1.15);opacity:0}50%{transform:scale(0.99)}}body:is(.mod-macos,.adaptive-mode-off):not(.is-phone) .prompt{animation:var(--anim-duration-moderate) bounceInScale var(--anim-motion-baseline) forwards;border-radius:var(--radius-xl)}body:is(.mod-macos,.adaptive-mode-off):not(.is-phone) .prompt-input-container::after{content:"";position:absolute;inset:auto var(--side-padding) 0;height:var(--border-width);background-color:var(--background-modifier-border);pointer-events:none}body:is(.mod-macos,.adaptive-mode-off).is-phone{--prompt-input-height: 48px}body:is(.mod-macos,.adaptive-mode-off).is-phone .prompt{--prompt-top: 0;border-radius:0;height:100vh;padding-bottom:0}body:is(.mod-macos,.adaptive-mode-off).is-phone .prompt .prompt-input-container{width:calc(100% - var(--safe-area-inset-side)*2)}body:is(.mod-macos,.adaptive-mode-off).is-phone .prompt .prompt-input-container,body:is(.mod-macos,.adaptive-mode-off).is-phone .prompt .suggester-input{border:none;gap:8px;position:absolute;inset:auto var(--safe-area-inset-side) calc(var(--safe-area-inset-side) + var(--safe-area-inset-bottom));z-index:1;background-color:rgba(0,0,0,0);box-shadow:none;backdrop-filter:none;margin:0}body:is(.mod-macos,.adaptive-mode-off).is-phone .prompt .prompt-input{border-radius:100vh}body:is(.mod-macos,.adaptive-mode-off).is-phone .prompt .prompt-input-container .prompt-input-cta:not(:empty),body:is(.mod-macos,.adaptive-mode-off).is-phone .prompt .prompt-input-container .search-input-clear-button{border-radius:100vh;position:relative;inset-inline-end:0;width:var(--prompt-input-height);height:var(--prompt-input-height);flex-shrink:0;margin:0}body:is(.mod-macos,.adaptive-mode-off).is-phone .prompt .prompt-input-container .search-input-clear-button:after{-webkit-mask-position:50% 50%;-webkit-mask-size:100% 100%;-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3e%3cpath fill='black' d='M13.993.26.253 14a.875.875 0 0 0 0 1.23.896.896 0 0 0 1.24 0l13.74-13.74a.875.875 0 0 0 0-1.23.87.87 0 0 0-1.24 0ZM15.233 14 1.493.26a.87.87 0 0 0-1.24 0 .884.884 0 0 0 0 1.23l13.74 13.74c.332.333.908.342 1.24 0a.884.884 0 0 0 0-1.23Z'/%3e%3c/svg%3e")}body:is(.mod-macos,.adaptive-mode-off).is-phone .prompt .prompt-results{mask:linear-gradient(to bottom, transparent, black calc(var(--safe-area-inset-top) + 16px), black calc(100vh - var(--side-padding) - var(--safe-area-inset-bottom) - 96px), transparent calc(100vh - var(--side-padding) - var(--safe-area-inset-bottom)));padding:calc(var(--safe-area-inset-top) + 16px) var(--side-padding) 128px}body:is(.mod-macos,.adaptive-mode-off).is-phone .prompt .suggestion-item{padding:var(--nav-item-padding)}body:is(.mod-macos,.adaptive-mode-off).is-phone .prompt{transition:var(--anim-duration-moderate) !important;transform:none !important;overflow:visible;box-shadow:none}@starting-style{body:is(.mod-macos,.adaptive-mode-off).is-phone .prompt{opacity:0}}body:is(.mod-macos,.adaptive-mode-off).is-phone .prompt-results{transition:var(--anim-duration-slow) var(--anim-motion-baseline)}@starting-style{body:is(.mod-macos,.adaptive-mode-off).is-phone .prompt-results{transform:translateY(var(--safe-area-inset-top))}}body:is(.mod-macos,.adaptive-mode-off).is-phone .prompt[style*="transform: translateY"]{opacity:0}body:is(.mod-macos,.adaptive-mode-off).is-tablet .prompt{border-radius:var(--radius-l)}body:is(.mod-macos,.adaptive-mode-off).is-mobile:where(.is-phone):not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2),body:is(.mod-macos,.adaptive-mode-off).is-mobile:where(.is-phone) .prompt-input,body:is(.mod-macos,.adaptive-mode-off).is-mobile:where(.is-phone) .prompt-input-container .prompt-input-cta:not(:empty),body:is(.mod-macos,.adaptive-mode-off).is-mobile:where(.is-phone) .prompt-input-container .search-input-clear-button,body:is(.mod-macos,.adaptive-mode-off).is-mobile:where(.is-phone) .workspace-drawer-header-icon,body:is(.mod-macos,.adaptive-mode-off).is-mobile .mobile-tab-switcher-menu-button,body:is(.mod-macos,.adaptive-mode-off).is-mobile .mobile-tab-switcher-menu-spacer .clickable-icon,body:is(.mod-macos,.adaptive-mode-off).is-mobile .modal-setting-back-button,body:is(.mod-macos,.adaptive-mode-off).is-mobile .modal-close-button,body:is(.mod-macos,.adaptive-mode-off).is-mobile .pull-action{backdrop-filter:var(--raised-blur);box-shadow:var(--shadow-xs);border:none;background-color:var(--raised-background);color:var(--text-normal);transition:var(--anim-duration-moderate)}@starting-style{body:is(.mod-macos,.adaptive-mode-off).is-mobile:where(.is-phone):not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2),body:is(.mod-macos,.adaptive-mode-off).is-mobile:where(.is-phone) .prompt-input,body:is(.mod-macos,.adaptive-mode-off).is-mobile:where(.is-phone) .prompt-input-container .prompt-input-cta:not(:empty),body:is(.mod-macos,.adaptive-mode-off).is-mobile:where(.is-phone) .prompt-input-container .search-input-clear-button,body:is(.mod-macos,.adaptive-mode-off).is-mobile:where(.is-phone) .workspace-drawer-header-icon,body:is(.mod-macos,.adaptive-mode-off).is-mobile .mobile-tab-switcher-menu-button,body:is(.mod-macos,.adaptive-mode-off).is-mobile .mobile-tab-switcher-menu-spacer .clickable-icon,body:is(.mod-macos,.adaptive-mode-off).is-mobile .modal-setting-back-button,body:is(.mod-macos,.adaptive-mode-off).is-mobile .modal-close-button,body:is(.mod-macos,.adaptive-mode-off).is-mobile .pull-action{opacity:0;filter:blur(4px);transform:scale(0.75)}}body:is(.mod-macos,.adaptive-mode-off).is-mobile .workspace-leaf-content:not([data-type=empty]) .mod-left-split-toggle svg.svg-icon{--icon-size: var(--icon-l);background-color:currentColor;content:"";-webkit-mask-position:25% 50%;-webkit-mask-size:80% 80%;-webkit-mask-repeat:no-repeat;-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='21' fill='none' viewBox='0 0 12 21'%3e%3cpath fill='white' d='M0 10.372c0 .397.141.732.459 1.046l9.137 8.934c.256.266.575.395.953.395a1.35 1.35 0 0 0 1.372-1.354c0-.382-.163-.718-.422-.983l-8.24-8.04 8.24-8.036c.261-.266.422-.61.422-.98A1.349 1.349 0 0 0 10.549 0c-.38 0-.697.129-.953.385L.459 9.327A1.397 1.397 0 0 0 0 10.372Z'/%3e%3c/svg%3e")}body:is(.mod-macos,.adaptive-mode-off).is-mobile .workspace-drawer .nav-buttons-container{justify-self:center;gap:0;backdrop-filter:blur(4px);border-radius:100vh;background-color:var(--background-modifier-hover);padding-inline:8px;width:fit-content;margin-bottom:8px}body:is(.mod-macos,.adaptive-mode-off).is-mobile:not(.is-floating-nav) .workspace-drawer .nav-buttons-container{margin-bottom:0}body:is(.mod-macos,.adaptive-mode-off).is-mobile.theme-dark .mod-raised::after{content:none !important}body:is(.mod-macos,.adaptive-mode-off).is-mobile.mod-macos.theme-light .mod-raised::after,body:is(.mod-macos,.adaptive-mode-off).is-mobile.mod-macos.theme-light.is-phone:not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2)::after,body:is(.mod-macos,.adaptive-mode-off).is-mobile.mod-macos.theme-light.is-phone .prompt-input-container::after,body:is(.mod-macos,.adaptive-mode-off).is-mobile.mod-macos.theme-light.is-phone .prompt-input-container .prompt-input-cta:not(:empty)::before,body:is(.mod-macos,.adaptive-mode-off).is-mobile.mod-macos.theme-light.is-phone .prompt-input-container .search-input-clear-button::before,body:is(.mod-macos,.adaptive-mode-off).is-mobile.mod-macos.theme-light.is-tablet .menu::after,body:is(.mod-macos,.adaptive-mode-off).is-mobile.mod-macos.theme-light.is-tablet .workspace-drawer:not(.is-pinned)::after,body:is(.mod-macos,.adaptive-mode-off).is-mobile.mod-macos.theme-light .mobile-tab-switcher-menu-button::after,body:is(.mod-macos,.adaptive-mode-off).is-mobile.mod-macos.theme-light .mobile-tab-switcher-menu-spacer .clickable-icon::before,body:is(.mod-macos,.adaptive-mode-off).is-mobile.mod-macos.theme-light .modal-setting-back-button::after,body:is(.mod-macos,.adaptive-mode-off).is-mobile.mod-macos.theme-light .modal-close-button::after,body:is(.mod-macos,.adaptive-mode-off).is-mobile.mod-macos.theme-light .notice::after{position:absolute;z-index:1;backdrop-filter:brightness(var(--blur-brightness));mask:var(--raised-mask);mask-composite:var(--raised-mask-composite);filter:blur(1px);inset:0;border:var(--raised-mask-border-width) solid rgba(0,0,0,0);border-radius:inherit;background:var(--raised-mask-background);pointer-events:none;content:""}body:is(.mod-macos,.adaptive-mode-off).is-mobile.mod-macos.theme-light.is-phone .prompt-input-container::after{height:auto;border-radius:100vh;margin-right:56px}body:is(.mod-macos,.adaptive-mode-off).is-mobile .bases-cards-item{padding:var(--side-padding)}body:is(.mod-macos,.adaptive-mode-off).is-mobile .bases-cards-line,body:is(.mod-macos,.adaptive-mode-off).is-mobile .bases-cards-label{padding:0}body:is(.mod-macos,.adaptive-mode-off).is-mobile .nav-files-container>div{--nav-item-color: var(--text-normal)}body:is(.mod-macos,.adaptive-mode-off).is-phone .mod-root .view-header-left,body:is(.mod-macos,.adaptive-mode-off).is-phone .mod-root .view-actions{flex:0;position:relative}body:is(.mod-macos,.adaptive-mode-off).is-phone .mod-root .view-header{padding-inline:var(--safe-area-inset-side)}body:is(.mod-macos,.adaptive-mode-off).is-phone .mod-root .view-header-title-parent{font-size:var(--font-ui-smaller);opacity:1}body:is(.mod-macos,.adaptive-mode-off).is-phone .mod-root .view-header-title{font-weight:var(--font-medium);opacity:1;height:1lh}body:is(.mod-macos,.adaptive-mode-off).is-phone .mod-root .view-header-breadcrumb{padding:0}body:is(.mod-macos,.adaptive-mode-off).is-phone .mod-root .view-header-breadcrumb-separator{padding:0 4px}body:is(.mod-macos,.adaptive-mode-off).is-phone .mod-root .view-header-breadcrumb-separator:last-child{display:none}body:is(.mod-macos,.adaptive-mode-off).is-phone.theme-light .nav-files-container>div{background-color:var(--background-primary)}body:is(.mod-macos,.adaptive-mode-off).is-phone.theme-dark .nav-files-container>div{background-color:var(--background-secondary)}body:is(.mod-macos,.adaptive-mode-off).is-phone .nav-files-container>div{--nav-item-size: var(--font-ui-medium);--nav-item-color: var(--text-normal);--nav-item-color-hover: var(--text-normal);--nav-item-color-active: var(--text-normal);--nav-item-background-hover: transparent;--nav-item-background-active: var(--background-modifier-hover);--nav-item-weight-hover: var(--font-normal);--nav-item-weight-active: var(--font-normal);border-radius:var(--radius-m)}body:is(.mod-macos,.adaptive-mode-off).is-phone .nav-files-container>div .tree-item{position:relative}body:is(.mod-macos,.adaptive-mode-off).is-phone .nav-files-container>div .tree-item .tree-item-self{padding-inline-end:var(--side-padding);margin-bottom:0;border-radius:0}body:is(.mod-macos,.adaptive-mode-off).is-phone .nav-files-container>div .tree-item .tree-item-self .tree-item-icon{position:relative;order:1;margin-inline-start:unset}body:is(.mod-macos,.adaptive-mode-off).is-phone .nav-files-container>div .tree-item .tree-item-inner{flex:1}body:is(.mod-macos,.adaptive-mode-off).is-phone .nav-files-container>div .tree-item-self.has-active-menu,body:is(.mod-macos,.adaptive-mode-off).is-phone .nav-files-container>div .tree-item-self.is-being-renamed{box-shadow:none;color:var(--text-accent)}body:is(.mod-macos,.adaptive-mode-off).is-phone .nav-files-container>div .tree-item:has(>.tree-item-self.is-active)::before,body:is(.mod-macos,.adaptive-mode-off).is-phone .nav-files-container>div .tree-item:has(>.tree-item-self.is-active)+.tree-item::before{content:none !important}body:is(.mod-macos,.adaptive-mode-off).is-phone .nav-files-container>div .tree-item:not(.nav-files-container>div>div:nth-child(2)):not(:last-child:only-child):before{position:absolute;inset:calc(-1*var(--border-width)/2) var(--side-padding) auto;background:var(--background-modifier-border);height:var(--border-width);content:""}body:is(.mod-macos,.adaptive-mode-off).is-phone .nav-files-container>div .tree-item-self.is-active::before{content:none}body:is(.mod-macos,.adaptive-mode-off).is-phone .mobile-navbar{border:none !important;background-color:var(--raised-background) !important}body:is(.mod-macos,.adaptive-mode-off).is-phone{--tab-switcher-background: transparent;--tab-switcher-preview-background-shadow: 0 4px 16px rgba(0, 0, 0, 0.2)}body:is(.mod-macos,.adaptive-mode-off).is-phone .mobile-tab-switcher{background:linear-gradient(rgba(var(--mono-rgb-0), 0.5), var(--mobile-sidebar-background)) !important;backdrop-filter:var(--blur-l)}body:is(.mod-macos,.adaptive-mode-off).is-phone .mobile-tab-switcher-menubar{padding:0 var(--navbar-side-offset) var(--navbar-bottom-offset)}body:is(.mod-macos,.adaptive-mode-off).is-phone .mobile-tab-switcher-menu-button{flex:1;height:var(--input-height);border-radius:var(--clickable-icon-radius);justify-content:center}body:is(.mod-macos,.adaptive-mode-off).is-phone .mobile-tab-switcher-menu-spacer .clickable-icon{position:relative}body:is(.mod-macos,.adaptive-mode-off).is-phone .mobile-tab-switcher-menu-spacer:first-child .clickable-icon{width:var(--input-height);height:var(--input-height)}body:is(.mod-macos,.adaptive-mode-off).is-phone .mobile-tab-switcher-menu-spacer:last-child .clickable-icon{padding:var(--input-padding);height:var(--input-height);backdrop-filter:none}body:is(.mod-macos,.adaptive-mode-off).is-phone .mobile-tab .mobile-tab-pin,body:is(.mod-macos,.adaptive-mode-off).is-phone .mobile-tab .close-button{width:32px;height:32px}body.mod-windows:not(.adaptive-mode-off){--font-interface-theme: "Segoe UI Variable Display", "Segoe UI Variable";--font-text-theme: "Segoe UI Variable Text", "Segoe UI Variable";--h1-size: 1.75rem;--h2-size: 1.5rem;--h3-size: 1.25rem;--radius-s: calc(4px * var(--radius-modifier));--radius-m: calc(4px * var(--radius-modifier));--radius-l: calc(8px * var(--radius-modifier));--radius-xl: calc(8px * var(--radius-modifier));--input-radius: var(--radius-m);--button-radius: var(--input-radius);--clickable-icon-radius: var(--radius-m);--checkbox-radius: var(--radius-m);--tab-radius: var(--radius-l);--toggle-thumb-height: 12px;--toggle-thumb-width: 12px;--toggle-width: 40px;--toggle-border-width: 4px;--slider-thumb-border-width: 4px;--slider-thumb-width: 18px;--slider-thumb-height: 18px;--slider-track-background: var(--color-base-50);--slider-track-height: 4px;--blur-s: blur(8px) saturate(0.75);--blur-m: blur(16px) saturate(0.75);--blur-l: blur(32px) saturate(0.75)}body.mod-windows:not(.adaptive-mode-off).is-mobile{--input-border-width: var(--border-width);--slider-thumb-width: 24px;--slider-thumb-height: 24px}body.mod-windows:not(.adaptive-mode-off).theme-light{--input-shadow: 0px 0px 0px var(--input-border-width) rgba(0, 0, 0, 0.05), 0 -0.5px 0 0 rgba(0, 0, 0, 0.25) inset !important;--input-shadow-hover: var(--input-shadow) !important;--input-shadow-active: inset 0 0 0 1px var(--background-modifier-border);--slider-thumb-border-color: var(--color-base-00);--shadow-s: 0px 1px 2px rgba(0, 0, 0, 0.028), 0px 3.4px 6.7px rgba(0, 0, 0, 0.042), 0px 15px 30px rgba(0, 0, 0, 0.07);--shadow-l: 0px 32px 64px 0px rgba(0, 0, 0, 0.19), 0px 2px 21px 0px rgba(0, 0, 0, 0.15);--modal-background: rgb(from white r g b / 85%);--setting-items-background: var(--background-primary)}body.mod-windows:not(.adaptive-mode-off).theme-dark{--input-shadow: 0px 0px 0px var(--input-border-width) rgba(0, 0, 0, 0.1), 0 0.5px 0 rgba(255, 255, 255, 0.1) inset !important;--input-shadow-hover: var(--input-shadow) !important;--input-shadow-active: inset 0 0 1px var(--background-modifier-border);--slider-thumb-border-color: var(--color-base-35);--shadow-s: 0px 1px 2px rgba(0, 0, 0, 0.028), 0px 3.4px 6.7px rgba(0, 0, 0, 0.042), 0px 15px 30px rgba(0, 0, 0, 0.07);--shadow-l: 0px 32px 64px 0px rgba(0, 0, 0, 0.37), 0px 2px 21px 0px rgba(0, 0, 0, 0.37);--modal-background: rgb(from var(--color-base-20) r g b / 65%);--setting-items-background: var(--background-secondary)}body.mod-windows:not(.adaptive-mode-off).is-translucent{--modal-background: var(--background-secondary)}body.mod-windows:not(.adaptive-mode-off) button:active,body.mod-windows:not(.adaptive-mode-off) select:focus,body.mod-windows:not(.adaptive-mode-off) .combobox-button:focus,body.mod-windows:not(.adaptive-mode-off) .dropdown:focus{opacity:.75;box-shadow:var(--input-shadow-active)}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .clickable-icon.is-active{color:var(--icon-color-focused);background-color:var(--background-primary)}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .clickable-icon:not([aria-disabled=true],.modal-close-button):hover,body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .clickable-icon.has-active-menu{background-color:var(--background-modifier-hover)}body.mod-windows:not(.adaptive-mode-off) input:is([type=text],[type=search],[type=email],[type=password],[type=number]):not(.prompt-input){box-shadow:0 -0.5px 0 var(--color-base-50) inset}body.mod-windows:not(.adaptive-mode-off) input:is([type=text],[type=search],[type=email],[type=password],[type=number]):not(.prompt-input):active,body.mod-windows:not(.adaptive-mode-off) input:is([type=text],[type=search],[type=email],[type=password],[type=number]):not(.prompt-input):focus,body.mod-windows:not(.adaptive-mode-off) input:is([type=text],[type=search],[type=email],[type=password],[type=number]):not(.prompt-input):focus-visible{box-shadow:0 -2px 0 var(--interactive-accent) inset;border-color:var(--background-modifier-border)}body.mod-windows:not(.adaptive-mode-off) input[type=range]::-webkit-slider-thumb{-webkit-transition:var(--anim-duration-fast);transition:var(--anim-duration-fast);box-shadow:0 .5px 1px 1px rgba(0,0,0,.1);background-color:var(--interactive-accent)}body.mod-windows:not(.adaptive-mode-off) input[type=range]::-webkit-slider-thumb:hover,body.mod-windows:not(.adaptive-mode-off) input[type=range]::-webkit-slider-thumb:active{--slider-thumb-border-width: 3px;border-color:var(--slider-thumb-border-color)}body.mod-windows:not(.adaptive-mode-off) .checkbox-container:not(.is-enabled){--toggle-thumb-color: var(--text-muted);outline:1px solid var(--text-faint);background-color:var(--color-base-10)}body.mod-windows:not(.adaptive-mode-off) .checkbox-container:hover{--toggle-thumb-height: 16px;--toggle-thumb-width: 16px;--toggle-border-width: 2px}body.mod-windows:not(.adaptive-mode-off) .menu,body.mod-windows:not(.adaptive-mode-off) .suggestion-container,body.mod-windows:not(.adaptive-mode-off) .popover,body.mod-windows:not(.adaptive-mode-off) .prompt,body.mod-windows:not(.adaptive-mode-off) .modal,body.mod-windows:not(.adaptive-mode-off) .cm-tooltip,body.mod-windows:not(.adaptive-mode-off) .notice{background-color:var(--modal-background) !important;backdrop-filter:var(--blur-l);border:none}body.mod-windows:not(.adaptive-mode-off) .modal.mod-settings{--setting-items-padding: 0px}body.mod-windows:not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-header-group-title,body.mod-windows:not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-nav-item{padding:calc(8px*var(--density-modifier)) 16px;position:relative;border-radius:var(--setting-items-radius)}body.mod-windows:not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-nav-item.is-active{background-color:var(--background-modifier-hover);color:var(--text-normal)}body.mod-windows:not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-nav-item.is-active::before{position:absolute;top:8px;bottom:8px;left:0;border-radius:var(--button-radius);background-color:var(--interactive-accent);width:4px;content:"";margin-left:unset;height:unset}body.mod-windows:not(.adaptive-mode-off) .modal.mod-settings .setting-items{background-color:rgba(0,0,0,0);padding-block:0}body.mod-windows:not(.adaptive-mode-off) .modal.mod-settings .setting-item:not(.setting-item-heading){border:var(--border-width) solid rgba(0,0,0,.1);border-radius:var(--radius-m);padding:calc(16px*var(--density-modifier));background-color:var(--setting-items-background)}body.mod-windows:not(.adaptive-mode-off) .modal.mod-settings .setting-item:not(.setting-item-heading):not(:first-child){margin-top:4px}body.mod-windows:not(.adaptive-mode-off) .notice{color:var(--text-muted)}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile){--menu-padding: 4px;--prompt-input-height: 64px;--tab-outline-color: rgba(var(--mono-rgb-100), 0.05)}@keyframes workspaceLeafInFluent{from{transform:translateY(16px);opacity:0}}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-leaf{animation:workspaceLeafInFluent var(--anim-duration-moderate)}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile):not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child .nav-buttons-container{padding:0}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile):not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child .nav-buttons-container .nav-action-button{flex:1;padding:12px}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile):not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child .nav-buttons-container .nav-action-button.is-active{background-color:var(--interactive-normal);color:var(--icon-color);box-shadow:inset 0 0 0 1px var(--background-modifier-hover)}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile):not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child .nav-buttons-container .nav-action-button.is-active::after{position:absolute;bottom:0;border-radius:var(--button-radius);background-color:var(--interactive-accent);width:24px;height:3px;content:""}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal-bg{background-color:#000;opacity:.3 !important}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .menu,body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .suggestion-container{animation:none;border-radius:var(--radius-l);border:var(--border-width) solid var(--background-modifier-border)}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .menu .menu-separator,body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .suggestion-container .menu-separator{margin:var(--menu-padding) calc(-1*var(--menu-padding))}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .menu .menu-item,body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .menu .suggestion-item,body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .suggestion-container .menu-item,body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .suggestion-container .suggestion-item{border-radius:var(--radius-m);padding:8px}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .menu .menu-item-icon .svg-icon,body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .suggestion-container .menu-item-icon .svg-icon{--icon-size: var(--icon-s);--icon-stroke: var(--icon-s-stroke-width)}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .prompt{animation:none}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .prompt .prompt-results{position:relative}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .prompt .prompt-results .suggestion-item{position:relative;padding:calc(12px*var(--density-modifier)) 20px}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .prompt .prompt-results .suggestion-item.is-selected::after{position:absolute;top:12px;bottom:12px;left:0;border-radius:var(--button-radius);background-color:var(--interactive-accent);width:4px;content:""}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal{animation:none}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal-close-button{top:0;inset-inline-end:0 !important;padding-inline:16px;border-radius:0}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal-close-button:empty::before{margin:0;width:var(--icon-s);height:var(--icon-s);font-size:var(--icon-xs);font-weight:100}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal-close-button:hover{background-color:var(--color-red);color:#fff}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal:not(.mod-sidebar-layout){padding:0;min-width:480px}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal:not(.mod-sidebar-layout) .modal-title{padding:24px 24px 4px;font-size:var(--font-ui-large)}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal:not(.mod-sidebar-layout) .modal-content{padding:4px 24px 16px}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal:not(.mod-sidebar-layout) .modal-button-container{margin:0;border-top:var(--border-width) solid var(--background-modifier-border);background-color:rgba(0,0,0,.05);padding:24px}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal:not(.mod-sidebar-layout) .modal-button-container button{border-radius:var(--button-radius)}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal:not(.mod-sidebar-layout) .modal-content>.modal-button-container{margin:0 -24px -16px}body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal.mod-sidebar-layout .vertical-tab-content{animation:workspaceLeafInFluent var(--anim-duration-moderate)}body.mod-windows:not(.adaptive-mode-off).is-phone .mobile-navbar,body.mod-windows:not(.adaptive-mode-off).is-phone:not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2){backdrop-filter:var(--blur-l);box-shadow:var(--shadow-s);border-radius:var(--radius-l);background-color:var(--modal-background) !important}body.mod-windows:not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-header-group-items{background-color:rgba(0,0,0,0)}body.mod-windows:not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-nav-item-chevron,body.mod-windows:not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-nav-item-title{border-bottom:none}body.mod-windows:not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-content{background-color:var(--settings-background)}@font-face{font-family:"Google Sans System";font-style:normal;font-weight:1 1000;src:local("GoogleSansFlex-Regular"),local("Google Sans Flex")}@font-face{font-family:"Google Sans System";font-style:italic;font-weight:1 1000;src:local("GoogleSans-Italic"),local("Google Sans Italic")}body.is-android:not(.adaptive-mode-off){--font-interface-theme: "Google Sans System", "Google Sans Flex", "Google Sans";--font-text-theme: "Google Sans System", "Google Sans Flex", "Google Sans";--h1-size: 2.25rem;--h1-weight: 400;--h2-size: 1.75rem;--h2-weight: 400;--h3-size: 1.375rem;--h3-weight: 400;--h4-weight: 500;--h5-weight: 500;--h6-weight: 500;--input-font-weight: var(--font-medium);--input-border-width: 1px;--input-height: 40px;--radius-xs: calc(4px * var(--radius-modifier));--radius-s: calc(8px * var(--radius-modifier));--radius-m: calc(12px * var(--radius-modifier));--radius-l: calc(16px * var(--radius-modifier));--radius-xl: calc(28px * var(--radius-modifier));--input-radius: var(--radius-s);--button-radius: 100vh;--clickable-icon-radius: 100vh;--tab-radius: var(--radius-m);--toggle-border-width: 4px;--toggle-thumb-height: 24px;--toggle-thumb-width: 24px;--toggle-width: 52px;--toggle-s-border-width: var(--toggle-border-width);--toggle-s-thumb-height: var(--toggle-thumb-height);--toggle-s-thumb-width: var(--toggle-thumb-width);--toggle-s-width: var(--toggle-width);--slider-thumb-border-width: 0;--slider-thumb-height: 44px;--slider-thumb-width: 4px;--slider-thumb-y: -19px;--slider-thumb-radius: 100vh;--slider-track-height: 16px;--tab-font-weight: var(--font-medium);--nav-item-weight: var(--font-medium);--nav-item-weight-hover: var(--font-medium);--nav-item-weight-active: var(--font-medium);--nav-item-radius: 100vh;--background-modifier-border: var(--color-base-30);--background-modifier-form-field: var(--background-modifier-hover);--interactive-hover: var(--color-base-25);--interactive-normal: var(--background-primary);--dropdown-background: var(--background-modifier-form-field);--dropdown-background-hover: var(--background-modifier-form-field);--menu-radius: var(--radius-l);--shadow-s: rgba(0, 0, 0, 0.2) 0px 3px 3px -2px, rgba(0, 0, 0, 0.14) 0px 3px 4px 0px, rgba(0, 0, 0, 0.12) 0px 1px 8px 0px !important;--shadow-l: rgba(0, 0, 0, 0.2) 0px 3px 5px -1px, rgba(0, 0, 0, 0.14) 0px 6px 10px 0px, rgba(0, 0, 0, 0.12) 0px 1px 18px 0px !important}body.is-android:not(.adaptive-mode-off).theme-light{--setting-items-background: var(--background-primary)}body.is-android:not(.adaptive-mode-off).theme-dark{--setting-items-background: var(--background-secondary)}body.is-android:not(.adaptive-mode-off) button:not([aria-disabled=true]),body.is-android:not(.adaptive-mode-off) .clickable-icon:not([aria-disabled=true]),body.is-android:not(.adaptive-mode-off) .tappable,body.is-android:not(.adaptive-mode-off) .is-clickable{cursor:pointer}body.is-android:not(.adaptive-mode-off) textarea,body.is-android:not(.adaptive-mode-off) input:is([type=text],[type=search],[type=email],[type=password],[type=number]):not(.prompt-input),body.is-android:not(.adaptive-mode-off) select,body.is-android:not(.adaptive-mode-off) .combobox-button,body.is-android:not(.adaptive-mode-off) .dropdown{transition:var(--anim-duration-fast);box-shadow:inset 0 0 var(--interactive-accent);border-width:0 0 var(--border-width);border-style:solid;border-color:var(--background-modifier-border-focus);border-bottom-right-radius:0;border-bottom-left-radius:0}body.is-android:not(.adaptive-mode-off) textarea:focus,body.is-android:not(.adaptive-mode-off) input:is([type=text],[type=search],[type=email],[type=password],[type=number]):not(.prompt-input):focus,body.is-android:not(.adaptive-mode-off) select:focus,body.is-android:not(.adaptive-mode-off) .combobox-button:focus,body.is-android:not(.adaptive-mode-off) .dropdown:focus{box-shadow:inset 0 -2px var(--interactive-accent);border-color:rgba(0,0,0,0);border-bottom-right-radius:0;border-bottom-left-radius:0}body.is-android:not(.adaptive-mode-off) input[type=range]::-webkit-slider-thumb{outline:6px solid var(--setting-items-background);background-color:var(--interactive-accent)}body.is-android:not(.adaptive-mode-off) input[type=range]:active{--slider-thumb-y: -23px;--slider-thumb-height: 52px}body.is-android:not(.adaptive-mode-off) .checkbox-container{cursor:pointer}body.is-android:not(.adaptive-mode-off) .checkbox-container:not(.is-enabled){--toggle-thumb-color: var(--text-muted);box-shadow:inset 0 0 0 2px var(--text-muted)}body.is-android:not(.adaptive-mode-off) .checkbox-container:not(.is-enabled):not(:hover,:active){--toggle-s-border-width: 8px;--toggle-s-thumb-height: 16px;--toggle-s-thumb-width: 16px;--toggle-border-width: 8px;--toggle-thumb-height: 16px;--toggle-thumb-width: 16px}body.is-android:not(.adaptive-mode-off) .menu,body.is-android:not(.adaptive-mode-off) .suggestion-container,body.is-android:not(.adaptive-mode-off) .popover,body.is-android:not(.adaptive-mode-off) .prompt,body.is-android:not(.adaptive-mode-off) .modal,body.is-android:not(.adaptive-mode-off) .cm-tooltip{border:none}body.is-android:not(.adaptive-mode-off) .menu .menu-item-icon .svg-icon,body.is-android:not(.adaptive-mode-off) .suggestion-container .menu-item-icon .svg-icon{--icon-size: var(--icon-m);--icon-stroke: var(--icon-m-stroke-width)}body.is-android:not(.adaptive-mode-off){--setting-items-radius: var(--radius-l)}body.is-android:not(.adaptive-mode-off).theme-light .modal.mod-sidebar-layout{background-color:var(--background-secondary)}body.is-android:not(.adaptive-mode-off).theme-dark .modal.mod-sidebar-layout{background-color:var(--background-primary)}body.is-android:not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-header-group-title{display:none}body.is-android:not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-header-group-items{gap:0}body.is-android:not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-nav-item{border-radius:var(--button-radius);padding:calc(12px*var(--density-modifier)) 16px;width:fit-content;font-weight:var(--font-medium);border-bottom:0;cursor:pointer;align-items:center}body.is-android:not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-nav-item.is-active{background-color:var(--setting-items-background)}body.is-android:not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-nav-item .vertical-tab-nav-item-icon{--icon-size: 20px;--setting-nav-icon-background: var(--color-base-50);padding:10px;border-radius:var(--clickable-icon-radius);color:hsl(from var(--setting-nav-icon-background) h calc(s * 1.05) calc(l * 0.35));background-color:hsl(from var(--setting-nav-icon-background) h calc(s * 0.9) calc(l * 1.15));margin-top:-4px;margin-left:-8px;margin-bottom:-4px}body.is-android:not(.adaptive-mode-off) .modal.mod-settings .setting-items{padding:0;background-color:rgba(0,0,0,0)}body.is-android:not(.adaptive-mode-off) .modal.mod-settings .setting-item:not(.setting-item-heading){border-top:none;border-radius:var(--radius-xs);background-color:var(--setting-items-background);padding:var(--setting-items-padding);margin-bottom:2px}body.is-android:not(.adaptive-mode-off) .modal.mod-settings .setting-item:nth-child(1 of .setting-item:not(.setting-item-heading)),body.is-android:not(.adaptive-mode-off) .modal.mod-settings .setting-item-heading+.setting-item{border-top-left-radius:var(--setting-items-radius);border-top-right-radius:var(--setting-items-radius)}body.is-android:not(.adaptive-mode-off) .modal.mod-settings .setting-item:nth-last-child(1 of .setting-item:not(.setting-item-heading)),body.is-android:not(.adaptive-mode-off) .modal.mod-settings .setting-item:has(+.setting-item-heading){border-bottom-left-radius:var(--setting-items-radius);border-bottom-right-radius:var(--setting-items-radius)}body.is-android:not(.adaptive-mode-off) .modal.mod-settings .setting-item-name{font-weight:var(--font-medium)}body.is-android:not(.adaptive-mode-off) .modal.mod-settings .setting-item-description{font-size:var(--font-ui-small)}body.is-android:not(.adaptive-mode-off).is-mobile .modal.mod-settings .setting-group .setting-item:not(:last-child):not(.setting-item-heading){margin-bottom:2px}body.is-android:not(.adaptive-mode-off).is-mobile .modal.mod-settings .setting-item-control button:not(.clickable-icon){width:fit-content;padding:16px}@keyframes menuInMaterial{from{opacity:0;transform:translateY(-4px) scaleY(95%)}}body.is-android:not(.adaptive-mode-off):not(.is-phone) .menu,body.is-android:not(.adaptive-mode-off):not(.is-phone) .suggestion-container{transform-origin:top center;animation:menuInMaterial var(--anim-duration-fast) forwards}body.is-android:not(.adaptive-mode-off):not(.is-phone) .menu .menu-item,body.is-android:not(.adaptive-mode-off):not(.is-phone) .menu .suggestion-item,body.is-android:not(.adaptive-mode-off):not(.is-phone) .suggestion-container .menu-item,body.is-android:not(.adaptive-mode-off):not(.is-phone) .suggestion-container .suggestion-item{padding:calc(8px*var(--density-modifier)) 12px;font-weight:var(--font-medium);cursor:pointer;gap:12px}body.is-android:not(.adaptive-mode-off):not(.is-phone) .prompt{border-radius:var(--radius-l)}body.is-android:not(.adaptive-mode-off):not(.is-phone) .prompt .prompt-input-container{margin:16px 16px 0}body.is-android:not(.adaptive-mode-off):not(.is-phone) .prompt .prompt-input{border:none;border-radius:100vh;background-color:var(--interactive-normal);font-size:var(--font-ui-large)}body.is-android:not(.adaptive-mode-off):not(.is-phone) .prompt .prompt-results{padding:16px}body.is-android:not(.adaptive-mode-off):not(.is-phone) .prompt .suggestion-item{border-radius:100vh}body.is-android:not(.adaptive-mode-off).is-phone .mobile-navbar,body.is-android:not(.adaptive-mode-off).is-phone:not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2){border:none !important;box-shadow:var(--shadow-s)}body.is-android:not(.adaptive-mode-off).is-phone.is-floating-nav .mod-root .workspace-leaf-content[data-type=markdown]>.view-content::before,body.is-android:not(.adaptive-mode-off).is-phone.is-floating-nav .mod-root .workspace-leaf-content[data-type=markdown]>.view-content::after{content:none}body.is-android:not(.adaptive-mode-off).is-phone .menu .menu-item:not(.is-label){border-radius:var(--radius-xs)}body.is-android:not(.adaptive-mode-off).is-phone .menu .menu-item.is-label+.menu-item:not(.is-label),body.is-android:not(.adaptive-mode-off).is-phone .menu .menu-item:first-child{border-top-left-radius:var(--setting-items-radius);border-top-right-radius:var(--setting-items-radius)}body.is-android:not(.adaptive-mode-off).is-phone .menu .menu-item:last-child{border-bottom-left-radius:var(--setting-items-radius);border-bottom-right-radius:var(--setting-items-radius)}body.is-android:not(.adaptive-mode-off).is-phone .menu .menu-item:not(:last-child){margin-bottom:2px}body.is-android:not(.adaptive-mode-off).is-phone .menu .menu-item::after{content:none}body.is-android:not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-header-group-items{gap:2px;background-color:rgba(0,0,0,0)}body.is-android:not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-nav-item{width:100%;border-radius:var(--radius-xs);padding:calc(16px*var(--density-modifier)) 20px;height:auto;background-color:var(--setting-items-background)}body.is-android:not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-nav-item-title,body.is-android:not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-nav-item-chevron{border-bottom:none}body.is-android:not(.adaptive-mode-off).is-phone .prompt .prompt-input{box-shadow:none;border:none;border-radius:100vh}body.is-android:not(.adaptive-mode-off).is-phone .prompt .prompt-input-container{margin:auto var(--safe-area-inset-side) var(--safe-area-inset-side)}body.is-android:not(.adaptive-mode-off).is-phone .prompt .suggestion-item{border-radius:100vh}body.mod-linux:not(.is-android):not(.adaptive-mode-off){--font-interface-theme: "Adwaita Sans", "Adwaita Sans Text";--font-text-theme: "Adwaita Sans", "Adwaita Sans Text";--shadow-s: 0 0 0 1px rgba(0, 0, 6, 3%), 0 1px 3px 1px rgba(0, 0, 6, 7%), 0 2px 6px 2px rgba(0, 0, 6, 3%);--shadow-l: 0 0 14px 5px rgba(0, 0, 0, 15%), 0 0 5px 2px rgba(0, 0, 0, 10%), 0 0 0 1px rgba(0, 0, 0, 5%);--input-border-width: 0;--input-shadow: none;--input-shadow-hover: none;--input-font-weight: calc(var(--font-weight) + var(--bold-modifier));--radius-s: calc(9px * var(--radius-modifier));--radius-m: calc(12px * var(--radius-modifier));--radius-l: calc(15px * var(--radius-modifier));--radius-xl: calc(18px * var(--radius-modifier));--button-radius: var(--radius-s)}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.dynamic-type-off){--font-ui-smaller: calc(var(--font-ui-medium) * 0.82 + var(--font-ui-modifier));--font-ui-small: calc(11px + var(--font-ui-modifier));--font-ui-medium: calc(11px + var(--font-ui-modifier));--font-ui-large: calc(var(--font-ui-medium) * 1.36 + var(--font-ui-modifier));--icon-m: calc(18px * var(--radius-modifier));--icon-l: calc(18px * var(--radius-modifier))}body.mod-linux:not(.is-android):not(.adaptive-mode-off) button:where(:not(.clickable-icon,.ant-switch,.workspace-leaf-content:not([data-type=markdown]) button,.copy-code-button)){padding:5px 17px}body.mod-linux:not(.is-android):not(.adaptive-mode-off){--toggle-border-width: 3px;--toggle-thumb-height: 20px;--toggle-thumb-width: 20px;--toggle-thumb-color: color-mix(in srgb, white 80%, var(--background-primary));--toggle-width: 46px;--toggle-s-border-width: var(--toggle-border-width);--toggle-s-thumb-height: var(--toggle-thumb-height);--toggle-s-thumb-width: var(--toggle-thumb-width);--toggle-s-width: var(--toggle-width);--slider-thumb-border-width: 0;--slider-thumb-y: -8px;--slider-thumb-height: var(--toggle-thumb-height);--slider-thumb-width: var(--toggle-thumb-width);--slider-thumb-radius: var(--toggle-thumb-radius);--slider-track-height: 4px;--slider-track-background: rgb(from var(--text-normal) r g b / 15%);--slider-track-background-hover: rgb(from var(--text-normal) r g b / 20%);--slider-track-background-active: rgb(from var(--text-normal) r g b / 25%)}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .checkbox-container::after{box-shadow:0 2px 4px rgba(0,0,6,.2)}body.mod-linux:not(.is-android):not(.adaptive-mode-off) input[type=range]::-webkit-slider-thumb{box-shadow:0 0 0 1px rgba(0,0,6,.1),0 2px 4px rgba(0,0,6,.2) !important;background-color:var(--toggle-thumb-color);-webkit-transition:none;transition:none}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .checkbox-container:not(.is-enabled){background-color:var(--slider-track-background)}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .checkbox-container:not(.is-enabled):hover,body.mod-linux:not(.is-android):not(.adaptive-mode-off) input[type=range]:hover{background-color:var(--slider-track-background-hover)}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .checkbox-container:not(.is-enabled):active,body.mod-linux:not(.is-android):not(.adaptive-mode-off) input[type=range]:active{background-color:var(--slider-track-background-active)}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .checkbox-container.is-enabled::after,body.mod-linux:not(.is-android):not(.adaptive-mode-off) .checkbox-container:hover::after,body.mod-linux:not(.is-android):not(.adaptive-mode-off) input[type=range]:hover::-webkit-slider-thumb,body.mod-linux:not(.is-android):not(.adaptive-mode-off) .checkbox-container:active::after,body.mod-linux:not(.is-android):not(.adaptive-mode-off) input[type=range]:active::-webkit-slider-thumb{opacity:1;background-color:#fff}body.mod-linux:not(.is-android):not(.adaptive-mode-off){--dropdown-padding-end: 2.4em}body.mod-linux:not(.is-android):not(.adaptive-mode-off) select,body.mod-linux:not(.is-android):not(.adaptive-mode-off) .dropdown{background-color:rgba(0,0,0,0);field-sizing:content;font-weight:var(--font-normal)}body.mod-linux:not(.is-android):not(.adaptive-mode-off) select:focus-visible,body.mod-linux:not(.is-android):not(.adaptive-mode-off) .dropdown:focus-visible{box-shadow:none}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .dropdown{background-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3e%3cpath stroke='black' stroke-linecap='round' stroke-linejoin='round' stroke-width='4' d='m4 8 8 8 8-8'/%3e%3c/svg%3e")}body.mod-linux:not(.is-android):not(.adaptive-mode-off).theme-dark .dropdown{background-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3e%3cpath stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='4' d='m4 8 8 8 8-8'/%3e%3c/svg%3e")}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .menu,body.mod-linux:not(.is-android):not(.adaptive-mode-off) .suggestion-container,body.mod-linux:not(.is-android):not(.adaptive-mode-off) .popover,body.mod-linux:not(.is-android):not(.adaptive-mode-off) .prompt,body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal,body.mod-linux:not(.is-android):not(.adaptive-mode-off) .cm-tooltip{border:none}body.mod-linux:not(.is-android):not(.adaptive-mode-off){--modal-background: var(--background-primary);--setting-group-heading-color: var(--text-normal);--setting-group-heading-size: var(--font-ui-medium);--setting-group-heading-weight: calc(var(--font-weight) + var(--bold-modifier));--setting-items-padding: 0px;--setting-items-shadow: 0 0 0 1px rgba(0, 0, 6, 3%), 0 1px 3px 1px rgba(0, 0, 6, 7%), 0 2px 6px 2px rgba(0, 0, 6, 3%)}body.mod-linux:not(.is-android):not(.adaptive-mode-off).theme-light{--divider-color-alt: rgba(0, 0, 6, 7%)}body.mod-linux:not(.is-android):not(.adaptive-mode-off).theme-dark{--divider-color-alt: rgba(0, 0, 6, 36%)}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-header{background-color:var(--background-secondary);border-right:var(--border-width) solid var(--divider-color-alt);padding:6px}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-header-group{padding-block:6px}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-header-group:first-child{padding-top:0px}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-header-group:not(:last-child){border-bottom:var(--border-width) solid rgb(from var(--text-normal) r g b/15%)}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-header-group-title{display:none}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-nav-item{padding:calc(12px*var(--density-modifier)) 14px}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-nav-item-icon{color:var(--text-normal);margin-inline-end:12px}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .setting-group .setting-items,body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings div:not(.setting-items,.hotkey-list-container,.style-settings-container)>.setting-item:not(.setting-item-heading),body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .installed-plugins-container .setting-item:not(.setting-item-heading){box-shadow:var(--setting-items-shadow)}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .setting-item-heading{padding-left:0}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .setting-item:not(.setting-item-heading){border-color:var(--divider-color-alt);padding:calc(12px*var(--density-modifier)) 14px}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .setting-item-description{color:var(--text-faint)}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .setting-group-search+.setting-items{border-radius:var(--setting-items-radius)}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .setting-items .mobile-option-setting-item{padding-inline:16px}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .installed-plugins-container .setting-items{box-shadow:none !important;background-color:rgba(0,0,0,0)}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-community-modal .community-item{box-shadow:var(--setting-items-shadow);border:none}body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-community-modal .modal-setting-nav-bar{padding:4px}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile){--frame-right-space: 124px}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .titlebar-button-container.mod-right{align-items:center;justify-content:space-evenly}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .titlebar-button-container.mod-right .titlebar-button{width:fit-content;height:fit-content;background-color:rgb(from var(--text-normal) r g b/10%);border-radius:100vh !important;padding:4px;flex:0}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .titlebar-button-container.mod-right .titlebar-button svg{height:16px}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .titlebar-button-container.mod-right .titlebar-button:hover{background-color:rgb(from var(--text-normal) r g b/15%)}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .titlebar-button.mod-minimize svg{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3e%3cpath fill='%232E3436' d='M4 10.008h8v1.988H4v-1.988Z'/%3e%3c/svg%3e")}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .titlebar-button.mod-maximize svg{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3e%3cpath fill='%232E3436' d='M3.988 3.992v8.012H12V3.992H3.988Zm2 2H10v4.012H5.988V5.992Z'/%3e%3c/svg%3e")}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .titlebar-button.mod-close svg{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3e%3cpath fill='%232E3436' d='M4 4h1.031c.254.012.512.129.688.313L8 6.592l2.313-2.28c.265-.231.445-.305.687-.313h1v1c0 .285-.035.55-.25.75L9.469 8.031l2.25 2.25c.187.188.281.453.281.719v1h-1c-.266 0-.531-.094-.719-.281L8 9.438l-2.281 2.28A1.016 1.016 0 0 1 5 12H4v-1c0-.266.094-.531.281-.719l2.282-2.25L4.28 5.75A.904.904 0 0 1 4 5V4Z'/%3e%3c/svg%3e")}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile).is-maximized .titlebar-button.mod-maximize svg{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3e%3cpath fill='%232E3434' d='M4.988 4.992v6.012H11V4.992H4.988Zm2 2H9v2.012H6.988V6.992Z'/%3e%3c/svg%3e")}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile){--menu-padding: 6px}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .menu,body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .suggestion-container{animation:none}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .menu .menu-item,body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .menu .suggestion-item,body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .suggestion-container .menu-item,body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .suggestion-container .suggestion-item{padding:calc(8px*var(--density-modifier)) 12px}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .menu .menu-separator,body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .suggestion-container .menu-separator{border-bottom-color:rgb(from var(--text-normal) r g b/15%)}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .prompt{border-radius:var(--radius-xl)}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .modal .modal-close-button{--icon-stroke: 4px;color:var(--text-normal);width:24px;height:24px;padding:4px;background-color:rgb(from var(--text-normal) r g b/10%)}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .modal .modal-close-button path,body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .modal .modal-close-button rect,body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .modal .modal-close-button circle{visibility:hidden}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .modal .modal-close-button svg{background-color:currentcolor;margin:0;-webkit-mask-size:100% 100%;-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3e%3cpath fill='%232E3436' d='M4 4h1.031c.254.012.512.129.688.313L8 6.592l2.313-2.28c.265-.231.445-.305.687-.313h1v1c0 .285-.035.55-.25.75L9.469 8.031l2.25 2.25c.187.188.281.453.281.719v1h-1c-.266 0-.531-.094-.719-.281L8 9.438l-2.281 2.28A1.016 1.016 0 0 1 5 12H4v-1c0-.266.094-.531.281-.719l2.282-2.25L4.28 5.75A.904.904 0 0 1 4 5V4Z'/%3e%3c/svg%3e")}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .modal .modal-close-button:hover{background-color:rgb(from var(--text-normal) r g b/15%)}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-phone) .prompt .prompt-input{box-shadow:none;border:none;font-size:var(--font-ui-large);font-weight:calc(var(--font-weight) + var(--bold-modifier))}body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-phone) .prompt .prompt-results{padding:8px;margin-inline:8px;border-radius:var(--radius-l);background:var(--background-secondary-alt)}body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-mobile{--dropdown-padding-start: 0}body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone{--mobile-sidebar-background: var(--modal-background)}body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .mobile-navbar,body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone:not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2){border:none !important}body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .mod-root .workspace-leaf-content[data-type=markdown]>.view-content::before,body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .mod-root .workspace-leaf-content[data-type=markdown]>.view-content::after{content:none}body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .menu,body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .suggestion-container{--interactive-normal: transparent;background-color:var(--menu-background)}body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .menu .menu-group .menu-item:not(.is-label):after,body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .suggestion-container .menu-group .menu-item:not(.is-label):after{content:none}body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .menu .menu-item,body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .suggestion-container .menu-item{padding:calc(12px*var(--density-modifier)) 14px}body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .menu .menu-separator,body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .suggestion-container .menu-separator{margin:calc(12px*var(--density-modifier)) 0;border-bottom:var(--border-width) solid var(--background-modifier-border)}body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone{--prompt-background: var(--modal-background);--settings-background: var(--modal-background)}body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-header{background-color:var(--settings-background);padding-inline:16px}body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-header-group{padding-inline:0}body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-header-group-items{background-color:rgba(0,0,0,0)}body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-nav-item{border-radius:var(--radius-s)}body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-nav-item-title,body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-nav-item-chevron{border-bottom:none}body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .modal.mod-settings .setting-item{gap:calc(12px*var(--density-modifier))}body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .modal.mod-settings .setting-item-heading{padding-left:8px}body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .modal.mod-settings .setting-item:not(.setting-item-heading){padding:calc(16px*var(--density-modifier)) 16px}input[type=checkbox]:checked{border:none}input[type=checkbox]:checked::after,.checklist-plugin-main .checked:after{top:0;inset-inline-start:0;-webkit-mask-position:50% 50%;-webkit-mask-size:100% 100%}input[type=checkbox][data-indeterminate=true]:not(:checked){--checkbox-color: var(--checkbox-border-color) !important;background-color:var(--checkbox-color)}input[type=checkbox][data-indeterminate=true]:not(:checked):after{top:0;inset-inline-start:0;-webkit-mask-position:50% 50%;-webkit-mask-size:100% 100%;background-color:var(--checkbox-marker-color);width:var(--checkbox-size);height:var(--checkbox-size)}li[data-task][data-task=">"],li[data-task][data-task=">"] input[type=checkbox]:checked,li[data-task][data-task="<"],li[data-task][data-task="<"] input[type=checkbox]:checked,li[data-task][data-task="*"],li[data-task][data-task="*"] input[type=checkbox]:checked,li[data-task][data-task='"'],li[data-task][data-task='"'] input[type=checkbox]:checked,li[data-task][data-task=“],li[data-task][data-task=“] input[type=checkbox]:checked,li[data-task][data-task=l],li[data-task][data-task=l] input[type=checkbox]:checked,li[data-task][data-task=b],li[data-task][data-task=b] input[type=checkbox]:checked,li[data-task][data-task=S],li[data-task][data-task=S] input[type=checkbox]:checked,li[data-task][data-task=I],li[data-task][data-task=I] input[type=checkbox]:checked,li[data-task][data-task=p],li[data-task][data-task=p] input[type=checkbox]:checked,li[data-task][data-task=c],li[data-task][data-task=c] input[type=checkbox]:checked,li[data-task][data-task=f],li[data-task][data-task=f] input[type=checkbox]:checked,li[data-task][data-task=k],li[data-task][data-task=k] input[type=checkbox]:checked,li[data-task][data-task=w],li[data-task][data-task=w] input[type=checkbox]:checked,li[data-task][data-task=u],li[data-task][data-task=u] input[type=checkbox]:checked,li[data-task][data-task=d],li[data-task][data-task=d] input[type=checkbox]:checked,li[data-task][data-task=B],li[data-task][data-task=B] input[type=checkbox]:checked,li[data-task][data-task=a],li[data-task][data-task=a] input[type=checkbox]:checked,li[data-task][data-task=n],li[data-task][data-task=n] input[type=checkbox]:checked,li[data-task][data-task=R],li[data-task][data-task=R] input[type=checkbox]:checked,li[data-task][data-task=t],li[data-task][data-task=t] input[type=checkbox]:checked,li[data-task][data-task=P],li[data-task][data-task=P] input[type=checkbox]:checked,li[data-task][data-task=L],li[data-task][data-task=L] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task=">"],input[type=checkbox][data-task]:checked[data-task=">"] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task="<"],input[type=checkbox][data-task]:checked[data-task="<"] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task="*"],input[type=checkbox][data-task]:checked[data-task="*"] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task='"'],input[type=checkbox][data-task]:checked[data-task='"'] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task=“],input[type=checkbox][data-task]:checked[data-task=“] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task=l],input[type=checkbox][data-task]:checked[data-task=l] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task=b],input[type=checkbox][data-task]:checked[data-task=b] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task=S],input[type=checkbox][data-task]:checked[data-task=S] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task=I],input[type=checkbox][data-task]:checked[data-task=I] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task=p],input[type=checkbox][data-task]:checked[data-task=p] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task=c],input[type=checkbox][data-task]:checked[data-task=c] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task=f],input[type=checkbox][data-task]:checked[data-task=f] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task=k],input[type=checkbox][data-task]:checked[data-task=k] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task=w],input[type=checkbox][data-task]:checked[data-task=w] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task=u],input[type=checkbox][data-task]:checked[data-task=u] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task=d],input[type=checkbox][data-task]:checked[data-task=d] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task=B],input[type=checkbox][data-task]:checked[data-task=B] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task=a],input[type=checkbox][data-task]:checked[data-task=a] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task=n],input[type=checkbox][data-task]:checked[data-task=n] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task=R],input[type=checkbox][data-task]:checked[data-task=R] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task=t],input[type=checkbox][data-task]:checked[data-task=t] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task=P],input[type=checkbox][data-task]:checked[data-task=P] input[type=checkbox]:checked,input[type=checkbox][data-task]:checked[data-task=L],input[type=checkbox][data-task]:checked[data-task=L] input[type=checkbox]:checked{--checkbox-color: transparent}li[data-task][data-task=">"]:hover,li[data-task][data-task=">"] input[type=checkbox]:checked:hover,li[data-task][data-task="<"]:hover,li[data-task][data-task="<"] input[type=checkbox]:checked:hover,li[data-task][data-task="*"]:hover,li[data-task][data-task="*"] input[type=checkbox]:checked:hover,li[data-task][data-task='"']:hover,li[data-task][data-task='"'] input[type=checkbox]:checked:hover,li[data-task][data-task=“]:hover,li[data-task][data-task=“] input[type=checkbox]:checked:hover,li[data-task][data-task=l]:hover,li[data-task][data-task=l] input[type=checkbox]:checked:hover,li[data-task][data-task=b]:hover,li[data-task][data-task=b] input[type=checkbox]:checked:hover,li[data-task][data-task=S]:hover,li[data-task][data-task=S] input[type=checkbox]:checked:hover,li[data-task][data-task=I]:hover,li[data-task][data-task=I] input[type=checkbox]:checked:hover,li[data-task][data-task=p]:hover,li[data-task][data-task=p] input[type=checkbox]:checked:hover,li[data-task][data-task=c]:hover,li[data-task][data-task=c] input[type=checkbox]:checked:hover,li[data-task][data-task=f]:hover,li[data-task][data-task=f] input[type=checkbox]:checked:hover,li[data-task][data-task=k]:hover,li[data-task][data-task=k] input[type=checkbox]:checked:hover,li[data-task][data-task=w]:hover,li[data-task][data-task=w] input[type=checkbox]:checked:hover,li[data-task][data-task=u]:hover,li[data-task][data-task=u] input[type=checkbox]:checked:hover,li[data-task][data-task=d]:hover,li[data-task][data-task=d] input[type=checkbox]:checked:hover,li[data-task][data-task=B]:hover,li[data-task][data-task=B] input[type=checkbox]:checked:hover,li[data-task][data-task=a]:hover,li[data-task][data-task=a] input[type=checkbox]:checked:hover,li[data-task][data-task=n]:hover,li[data-task][data-task=n] input[type=checkbox]:checked:hover,li[data-task][data-task=R]:hover,li[data-task][data-task=R] input[type=checkbox]:checked:hover,li[data-task][data-task=t]:hover,li[data-task][data-task=t] input[type=checkbox]:checked:hover,li[data-task][data-task=P]:hover,li[data-task][data-task=P] input[type=checkbox]:checked:hover,li[data-task][data-task=L]:hover,li[data-task][data-task=L] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task=">"]:hover,input[type=checkbox][data-task]:checked[data-task=">"] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task="<"]:hover,input[type=checkbox][data-task]:checked[data-task="<"] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task="*"]:hover,input[type=checkbox][data-task]:checked[data-task="*"] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task='"']:hover,input[type=checkbox][data-task]:checked[data-task='"'] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task=“]:hover,input[type=checkbox][data-task]:checked[data-task=“] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task=l]:hover,input[type=checkbox][data-task]:checked[data-task=l] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task=b]:hover,input[type=checkbox][data-task]:checked[data-task=b] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task=S]:hover,input[type=checkbox][data-task]:checked[data-task=S] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task=I]:hover,input[type=checkbox][data-task]:checked[data-task=I] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task=p]:hover,input[type=checkbox][data-task]:checked[data-task=p] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task=c]:hover,input[type=checkbox][data-task]:checked[data-task=c] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task=f]:hover,input[type=checkbox][data-task]:checked[data-task=f] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task=k]:hover,input[type=checkbox][data-task]:checked[data-task=k] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task=w]:hover,input[type=checkbox][data-task]:checked[data-task=w] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task=u]:hover,input[type=checkbox][data-task]:checked[data-task=u] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task=d]:hover,input[type=checkbox][data-task]:checked[data-task=d] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task=B]:hover,input[type=checkbox][data-task]:checked[data-task=B] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task=a]:hover,input[type=checkbox][data-task]:checked[data-task=a] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task=n]:hover,input[type=checkbox][data-task]:checked[data-task=n] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task=R]:hover,input[type=checkbox][data-task]:checked[data-task=R] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task=t]:hover,input[type=checkbox][data-task]:checked[data-task=t] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task=P]:hover,input[type=checkbox][data-task]:checked[data-task=P] input[type=checkbox]:checked:hover,input[type=checkbox][data-task]:checked[data-task=L]:hover,input[type=checkbox][data-task]:checked[data-task=L] input[type=checkbox]:checked:hover{background-color:rgba(0,0,0,0)}li[data-task][data-task=">"]:hover::after,li[data-task][data-task=">"] input[type=checkbox]:checked:hover::after,li[data-task][data-task="<"]:hover::after,li[data-task][data-task="<"] input[type=checkbox]:checked:hover::after,li[data-task][data-task="*"]:hover::after,li[data-task][data-task="*"] input[type=checkbox]:checked:hover::after,li[data-task][data-task='"']:hover::after,li[data-task][data-task='"'] input[type=checkbox]:checked:hover::after,li[data-task][data-task=“]:hover::after,li[data-task][data-task=“] input[type=checkbox]:checked:hover::after,li[data-task][data-task=l]:hover::after,li[data-task][data-task=l] input[type=checkbox]:checked:hover::after,li[data-task][data-task=b]:hover::after,li[data-task][data-task=b] input[type=checkbox]:checked:hover::after,li[data-task][data-task=S]:hover::after,li[data-task][data-task=S] input[type=checkbox]:checked:hover::after,li[data-task][data-task=I]:hover::after,li[data-task][data-task=I] input[type=checkbox]:checked:hover::after,li[data-task][data-task=p]:hover::after,li[data-task][data-task=p] input[type=checkbox]:checked:hover::after,li[data-task][data-task=c]:hover::after,li[data-task][data-task=c] input[type=checkbox]:checked:hover::after,li[data-task][data-task=f]:hover::after,li[data-task][data-task=f] input[type=checkbox]:checked:hover::after,li[data-task][data-task=k]:hover::after,li[data-task][data-task=k] input[type=checkbox]:checked:hover::after,li[data-task][data-task=w]:hover::after,li[data-task][data-task=w] input[type=checkbox]:checked:hover::after,li[data-task][data-task=u]:hover::after,li[data-task][data-task=u] input[type=checkbox]:checked:hover::after,li[data-task][data-task=d]:hover::after,li[data-task][data-task=d] input[type=checkbox]:checked:hover::after,li[data-task][data-task=B]:hover::after,li[data-task][data-task=B] input[type=checkbox]:checked:hover::after,li[data-task][data-task=a]:hover::after,li[data-task][data-task=a] input[type=checkbox]:checked:hover::after,li[data-task][data-task=n]:hover::after,li[data-task][data-task=n] input[type=checkbox]:checked:hover::after,li[data-task][data-task=R]:hover::after,li[data-task][data-task=R] input[type=checkbox]:checked:hover::after,li[data-task][data-task=t]:hover::after,li[data-task][data-task=t] input[type=checkbox]:checked:hover::after,li[data-task][data-task=P]:hover::after,li[data-task][data-task=P] input[type=checkbox]:checked:hover::after,li[data-task][data-task=L]:hover::after,li[data-task][data-task=L] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task=">"]:hover::after,input[type=checkbox][data-task]:checked[data-task=">"] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task="<"]:hover::after,input[type=checkbox][data-task]:checked[data-task="<"] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task="*"]:hover::after,input[type=checkbox][data-task]:checked[data-task="*"] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task='"']:hover::after,input[type=checkbox][data-task]:checked[data-task='"'] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task=“]:hover::after,input[type=checkbox][data-task]:checked[data-task=“] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task=l]:hover::after,input[type=checkbox][data-task]:checked[data-task=l] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task=b]:hover::after,input[type=checkbox][data-task]:checked[data-task=b] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task=S]:hover::after,input[type=checkbox][data-task]:checked[data-task=S] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task=I]:hover::after,input[type=checkbox][data-task]:checked[data-task=I] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task=p]:hover::after,input[type=checkbox][data-task]:checked[data-task=p] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task=c]:hover::after,input[type=checkbox][data-task]:checked[data-task=c] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task=f]:hover::after,input[type=checkbox][data-task]:checked[data-task=f] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task=k]:hover::after,input[type=checkbox][data-task]:checked[data-task=k] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task=w]:hover::after,input[type=checkbox][data-task]:checked[data-task=w] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task=u]:hover::after,input[type=checkbox][data-task]:checked[data-task=u] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task=d]:hover::after,input[type=checkbox][data-task]:checked[data-task=d] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task=B]:hover::after,input[type=checkbox][data-task]:checked[data-task=B] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task=a]:hover::after,input[type=checkbox][data-task]:checked[data-task=a] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task=n]:hover::after,input[type=checkbox][data-task]:checked[data-task=n] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task=R]:hover::after,input[type=checkbox][data-task]:checked[data-task=R] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task=t]:hover::after,input[type=checkbox][data-task]:checked[data-task=t] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task=P]:hover::after,input[type=checkbox][data-task]:checked[data-task=P] input[type=checkbox]:checked:hover::after,input[type=checkbox][data-task]:checked[data-task=L]:hover::after,input[type=checkbox][data-task]:checked[data-task=L] input[type=checkbox]:checked:hover::after{background-color:var(--checkbox-color-hover)}input[data-task="/"]:checked,li[data-task="/"]>input:checked,li[data-task="/"]>p>input:checked{border:1px solid var(--interactive-accent);background:linear-gradient(to right, var(--interactive-accent) 50%, transparent 50%)}input[data-task="/"]:checked::after,li[data-task="/"]>input:checked::after,li[data-task="/"]>p>input:checked::after{display:none}.task-list-item:not([data-task]) input[type=checkbox],.checked:after,div:checked::after,input[type=checkbox]:checked::after,.tasks-modal-checkbox:checked::after{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cpath fill='black' d='m12.998 6.084-4.17 6.7-1.982-2.56c-.244-.322-.46-.41-.742-.41a.788.788 0 0 0-.782.801c0 .225.088.44.235.635l2.45 3.008c.255.342.528.478.86.478.332 0 .615-.156.82-.478l4.59-7.227c.118-.205.245-.43.245-.644 0-.46-.4-.752-.83-.752-.255 0-.508.156-.694.449Z'/%3e%3c/svg%3e")}input[data-task="-"]:checked,li[data-task="-"]>input:checked,li[data-task="-"]>p>input:checked{--checkbox-color: var(--checkbox-border-color)}input[data-task="-"]:checked:after,li[data-task="-"]>input:checked:after,li[data-task="-"]>p>input:checked:after{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cpath fill='black' d='M6.025 9.121c-.595 0-.966.313-.966.86 0 .537.39.84.966.84h7.891c.566 0 .947-.303.947-.84 0-.547-.361-.86-.947-.86h-7.89Z'/%3e%3c/svg%3e")}input[data-task="-"],li[data-task="-"],.HyperMD-list-line[data-task="-"] .cm-list-1{-webkit-text-decoration:var(--checklist-done-decoration);text-decoration:var(--checklist-done-decoration);color:var(--text-faint)}input[data-task=">"]:checked::after,li[data-task=">"]>input:checked::after,li[data-task=">"]>p>input:checked::after{background-color:var(--color-cyan);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='22' height='18' fill='none' viewBox='0 0 22 18'%3e%3cpath fill='black' d='M11.533 0c.479 0 .801.205 1.319.693L20.557 7.9c.38.362.498.723.498 1.055 0 .322-.127.693-.498 1.045l-7.705 7.275c-.47.44-.86.635-1.338.635-.664 0-1.153-.488-1.153-1.142v-3.73h-.283c-3.78 0-6.172.956-7.871 4.15-.342.625-.791.722-1.201.722C.479 17.91 0 17.441 0 16.602c0-7.217 3.057-11.72 10.078-11.72h.283v-3.69C10.361.536 10.85 0 11.533 0Z'/%3e%3c/svg%3e")}input[data-task="<"]:checked::after,li[data-task="<"]>input:checked::after,li[data-task="<"]>p>input:checked::after{background-color:var(--color-blue);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='18' fill='none' viewBox='0 0 20 18'%3e%3cpath fill='black' d='M3.066 17.979h13.34c2.041 0 3.057-1.016 3.057-3.028V3.027C19.463 1.016 18.447 0 16.406 0H3.066C1.026 0 0 1.006 0 3.027v11.924c0 2.022 1.025 3.027 3.066 3.027Zm-.146-1.573c-.87 0-1.348-.459-1.348-1.367V5.83c0-.898.479-1.367 1.348-1.367h13.613c.87 0 1.358.469 1.358 1.367v9.21c0 .907-.489 1.366-1.358 1.366H2.92ZM7.832 7.97h.576c.342 0 .45-.098.45-.44v-.576c0-.342-.108-.45-.45-.45h-.576c-.342 0-.459.108-.459.45v.576c0 .342.117.44.459.44Zm3.242 0h.576c.342 0 .46-.098.46-.44v-.576c0-.342-.118-.45-.46-.45h-.576c-.342 0-.459.108-.459.45v.576c0 .342.117.44.46.44Zm3.242 0h.577c.341 0 .459-.098.459-.44v-.576c0-.342-.118-.45-.46-.45h-.576c-.341 0-.449.108-.449.45v.576c0 .342.108.44.45.44ZM4.59 11.162h.566c.352 0 .46-.098.46-.44v-.575c0-.342-.108-.44-.46-.44H4.59c-.352 0-.46.098-.46.44v.576c0 .341.108.44.46.44Zm3.242 0h.576c.342 0 .45-.098.45-.44v-.575c0-.342-.108-.44-.45-.44h-.576c-.342 0-.459.098-.459.44v.576c0 .341.117.44.459.44Zm3.242 0h.576c.342 0 .46-.098.46-.44v-.575c0-.342-.118-.44-.46-.44h-.576c-.342 0-.459.098-.459.44v.576c0 .341.117.44.46.44Zm3.242 0h.577c.341 0 .459-.098.459-.44v-.575c0-.342-.118-.44-.46-.44h-.576c-.341 0-.449.098-.449.44v.576c0 .341.108.44.45.44ZM4.59 14.365h.566c.352 0 .46-.107.46-.449v-.576c0-.342-.108-.44-.46-.44H4.59c-.352 0-.46.098-.46.44v.576c0 .342.108.45.46.45Zm3.242 0h.576c.342 0 .45-.107.45-.449v-.576c0-.342-.108-.44-.45-.44h-.576c-.342 0-.459.098-.459.44v.576c0 .342.117.45.459.45Zm3.242 0h.576c.342 0 .46-.107.46-.449v-.576c0-.342-.118-.44-.46-.44h-.576c-.342 0-.459.098-.459.44v.576c0 .342.117.45.46.45Z'/%3e%3c/svg%3e")}input[data-task="?"]:checked,li[data-task="?"]>input:checked,li[data-task="?"]>p>input:checked,input[type=checkbox][data-indeterminate=true]:not(:checked){--checkbox-color: var(--color-pink);border:none}input[data-task="?"]:checked:hover,li[data-task="?"]>input:checked:hover,li[data-task="?"]>p>input:checked:hover,input[type=checkbox][data-indeterminate=true]:not(:checked):hover{background-color:var(--checkbox-color-hover)}input[data-task="?"]:checked:after,li[data-task="?"]>input:checked:after,li[data-task="?"]>p>input:checked:after,input[type=checkbox][data-indeterminate=true]:not(:checked):after{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cpath fill='black' d='M8.643 14.004c0 .576.507 1.045 1.093 1.045s1.094-.46 1.094-1.045c0-.586-.498-1.055-1.094-1.055-.595 0-1.093.479-1.093 1.055ZM6.924 6.553a1.665 1.665 0 0 0-.088.498c0 .449.361.693.693.693.342 0 .567-.166.752-.4l.176-.244c.361-.586.879-.918 1.553-.918.908 0 1.504.517 1.504 1.279 0 .684-.42 1.016-1.3 1.63-.722.509-1.269 1.036-1.269 2.032v.127c0 .527.293.8.81.8.509 0 .821-.322.821-.722v-.117c0-.566.322-.928 1.026-1.387.976-.644 1.68-1.23 1.68-2.441 0-1.68-1.495-2.569-3.214-2.569-1.738 0-2.87.811-3.144 1.739Z'/%3e%3c/svg%3e")}input[data-task="!"]:checked,li[data-task="!"]>input:checked,li[data-task="!"]>p>input:checked{--checkbox-color: var(--color-orange)}input[data-task="!"]:checked:after,li[data-task="!"]>input:checked:after,li[data-task="!"]>p>input:checked:after{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cpath fill='black' d='M8.867 14.004c0 .576.508 1.045 1.094 1.045.586 0 1.094-.46 1.094-1.045 0-.586-.498-1.055-1.094-1.055-.596 0-1.094.479-1.094 1.055Zm.166-8.35.127 5.323c.01.517.293.8.8.8.49 0 .772-.273.782-.8l.137-5.313c.01-.518-.39-.898-.928-.898-.547 0-.928.37-.918.888Z'/%3e%3c/svg%3e")}input[data-task="*"]:checked::after,li[data-task="*"]>input:checked::after,li[data-task="*"]>p>input:checked::after{background-color:var(--color-yellow);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='22' height='21' fill='none' viewBox='0 0 22 21'%3e%3cpath fill='black' d='M4.161 20.547c.4.312.908.205 1.514-.235l5.166-3.798 5.176 3.799c.605.439 1.103.546 1.513.234.4-.303.488-.8.244-1.514l-2.04-6.074 5.214-3.75c.606-.43.85-.879.694-1.367-.157-.469-.616-.694-1.368-.694h-6.396l-1.944-6.064C11.7.361 11.35 0 10.841 0c-.498 0-.85.361-1.084 1.084L7.813 7.148H1.417c-.752 0-1.211.225-1.367.694-.166.488.088.937.693 1.367l5.215 3.75-2.041 6.074c-.244.713-.156 1.211.244 1.514Z'/%3e%3c/svg%3e")}input[data-task='"']:checked::after,li[data-task='"']>input:checked::after,li[data-task='"']>p>input:checked::after,input[data-task=“]:checked::after,li[data-task=“]>input:checked::after,li[data-task=“]>p>input:checked::after{background-color:var(--color-purple);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='22' height='21' fill='none' viewBox='0 0 22 21'%3e%3cpath fill='black' d='M21.523 4.473v7.48c0 2.861-1.562 4.463-4.472 4.463h-6.602l-3.525 3.223c-.46.43-.742.625-1.123.625-.557 0-.87-.4-.87-1.006v-2.842h-.458C1.563 16.416 0 14.824 0 11.953v-7.48C0 1.602 1.563 0 4.473 0H17.05c2.91 0 4.472 1.611 4.472 4.473ZM5.898 7.148c0 1.143.713 2.032 1.856 2.032.42 0 .84-.069 1.103-.4h.079a2.863 2.863 0 0 1-1.797 1.542c-.381.098-.489.254-.489.498 0 .254.215.47.498.47 1.016 0 3.057-1.212 3.057-3.77 0-1.368-.879-2.413-2.187-2.413-1.211 0-2.12.84-2.12 2.041Zm5.44 0c0 1.143.713 2.032 1.846 2.032.43 0 .85-.069 1.113-.4h.078a2.855 2.855 0 0 1-1.807 1.542c-.361.098-.478.254-.478.498 0 .254.215.47.498.47 1.016 0 3.057-1.212 3.057-3.77 0-1.368-.89-2.413-2.198-2.413-1.21 0-2.11.84-2.11 2.041Z'/%3e%3c/svg%3e")}input[data-task=l]:checked::after,li[data-task=l]>input:checked::after,li[data-task=l]>p>input:checked::after{background-color:var(--color-red);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='8' height='21' fill='none' viewBox='0 0 8 21'%3e%3cpath fill='black' d='M7.334 3.682A3.65 3.65 0 0 1 4.57 7.236V16.3c0 2.89-.508 4.453-.908 4.453-.39 0-.908-1.572-.908-4.453V7.236A3.65 3.65 0 0 1 0 3.682C0 1.66 1.63 0 3.662 0a3.676 3.676 0 0 1 3.672 3.682ZM1.357 2.617c0 .684.586 1.27 1.26 1.27.684 0 1.25-.586 1.25-1.27 0-.674-.566-1.25-1.25-1.25-.674 0-1.26.576-1.26 1.25Z'/%3e%3c/svg%3e")}input[data-task=b]:checked::after,li[data-task=b]>input:checked::after,li[data-task=b]>p>input:checked::after{background-color:var(--color-orange);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='14' height='21' fill='none' viewBox='0 0 14 21'%3e%3cpath fill='black' d='M1.035 20.947c.479 0 .762-.273 1.64-1.123l3.82-3.76c.048-.048.136-.048.175 0l3.818 3.76c.88.85 1.162 1.123 1.64 1.123.655 0 1.036-.43 1.036-1.191V2.803C13.164.947 12.236 0 10.4 0H2.764C.928 0 0 .947 0 2.803v16.953c0 .762.38 1.191 1.035 1.191Z'/%3e%3c/svg%3e")}input[data-task=i]:checked,li[data-task=i]>input:checked,li[data-task=i]>p>input:checked{--checkbox-color: var(--color-blue)}input[data-task=i]:checked:after,li[data-task=i]>input:checked:after,li[data-task=i]>p>input:checked:after{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cpath fill='black' d='M8.37 8.154a.721.721 0 0 0-.733.713c0 .42.322.723.732.723h1.074v4.59h-1.24a.724.724 0 0 0-.742.713c0 .42.322.722.742.722h4.092c.42 0 .742-.303.742-.722a.724.724 0 0 0-.742-.713h-1.24V9.072c0-.547-.274-.918-.791-.918H8.369Zm.185-2.988c0 .742.586 1.328 1.318 1.328.732 0 1.309-.586 1.309-1.328 0-.742-.577-1.328-1.309-1.328s-1.318.586-1.318 1.328Z'/%3e%3c/svg%3e")}input[data-task=S]:checked::after,li[data-task=S]>input:checked::after,li[data-task=S]>p>input:checked::after{background-color:var(--color-green);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='13' height='23' fill='none' viewBox='0 0 13 23'%3e%3cpath fill='black' d='M6.24 19.639c3.301 0 6.143-1.66 6.143-4.824 0-2.93-2.295-3.975-5.02-4.63l-1.875-.458c-1.777-.43-3.252-1.202-3.252-2.891 0-1.895 2.022-2.861 3.994-2.861 2.022 0 3.487.947 4.024 2.685.156.46.459.772.967.772s.879-.352.879-.87c0-.78-.518-1.835-1.192-2.51-1.191-1.19-2.9-1.747-4.678-1.747-3.056 0-5.869 1.62-5.869 4.677 0 2.705 2.305 3.926 4.815 4.502l1.885.44c1.875.44 3.457 1.123 3.457 3.037 0 2.148-1.973 3.018-4.258 3.018-2.158 0-3.906-.87-4.424-2.813-.147-.479-.43-.752-.928-.752-.547 0-.908.371-.908.86 0 .908.596 1.962 1.27 2.607 1.318 1.24 3.173 1.758 4.97 1.758Zm-.049 2.373a.642.642 0 0 0 .635-.645V.635A.64.64 0 0 0 6.191 0a.64.64 0 0 0-.634.635v20.732c0 .352.283.645.634.645Z'/%3e%3c/svg%3e")}input[data-task=I]:checked::after,li[data-task=I]>input:checked::after,li[data-task=I]>p>input:checked::after{background-color:var(--color-yellow);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='21' height='22' fill='none' viewBox='0 0 21 22'%3e%3cpath fill='black' d='M4.346 12.48c-.215 0-.362.137-.381.362-.371 3.017-.518 3.095-3.574 3.594-.254.029-.391.156-.391.38 0 .215.137.342.342.372 3.086.595 3.252.576 3.623 3.584.02.234.166.37.38.37.206 0 .362-.136.382-.36.39-3.057.507-3.145 3.613-3.595.195-.019.342-.156.342-.37 0-.215-.147-.352-.342-.381-3.106-.596-3.213-.596-3.613-3.614a.367.367 0 0 0-.381-.341ZM11.982 0c-.283 0-.507.205-.546.508-.85 6.181-1.7 7.002-7.793 7.812-.313.03-.538.254-.538.547 0 .303.225.537.538.567 6.113.664 6.992 1.62 7.792 7.793.04.302.264.517.547.517.293 0 .508-.215.557-.517.81-6.172 1.68-7.13 7.793-7.793a.552.552 0 0 0 .527-.567c0-.293-.205-.517-.527-.547-6.113-.683-6.982-1.63-7.793-7.812C12.49.205 12.275 0 11.982 0Z'/%3e%3c/svg%3e")}input[data-task=p]:checked::after,li[data-task=p]>input:checked::after,li[data-task=p]>p>input:checked::after{background-color:var(--color-green);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cpath fill='black' d='M0 13.74c0 2.89 1.807 5.313 4.229 5.313h1.718c-1.758-1.28-2.48-3.213-2.48-5.41.01-2.442.957-4.19 1.797-5.245H3.867C1.69 8.398 0 10.742 0 13.74Zm4.814-.078c0 3.565 2.784 6.318 7.325 6.318h1.328c1.26 0 2.197-.087 2.724-.234.762-.185 1.495-.654 1.495-1.572 0-.381-.098-.654-.215-.86-.078-.127-.059-.224.058-.273.606-.254 1.104-.82 1.104-1.592 0-.44-.127-.83-.342-1.094-.107-.146-.098-.283.088-.38.43-.254.742-.801.742-1.436 0-.459-.146-.937-.4-1.172-.157-.137-.127-.234.029-.38.303-.255.498-.694.498-1.25a1.69 1.69 0 0 0-1.7-1.71h-3.437c-.869 0-1.445-.449-1.445-1.172 0-1.298 1.63-3.7 1.63-5.42C14.297.528 13.712 0 12.95 0c-.703 0-1.045.479-1.416 1.21-1.455 2.823-3.388 5.108-4.863 7.061-1.25 1.66-1.856 3.096-1.856 5.391Z'/%3e%3c/svg%3e")}input[data-task=c]:checked::after,li[data-task=c]>input:checked::after,li[data-task=c]>p>input:checked::after{background-color:var(--color-red);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cpath fill='black' d='M19.238 6.24c0-2.89-1.816-5.312-4.228-5.312h-1.72c1.758 1.28 2.54 3.213 2.5 5.41-.03 2.442-.976 4.19-1.826 5.245h1.406c2.178 0 3.867-2.344 3.867-5.342Zm-4.756.07C14.541 2.744 11.65.05 7.11.01L5.791 0c-1.27-.01-2.207.09-2.734.236-.762.185-1.494.644-1.494 1.571 0 .371.097.655.214.86.078.117.069.224-.058.273-.596.244-1.104.82-1.104 1.582 0 .45.127.83.352 1.104.107.146.088.273-.088.38-.44.254-.752.801-.752 1.436 0 .46.146.938.4 1.172.166.137.137.234-.029.38C.195 9.25 0 9.689 0 10.245a1.69 1.69 0 0 0 1.7 1.71h3.437c.869 0 1.445.449 1.445 1.172 0 1.299-1.621 3.691-1.621 5.41 0 .918.576 1.445 1.348 1.445.693 0 1.035-.478 1.406-1.21 1.455-2.823 3.389-5.108 4.863-7.071 1.25-1.66 1.865-3.086 1.904-5.39Z'/%3e%3c/svg%3e")}input[data-task=f]:checked::after,li[data-task=f]>input:checked::after,li[data-task=f]>p>input:checked::after{background-color:var(--color-orange);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='17' height='22' fill='none' viewBox='0 0 17 22'%3e%3cpath fill='black' d='M7.676 21.123c5.156 0 8.594-3.486 8.594-8.74C16.27 3.643 8.828 0 3.662 0c-.918 0-1.504.322-1.504.947 0 .244.108.498.313.733 1.162 1.386 2.324 3.037 2.343 4.96 0 .44-.048.83-.36 1.378l.487-.098c-.439-1.436-1.62-2.451-2.656-2.451-.4 0-.674.293-.674.732 0 .254.069.85.069 1.28C1.68 9.667 0 10.946 0 14.472c0 3.994 3.057 6.65 7.676 6.65Zm.224-2.744c-1.826 0-3.037-1.104-3.037-2.744 0-1.719 1.221-2.334 1.377-3.438.02-.088.078-.117.147-.058.449.4.742.888.986 1.455.518-.703.762-2.188.596-3.79-.01-.087.049-.136.136-.107 2.14 1.006 3.252 3.135 3.252 5.04 0 1.933-1.132 3.642-3.457 3.642Z'/%3e%3c/svg%3e")}input[data-task=k]:checked::after,li[data-task=k]>input:checked::after,li[data-task=k]>p>input:checked::after{background-color:var(--color-yellow);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='13' height='25' fill='none' viewBox='0 0 13 25'%3e%3cpath fill='black' d='M6.24 0C2.764 0 0 2.764 0 6.22c0 2.608 1.563 4.913 4.004 5.84v9.64a.83.83 0 0 0 .254.614l1.63 1.641c.167.166.499.215.704.01l3.096-3.096a.487.487 0 0 0 0-.703l-1.924-1.895 2.636-2.627c.186-.195.186-.478-.02-.693l-2.607-2.627c3.018-1.201 4.698-3.428 4.698-6.103A6.22 6.22 0 0 0 6.24 0Zm0 5.723c-.908 0-1.63-.733-1.63-1.631 0-.908.712-1.631 1.63-1.631.899 0 1.631.723 1.631 1.63 0 .9-.732 1.632-1.63 1.632Z'/%3e%3c/svg%3e")}input[data-task=w]:checked::after,li[data-task=w]>input:checked::after,li[data-task=w]>p>input:checked::after{background-color:var(--color-orange);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='22' fill='none' viewBox='0 0 20 22'%3e%3cpath fill='black' d='M0 3.223c0 4.033 1.934 6.552 5.791 7.734a8.289 8.289 0 0 0 1.953 1.758v4.248H6.211c-1.377 0-2.09.79-2.09 2.09v1.611c0 .44.342.742.752.742h9.356c.41 0 .752-.302.752-.742v-1.611c0-1.3-.723-2.09-2.1-2.09h-1.524v-4.248a8.07 8.07 0 0 0 1.944-1.758c3.867-1.182 5.8-3.701 5.8-7.734 0-1.006-.624-1.621-1.67-1.621h-1.894C15.381.605 14.677 0 13.497 0H5.604C4.433 0 3.72.596 3.564 1.602H1.67C.625 1.602 0 2.217 0 3.222Zm1.396.136c0-.156.118-.283.284-.283h1.836V4.99c0 1.494.39 2.881.996 4.082C2.47 8.037 1.396 6.142 1.396 3.36ZM14.58 9.072a8.947 8.947 0 0 0 1.006-4.082V3.076h1.836c.166 0 .283.127.283.283 0 2.784-1.074 4.678-3.125 5.713Z'/%3e%3c/svg%3e")}input[data-task=u]:checked::after,li[data-task=u]>input:checked::after,li[data-task=u]>p>input:checked::after{background-color:var(--color-orange);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='15' height='19' fill='none' viewBox='0 0 15 19'%3e%3cpath fill='black' d='M.84 8.271c.234 0 .469-.078.615-.234L3.682 5.85l3.71-4.082 3.731 4.082 2.227 2.187c.156.156.38.234.615.234.488 0 .84-.37.84-.85a.879.879 0 0 0-.264-.634L8.057.293A.885.885 0 0 0 7.402 0a.885.885 0 0 0-.654.293L.273 6.787c-.185.195-.273.4-.273.635 0 .478.352.85.84.85Zm6.562 10.176c.508 0 .87-.351.87-.86V4.728l-.098-2.91c0-.46-.313-.772-.772-.772s-.771.312-.771.771l-.098 2.91v12.862c0 .508.362.86.87.86Z'/%3e%3c/svg%3e")}input[data-task=d]:checked::after,li[data-task=d]>input:checked::after,li[data-task=d]>p>input:checked::after{background-color:var(--color-blue);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='15' height='19' fill='none' viewBox='0 0 15 19'%3e%3cpath fill='black' d='M7.402 18.447a.885.885 0 0 0 .655-.293l6.484-6.494a.879.879 0 0 0 .264-.635c0-.478-.352-.85-.84-.85a.863.863 0 0 0-.615.235l-2.227 2.188-3.73 4.082-3.711-4.082-2.227-2.188c-.146-.156-.38-.234-.615-.234-.488 0-.84.37-.84.85 0 .234.088.439.273.634l6.475 6.494c.186.196.41.293.654.293Zm0-1.045c.46 0 .772-.312.772-.771l.097-2.91V.859c0-.507-.36-.859-.869-.859-.507 0-.869.352-.869.86v12.86l.098 2.91c0 .46.312.772.771.772Z'/%3e%3c/svg%3e")}input[data-task="+"]:checked,li[data-task="+"]>input:checked,li[data-task="+"]>p>input:checked{--checkbox-color: var(--color-orange)}input[data-task="+"]:checked:after,li[data-task="+"]>input:checked:after,li[data-task="+"]>p>input:checked:after{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' fill='none' viewBox='0 0 18 18'%3e%3cpath fill='black' d='M8.154 5.172v2.963H5.192c-.509 0-.86.352-.86.86 0 .499.351.831.86.831h2.962V12.8c0 .498.342.86.841.86.509 0 .86-.352.86-.86V9.826h2.973c.498 0 .86-.332.86-.83 0-.51-.362-.861-.86-.861H9.856V5.172c0-.508-.352-.87-.86-.87-.5 0-.842.362-.842.87Z'/%3e%3c/svg%3e")}input[data-task=B]:checked::after,li[data-task=B]>input:checked::after,li[data-task=B]>p>input:checked::after{background-color:var(--color-pink);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='22' height='20' fill='none' viewBox='0 0 22 20'%3e%3cg clip-path='url(%23a)'%3e%3cpath fill='black' d='M14.023 19.365a3.261 3.261 0 0 0 3.262-3.261 3.263 3.263 0 0 0-3.262-3.272 3.263 3.263 0 0 0-3.261 3.271 3.261 3.261 0 0 0 3.261 3.262Zm-7.177 0a3.261 3.261 0 0 0 3.261-3.261 3.263 3.263 0 0 0-3.261-3.272 3.263 3.263 0 0 0-3.262 3.271 3.261 3.261 0 0 0 3.262 3.262Zm10.761-6.425a3.255 3.255 0 0 0 3.262-3.262 3.255 3.255 0 0 0-3.262-3.262 3.263 3.263 0 0 0-3.271 3.262 3.263 3.263 0 0 0 3.271 3.261Zm-14.345 0a3.263 3.263 0 0 0 3.271-3.262 3.263 3.263 0 0 0-3.271-3.262 3.261 3.261 0 1 0 0 6.524Zm10.761-6.417a3.255 3.255 0 0 0 3.262-3.261A3.255 3.255 0 0 0 14.023 0a3.255 3.255 0 0 0-3.261 3.262 3.255 3.255 0 0 0 3.261 3.261Zm-7.177 0a3.255 3.255 0 0 0 3.261-3.261A3.255 3.255 0 0 0 6.846 0a3.255 3.255 0 0 0-3.262 3.262 3.255 3.255 0 0 0 3.262 3.261Z'/%3e%3c/g%3e%3cdefs%3e%3cclipPath id='a'%3e%3cpath fill='white' d='M0 0h21.23v19.365H0z'/%3e%3c/clipPath%3e%3c/defs%3e%3c/svg%3e")}input[data-task=a]:checked::after,li[data-task=a]>input:checked::after,li[data-task=a]>p>input:checked::after{background-color:var(--color-pink);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='22' fill='none' viewBox='0 0 20 22'%3e%3cg clip-path='url(%23a)'%3e%3cpath fill='black' d='M9.336 20.254a9.336 9.336 0 0 0 9.336-9.336c0-5.156-4.18-9.346-9.336-9.346C4.18 1.572 0 5.762 0 10.918a9.336 9.336 0 0 0 9.336 9.336Zm-4.443-8.262a.663.663 0 0 1-.674-.674c0-.38.293-.683.674-.683h3.76V5.4a.68.68 0 1 1 1.357 0v5.918a.672.672 0 0 1-.684.674H4.893Zm-3.575-7.91c.147 0 .254-.02.391-.127l3.271-2.47c.157-.118.245-.274.245-.44 0-.205-.098-.371-.264-.527C4.59.186 3.926 0 3.34 0A2.734 2.734 0 0 0 .596 2.744c0 .361.058.723.166.947.107.245.312.391.556.391Zm16.035 0c.245 0 .45-.156.567-.39.098-.215.156-.587.156-.948A2.728 2.728 0 0 0 15.332 0c-.586 0-1.25.186-1.621.518-.166.156-.264.322-.264.527 0 .166.088.322.254.44l3.262 2.47a.568.568 0 0 0 .39.127ZM1.172 19.971a.74.74 0 0 0 1.074-.01l1.846-1.836-1.055-1.045-1.855 1.836a.743.743 0 0 0-.01 1.055Zm16.328 0a.734.734 0 0 0-.01-1.055l-1.855-1.836-1.045 1.045 1.836 1.836a.74.74 0 0 0 1.074.01Z'/%3e%3c/g%3e%3cdefs%3e%3cclipPath id='a'%3e%3cpath fill='white' d='M0 0h19.033v21.924H0z'/%3e%3c/clipPath%3e%3c/defs%3e%3c/svg%3e")}input[data-task=n]:checked::after,li[data-task=n]>input:checked::after,li[data-task=n]>p>input:checked::after{background-color:var(--color-blue);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3e%3cg clip-path='url(%23a)'%3e%3cpath fill='black'  d='M2.668 14.63 13.322 3.985l-1.709-1.719L.95 12.911l-.928 2.178c-.097.234.157.508.391.41l2.256-.87ZM14.182 3.145l.986-.966c.498-.499.527-1.036.078-1.485l-.332-.332c-.44-.44-.976-.4-1.475.088l-.986.977 1.729 1.718Z'/%3e%3c/g%3e%3cdefs%3e%3cclipPath id='a'%3e%3cpath fill='white' d='M0 0h15.932v15.52H0z'/%3e%3c/clipPath%3e%3c/defs%3e%3c/svg%3e")}input[data-task=R]:checked::after,li[data-task=R]>input:checked::after,li[data-task=R]>p>input:checked::after{background-color:var(--color-cyan);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='22' height='18' fill='none' viewBox='0 0 22 18'%3e%3cg clip-path='url(%23a)'%3e%3cpath fill='black'  d='M8.652 16.777v-6.181c0-.4-.224-.616-.625-.616a.803.803 0 0 0-.507.176l-3.692 3.057c-.303.264-.322.664 0 .928l3.692 3.066a.812.812 0 0 0 .507.186c.4 0 .625-.225.625-.616ZM20.02 8.36a.81.81 0 0 0-.82.83v.928c0 1.67-1.163 2.764-2.93 2.764H7.216c-.45 0-.82.371-.82.81 0 .45.37.82.82.82h8.896c2.91 0 4.727-1.65 4.727-4.277V9.19a.81.81 0 0 0-.82-.83ZM12.188.635v6.181c0 .391.224.616.624.616a.812.812 0 0 0 .508-.186l3.692-3.057c.312-.253.332-.654 0-.927L13.32.195a.803.803 0 0 0-.508-.175c-.4 0-.624.214-.624.615ZM.82 9.053c.47 0 .83-.362.83-.83v-.928c0-1.67 1.153-2.774 2.92-2.774h9.063c.44 0 .81-.36.81-.81a.82.82 0 0 0-.81-.81H4.727C1.827 2.9 0 4.54 0 7.177v1.045c0 .468.361.83.82.83Z'/%3e%3c/g%3e%3cdefs%3e%3cclipPath id='a'%3e%3cpath fill='white' d='M0 0h21.201v17.393H0z'/%3e%3c/clipPath%3e%3c/defs%3e%3c/svg%3e")}input[data-task=t]:checked::after,li[data-task=t]>input:checked::after,li[data-task=t]>p>input:checked::after{background-color:var(--color-orange);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='21' height='20' fill='none' viewBox='0 0 21 20'%3e%3cg clip-path='url(%23a)'%3e%3cpath fill='white' d='M4.854 11.016a.667.667 0 0 1-.684-.684c0-.38.293-.674.684-.674h4.423V3.75c0-.38.293-.674.674-.674.381 0 .684.293.684.674v6.582c0 .39-.303.684-.684.684H4.854Zm5.107 8.906c5.498 0 9.96-4.473 9.96-9.961C19.922 4.463 15.46 0 9.962 0 4.473 0 0 4.463 0 9.96c0 5.49 4.473 9.962 9.96 9.962Z'/%3e%3c/g%3e%3cdefs%3e%3cclipPath id='a'%3e%3cpath fill='white' d='M0 0h20.283v19.932H0z'/%3e%3c/clipPath%3e%3c/defs%3e%3c/svg%3e")}input[data-task=P]:checked::after,li[data-task=P]>input:checked::after,li[data-task=P]>p>input:checked::after{background-color:var(--color-green);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='19' height='19' fill='none' viewBox='0 0 19 19'%3e%3cg clip-path='url(%23a)'%3e%3cpath fill='white' d='M5 13.154c2.871 2.881 6.309 5.069 9.072 5.069 1.3 0 2.432-.518 3.174-1.348.713-.8.957-1.396.957-1.924 0-.41-.254-.79-.898-1.24l-2.383-1.709c-.596-.42-.86-.498-1.211-.498-.303 0-.557.059-1.065.332l-1.562.86c-.186.107-.264.126-.4.126-.186 0-.313-.049-.498-.127-.743-.341-1.788-1.162-2.715-2.09-.928-.927-1.65-1.875-2.022-2.607a.971.971 0 0 1-.107-.41c0-.127.068-.234.146-.371l.918-1.572c.254-.43.323-.665.323-.997 0-.38-.127-.79-.489-1.308L4.6 1.055C4.13.4 3.78 0 3.252 0 2.598 0 1.807.498 1.24 1.045.43 1.826 0 2.92 0 4.15c0 2.784 2.139 6.153 5 9.004Z'/%3e%3c/g%3e%3cdefs%3e%3cclipPath id='a'%3e%3cpath fill='white' d='M0 0h18.564v18.232H0z'/%3e%3c/clipPath%3e%3c/defs%3e%3c/svg%3e")}input[data-task=L]:checked::after,li[data-task=L]>input:checked::after,li[data-task=L]>p>input:checked::after{background-color:var(--color-pink);-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='19' fill='none' viewBox='0 0 20 19'%3e%3cg clip-path='url(%23a)'%3e%3cpath fill='white' d='M9.697 18.525c.205 0 .498-.136.713-.263 5.498-3.516 8.985-7.608 8.985-11.768 0-3.457-2.373-5.898-5.44-5.898-1.904 0-3.37 1.054-4.258 2.666C8.828 1.66 7.344.596 5.44.596 2.373.596 0 3.037 0 6.494c0 4.16 3.486 8.252 8.994 11.768.205.127.498.263.703.263Z'/%3e%3c/g%3e%3cdefs%3e%3cclipPath id='a'%3e%3cpath fill='white' d='M0 0h19.756v18.525H0z'/%3e%3c/clipPath%3e%3c/defs%3e%3c/svg%3e")}body:not(.banner-off){--banner-image-object-fit: cover;--banner-image-inset: 8px;--banner-image-height: 320px;--banner-image-height-s: 240px;--banner-image-radius: var(--radius-s);--banner-fade-height: 80px;--banner-icon-size: 3rem;--banner-mobile-offset: 0px}body:not(.banner-off):where(.is-mobile){--banner-image-height: var(--banner-image-height-s)}body:not(.banner-off):where(.is-mobile) .markdown-preview-view:not(.banner),body:not(.banner-off):where(.is-mobile) .is-live-preview:not(.banner){--banner-mobile-offset: 0px}body:not(.banner-off):not(.is-phone){--view-top-spacing-markdown: 0px}body:not(.banner-off).is-mobile .banner:not(.banner-icon){--banner-mobile-offset: 0.5rem}body:not(.banner-off).is-mobile .banner.banner-icon{--banner-mobile-offset: 1.5rem}body:not(.banner-off):not(.is-phone) .banner-icon.banner-title .inline-title~.metadata-container{padding-top:0px}body:not(.banner-off).is-mobile .banner-icon .inline-title{padding-top:0px}body:not(.banner-off).is-phone .banner-icon.banner-title .inline-title~.metadata-container{padding-top:8px}body:not(.banner-off) .banner.y0 img[alt=banner]{object-position:center 0%}body:not(.banner-off) .banner.y5 img[alt=banner]{object-position:center 5%}body:not(.banner-off) .banner.y10 img[alt=banner]{object-position:center 10%}body:not(.banner-off) .banner.y15 img[alt=banner]{object-position:center 15%}body:not(.banner-off) .banner.y20 img[alt=banner]{object-position:center 20%}body:not(.banner-off) .banner.y25 img[alt=banner]{object-position:center 25%}body:not(.banner-off) .banner.y30 img[alt=banner]{object-position:center 30%}body:not(.banner-off) .banner.y35 img[alt=banner]{object-position:center 35%}body:not(.banner-off) .banner.y40 img[alt=banner]{object-position:center 40%}body:not(.banner-off) .banner.y45 img[alt=banner]{object-position:center 45%}body:not(.banner-off) .banner.y50 img[alt=banner]{object-position:center 50%}body:not(.banner-off) .banner.y55 img[alt=banner]{object-position:center 55%}body:not(.banner-off) .banner.y60 img[alt=banner]{object-position:center 60%}body:not(.banner-off) .banner.y65 img[alt=banner]{object-position:center 65%}body:not(.banner-off) .banner.y70 img[alt=banner]{object-position:center 70%}body:not(.banner-off) .banner.y75 img[alt=banner]{object-position:center 75%}body:not(.banner-off) .banner.y80 img[alt=banner]{object-position:center 80%}body:not(.banner-off) .banner.y85 img[alt=banner]{object-position:center 85%}body:not(.banner-off) .banner.y90 img[alt=banner]{object-position:center 90%}body:not(.banner-off) .banner.y95 img[alt=banner]{object-position:center 95%}body:not(.banner-off) .banner.y100 img[alt=banner]{object-position:center 100%}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview) .markdown-preview-sizer,body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview) .cm-editor>.cm-scroller>.cm-sizer{margin-top:calc(var(--banner-image-height) + var(--banner-icon-size) - var(--banner-fade-height) + var(--banner-mobile-offset))}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview):not(.banner){--banner-image-height: 0px}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview):not(.banner.banner-fade){--banner-fade-height: 0px}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview):not(.banner-icon){--banner-icon-size: 0px}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner-icon:not(.banner){--banner-image-height: var(--banner-icon-size)}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner-icon:not(.banner.banner-fade){--banner-fade-height: var(--banner-icon-size)}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner.banner-icon.banner-title:not(.banner-fade){--banner-fade-height: 0px}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner-image-contain{--banner-image-object-fit: contain}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner-image-cover{--banner-image-object-fit: cover}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner-image-fill{--banner-image-object-fit: fill}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner img[alt=banner]:not([contenteditable]){position:absolute;inset:var(--view-top-spacing-markdown) var(--banner-image-inset) auto;border-radius:var(--banner-image-radius);width:-webkit-fill-available;width:stretch;height:var(--banner-image-height);overflow:hidden;object-fit:var(--banner-image-object-fit);line-height:0;max-width:calc(100% - var(--banner-image-inset)*2)}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner .image-embed[alt=banner],body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner .image-embed[alt=banner]>.image-wrapper,body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner .image-embed[alt=banner]>.image-resize-container{display:contents !important}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner .image-embed[alt=banner]::before,body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner .image-embed[alt=banner]::after,body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner .image-embed[alt=banner] .image-resize-corner,body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner .image-embed[alt=banner] .image-resize-handle,body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner .image-embed[alt=banner]>.image-wrapper::before,body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner .image-embed[alt=banner]>.image-wrapper::after,body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner .image-embed[alt=banner]>.image-wrapper .image-resize-corner,body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner .image-embed[alt=banner]>.image-wrapper .image-resize-handle,body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner .image-embed[alt=banner]>.image-resize-container::before,body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner .image-embed[alt=banner]>.image-resize-container::after,body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner .image-embed[alt=banner]>.image-resize-container .image-resize-corner,body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner .image-embed[alt=banner]>.image-resize-container .image-resize-handle{display:none !important}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner div:is(.mod-header,.inline-title,.metadata-container){z-index:1}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner.banner-fade img[alt=banner]{mask:linear-gradient(to bottom, hsl(0, 0%, 0%) 0%, hsla(0, 0%, 0%, 0.987) 14%, hsla(0, 0%, 0%, 0.951) 26.2%, hsla(0, 0%, 0%, 0.896) 36.8%, hsla(0, 0%, 0%, 0.825) 45.9%, hsla(0, 0%, 0%, 0.741) 53.7%, hsla(0, 0%, 0%, 0.648) 60.4%, hsla(0, 0%, 0%, 0.55) 66.2%, hsla(0, 0%, 0%, 0.45) 71.2%, hsla(0, 0%, 0%, 0.352) 75.6%, hsla(0, 0%, 0%, 0.259) 79.6%, hsla(0, 0%, 0%, 0.175) 83.4%, hsla(0, 0%, 0%, 0.104) 87.2%, hsla(0, 0%, 0%, 0.049) 91.1%, hsla(0, 0%, 0%, 0.013) 95.3%, hsla(0, 0%, 0%, 0) 100%)}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner-icon .cm-callout:has(.callout[data-callout=banner-icon]){display:contents !important}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner-icon .callout[data-callout=banner-icon]{z-index:1;position:absolute;top:calc(var(--view-top-spacing-markdown) + var(--banner-image-height) - var(--banner-fade-height) + 1rem);margin:0 !important;border:none !important;background:none !important;padding:0 !important;width:var(--banner-icon-size);height:var(--banner-icon-size);font-size:var(--banner-icon-size);display:flex;justify-content:center;overflow:visible;box-shadow:none}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner-icon .callout[data-callout=banner-icon] .callout-title-inner{line-height:1}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner-icon .callout[data-callout=banner-icon] .callout-icon,body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner-icon .callout[data-callout=banner-icon] .callout-content{display:none}@keyframes bannerTitleEditIn{from{transform:translateY(-0.5rem);opacity:0}to{transform:translateY(0);opacity:1}}@keyframes bannerTitleEditOut{from{transform:translateY(0.5rem);opacity:0}to{transform:translateY(0);opacity:1}}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner-icon.banner-title .inline-title{transition:var(--anim-duration-moderate) var(--anim-motion-baseline),margin-left 0s}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner-icon.banner-title .inline-title:focus-within{animation:bannerTitleEditIn var(--anim-duration-moderate) var(--anim-motion-baseline) forwards}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner-icon.banner-title .inline-title:not(:focus-within){position:absolute;top:calc(var(--view-top-spacing-markdown) + var(--banner-image-height) - var(--banner-fade-height) + 1rem);align-items:center;animation:bannerTitleEditOut var(--anim-duration-moderate) var(--anim-motion-baseline) forwards;margin-bottom:0;margin-left:calc(var(--banner-icon-size) + 1rem);width:calc(var(--file-line-width) - var(--banner-icon-size) - 1rem);max-width:calc(100% - var(--file-margins-x)*2 - var(--banner-icon-size) - 1rem);height:var(--banner-icon-size);overflow:hidden;line-height:var(--banner-icon-size);text-overflow:ellipsis;white-space:nowrap}body:not(.banner-off) .mod-root .view-content:not(.pixel-banner,.has-banner) div:is(.markdown-preview-view,.is-live-preview).banner-icon.banner-title .inline-title:not(:focus-within)::before{content:none}body{--file-line-width: var(--line-width);--line-width: 700px}body:not(.block-width-off){--line-width-wide: 50rem}body:not(.block-width-off) .wide{--file-line-width: min(100cqw, var(--line-width-wide))}body:not(.block-width-off) .max{--file-line-width: 100%}body:not(.block-width-off){--block-width-wide: min(100cqw, var(--line-width-wide));--block-width-max: calc(100cqw - (var(--file-margins-x) * 2));--block-width-offset: calc(-1 * var(--file-margins-x))}body:not(.block-width-off) .mod-root .workspace-tab-container{container-type:inline-size}body:not(.block-width-off) div:is(.table-wide,.table-max,.table-100) .markdown-preview-sizer>.el-table,body:not(.block-width-off) div:is(.table-wide,.table-max,.table-100) .markdown-preview-sizer>.el-pre .block-language-dataview,body:not(.block-width-off) div:is(.table-wide,.table-max,.table-100) .markdown-preview-sizer>.el-pre .block-language-dataviewjs,body:not(.block-width-off) div:is(.table-wide,.table-max,.table-100) .markdown-preview-sizer>.el-pre .block-language-datacorejsx,body:not(.block-width-off) div:is(.table-wide,.table-max,.table-100) .cm-content>.cm-table-widget,body:not(.block-width-off) div:is(.table-wide,.table-max,.table-100) .cm-content>.cm-lang-dataview,body:not(.block-width-off) div:is(.table-wide,.table-max,.table-100) .cm-content>.cm-lang-dataviewjs,body:not(.block-width-off) div:is(.table-wide,.table-max,.table-100) .cm-content>.cm-lang-datacorejsx{max-width:var(--table-line-max-width);width:var(--table-line-width) !important;justify-self:center;margin-inline:var(--table-line-width-offset) !important}body:not(.block-width-off) .table-wide{--table-line-max-width: var(--block-width-max);--table-line-width: var(--block-width-wide)}body:not(.block-width-off) .table-max{--table-line-max-width: var(--block-width-max);--table-line-width: var(--block-width-max)}body:not(.block-width-off) .table-100{--table-line-max-width: 100cqw;--table-line-width: 100cqw;--table-line-width-offset: var(--block-width-offset)}body:not(.block-width-off) .table-100 .markdown-preview-sizer>.el-table tbody>tr>td,body:not(.block-width-off) .table-100 .cm-content>.cm-table-widget tbody>tr>td{border-radius:0}body:not(.block-width-off) .table-100 .markdown-preview-sizer>.el-table tbody tr:first-child>td,body:not(.block-width-off) .table-100 .cm-content>.cm-table-widget tbody tr:first-child>td{border-block-start-width:0}body:not(.block-width-off) .table-100 .markdown-preview-sizer>.el-table tbody tr>td:last-child,body:not(.block-width-off) .table-100 .cm-content>.cm-table-widget tbody tr>td:last-child{border-inline-end-width:0}body:not(.block-width-off) .table-100 .markdown-preview-sizer>.el-table tbody tr>td:first-child,body:not(.block-width-off) .table-100 .cm-content>.cm-table-widget tbody tr>td:first-child{border-inline-start-width:0}body:not(.block-width-off) .table-100 .markdown-preview-sizer>.el-table tbody tr:last-child>td,body:not(.block-width-off) .table-100 .cm-content>.cm-table-widget tbody tr:last-child>td{border-block-end-width:0}body:not(.block-width-off) div:is(.bases-wide,.bases-max,.bases-100) .markdown-preview-sizer>.el-pre .bases-embed,body:not(.block-width-off) div:is(.bases-wide,.bases-max,.bases-100) .markdown-preview-sizer>.el-p .bases-embed,body:not(.block-width-off) div:is(.bases-wide,.bases-max,.bases-100) .cm-content>.bases-embed,body:not(.block-width-off) div:is(.bases-wide,.bases-max,.bases-100) .cm-content>.cm-lang-base{max-width:var(--bases-line-max-width);width:var(--bases-line-width) !important;justify-self:center;margin-inline:var(--bases-line-width-offset) !important}body:not(.block-width-off) .bases-wide{--bases-line-max-width: var(--block-width-max);--bases-line-width: var(--block-width-wide)}body:not(.block-width-off) .bases-max{--bases-line-max-width: var(--block-width-max);--bases-line-width: var(--block-width-max)}body:not(.block-width-off) .bases-100{--bases-line-max-width: 100cqw;--bases-line-width: 100cqw;--bases-line-width-offset: var(--block-width-offset)}body:not(.block-width-off) div:is(.img-wide,.img-max,.img-100) .markdown-preview-sizer>.el-p p:has(img),body:not(.block-width-off) div:is(.img-wide,.img-max,.img-100) .markdown-preview-sizer>.el-iframe,body:not(.block-width-off) div:is(.img-wide,.img-max,.img-100) .cm-content .image-embed{max-width:var(--img-line-max-width);width:var(--img-line-width) !important;justify-self:center;margin-inline:var(--img-line-width-offset) !important}body:not(.block-width-off) .cm-content .image-embed{display:block}body:not(.block-width-off) .img-wide{--img-line-max-width: var(--block-width-max);--img-line-width: var(--block-width-wide)}body:not(.block-width-off) .img-max{--img-line-max-width: var(--block-width-max);--img-line-width: var(--block-width-max)}body:not(.block-width-off) .img-100{--img-line-max-width: 100cqw;--img-line-width: 100cqw;--img-line-width-offset: var(--block-width-offset)}body:not(.block-width-off) .img-100 .markdown-preview-sizer img:not([alt=banner]),body:not(.block-width-off) .img-100 .cm-content img:not([alt=banner]){border-radius:0 !important}.callout-icon .lucide-pencil,.callout-icon .lucide-clipboard-list,.callout-icon .lucide-info,.callout-icon .lucide-check-circle-2,.callout-icon .lucide-flame,.callout-icon .lucide-check,.callout-icon .lucide-help-circle,.callout-icon .lucide-alert-triangle,.callout-icon .lucide-x,.callout-icon .lucide-zap,.callout-icon .lucide-bug,.callout-icon .lucide-list,.callout-icon .lucide-quote{-webkit-mask-position:50% 50%;-webkit-mask-size:100% 100%;background-color:rgb(var(--callout-color))}.callout-icon .lucide-pencil path,.callout-icon .lucide-pencil rect,.callout-icon .lucide-pencil circle,.callout-icon .lucide-clipboard-list path,.callout-icon .lucide-clipboard-list rect,.callout-icon .lucide-clipboard-list circle,.callout-icon .lucide-info path,.callout-icon .lucide-info rect,.callout-icon .lucide-info circle,.callout-icon .lucide-check-circle-2 path,.callout-icon .lucide-check-circle-2 rect,.callout-icon .lucide-check-circle-2 circle,.callout-icon .lucide-flame path,.callout-icon .lucide-flame rect,.callout-icon .lucide-flame circle,.callout-icon .lucide-check path,.callout-icon .lucide-check rect,.callout-icon .lucide-check circle,.callout-icon .lucide-help-circle path,.callout-icon .lucide-help-circle rect,.callout-icon .lucide-help-circle circle,.callout-icon .lucide-alert-triangle path,.callout-icon .lucide-alert-triangle rect,.callout-icon .lucide-alert-triangle circle,.callout-icon .lucide-x path,.callout-icon .lucide-x rect,.callout-icon .lucide-x circle,.callout-icon .lucide-zap path,.callout-icon .lucide-zap rect,.callout-icon .lucide-zap circle,.callout-icon .lucide-bug path,.callout-icon .lucide-bug rect,.callout-icon .lucide-bug circle,.callout-icon .lucide-list path,.callout-icon .lucide-list rect,.callout-icon .lucide-list circle,.callout-icon .lucide-quote path,.callout-icon .lucide-quote rect,.callout-icon .lucide-quote circle{visibility:hidden}.callout-icon .lucide-pencil{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3e%3cpath fill='black' d='M2.668 14.573 13.322 3.93l-1.709-1.72L.95 12.856l-.928 2.177c-.097.235.157.508.391.41l2.256-.869ZM14.182 3.09l.986-.967c.498-.498.527-1.035.078-1.484l-.332-.332c-.44-.44-.976-.4-1.475.087l-.986.977 1.729 1.719Z'/%3e%3c/svg%3e")}.callout-icon .lucide-clipboard-list{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='17' height='21' fill='none' viewBox='0 0 17 21'%3e%3cg fill='black'%3e%3cpath d='M0 17.88c0 2.042 1.006 3.058 3.027 3.058h10.371c2.022 0 3.028-1.016 3.028-3.057V3.066C16.426 1.036 15.42 0 13.398 0H3.028C1.005 0 0 1.035 0 3.066v14.815Zm1.572-.028V3.096c0-.977.518-1.524 1.533-1.524H13.32c1.016 0 1.534.547 1.534 1.524v14.756c0 .976-.518 1.513-1.534 1.513H3.105c-1.015 0-1.533-.537-1.533-1.513Z'/%3e%3cpath d='M4.512 5.654h7.412a.588.588 0 0 0 .596-.605.586.586 0 0 0-.596-.596H4.512a.588.588 0 0 0-.606.596.59.59 0 0 0 .606.605Zm0 3.409h7.412a.588.588 0 0 0 .596-.606.586.586 0 0 0-.596-.596H4.512a.588.588 0 0 0-.606.596.59.59 0 0 0 .606.605Zm0 3.407h3.506c.351 0 .605-.253.605-.585a.593.593 0 0 0-.605-.615H4.512a.593.593 0 0 0-.606.615c0 .332.254.586.606.586Z'/%3e%3c/g%3e%3c/svg%3e")}.callout-icon .lucide-info{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cg fill='black'%3e%3cpath d='M9.96 19.922c5.499 0 9.962-4.463 9.962-9.961S15.459 0 9.96 0 0 4.463 0 9.96c0 5.499 4.463 9.962 9.96 9.962Zm0-1.66c-4.589 0-8.3-3.711-8.3-8.301s3.711-8.3 8.3-8.3c4.59 0 8.302 3.71 8.302 8.3 0 4.59-3.711 8.3-8.301 8.3Z'/%3e%3cpath d='M8.252 15.43h3.975c.4 0 .713-.293.713-.694 0-.38-.313-.683-.713-.683h-1.211V9.082c0-.527-.264-.879-.762-.879H8.418c-.4 0-.713.303-.713.684 0 .4.313.693.713.693h1.045v4.473H8.252c-.4 0-.713.302-.713.683 0 .4.313.694.713.694Zm1.621-8.848c.713 0 1.27-.566 1.27-1.28 0-.712-.557-1.279-1.27-1.279a1.27 1.27 0 0 0-1.27 1.28 1.27 1.27 0 0 0 1.27 1.279Z'/%3e%3c/g%3e%3c/svg%3e")}.callout-icon .lucide-check-circle-2{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cg fill='black'%3e%3cpath d='M9.96 19.922c5.499 0 9.962-4.463 9.962-9.961S15.459 0 9.96 0 0 4.463 0 9.96c0 5.499 4.463 9.962 9.96 9.962Zm0-1.66c-4.589 0-8.3-3.711-8.3-8.301s3.711-8.3 8.3-8.3c4.59 0 8.302 3.71 8.302 8.3 0 4.59-3.711 8.3-8.301 8.3Z'/%3e%3cpath d='M8.887 14.6c.322 0 .595-.157.79-.46l4.464-7.02c.107-.196.234-.411.234-.626 0-.44-.39-.723-.8-.723-.245 0-.49.157-.675.44l-4.052 6.504-1.924-2.49c-.235-.313-.45-.391-.723-.391a.757.757 0 0 0-.752.771c0 .215.088.42.225.606l2.383 2.93c.244.322.507.459.83.459Z'/%3e%3c/g%3e%3c/svg%3e")}.callout-icon .lucide-flame{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='14' height='23' fill='none' viewBox='0 0 14 23'%3e%3cpath fill='black' d='M0 6.016c0 3.75 2.246 4.677 2.871 11.191.04.352.234.576.606.576H9.59c.38 0 .576-.224.615-.576.625-6.514 2.861-7.441 2.861-11.191 0-3.37-2.88-6.016-6.533-6.016C2.881 0 0 2.646 0 6.016Zm1.475 0c0-2.637 2.314-4.541 5.058-4.541 2.744 0 5.059 1.904 5.059 4.54 0 2.803-1.856 3.467-2.735 10.294H4.22c-.89-6.827-2.745-7.49-2.745-10.293Zm1.972 13.877H9.63a.563.563 0 0 0 .566-.577.56.56 0 0 0-.566-.566H3.447a.571.571 0 1 0 0 1.143Zm3.086 2.832c1.514 0 2.774-.743 2.871-1.866H3.672c.068 1.123 1.338 1.866 2.861 1.866Z'/%3e%3c/svg%3e")}.callout-icon .lucide-check{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='17' height='17' fill='none' viewBox='0 0 17 17'%3e%3cpath fill='black' d='M6.367 16.69c.42 0 .752-.186.987-.547L16.582 1.61c.176-.283.244-.498.244-.722 0-.537-.351-.889-.889-.889-.39 0-.605.127-.84.498L6.329 14.473l-4.55-5.957c-.245-.342-.489-.479-.84-.479-.557 0-.938.381-.938.918 0 .225.098.479.283.713l5.069 6.455c.293.38.595.566 1.015.566Z'/%3e%3c/svg%3e")}.callout-icon .lucide-help-circle{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cg fill='black'%3e%3cpath d='M9.96 19.922c5.499 0 9.962-4.463 9.962-9.961S15.459 0 9.96 0 0 4.463 0 9.96c0 5.499 4.463 9.962 9.96 9.962Zm0-1.66c-4.589 0-8.3-3.711-8.3-8.301s3.711-8.3 8.3-8.3c4.59 0 8.302 3.71 8.302 8.3 0 4.59-3.711 8.3-8.301 8.3Z'/%3e%3cpath d='M9.756 11.982c.488 0 .79-.312.79-.693v-.117c0-.547.313-.899.997-1.348.947-.625 1.621-1.191 1.621-2.363 0-1.621-1.445-2.5-3.105-2.5-1.68 0-2.784.8-3.047 1.7a1.584 1.584 0 0 0-.078.478c0 .44.341.673.664.673.332 0 .547-.156.722-.39l.176-.234c.342-.567.85-.899 1.504-.899.889 0 1.465.508 1.465 1.25 0 .664-.41.986-1.26 1.582-.703.488-1.23 1.006-1.23 1.963v.127c0 .508.283.771.78.771Zm-.02 2.91c.567 0 1.055-.449 1.055-1.015 0-.567-.479-1.016-1.055-1.016s-1.054.46-1.054 1.016c0 .557.488 1.016 1.054 1.016Z'/%3e%3c/g%3e%3c/svg%3e")}.callout-icon .lucide-alert-triangle{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cg fill='black'%3e%3cpath d='M9.96 19.922c5.499 0 9.962-4.463 9.962-9.961S15.459 0 9.96 0 0 4.463 0 9.96c0 5.499 4.463 9.962 9.96 9.962Zm0-1.66c-4.589 0-8.3-3.711-8.3-8.301s3.711-8.3 8.3-8.3c4.59 0 8.302 3.71 8.302 8.3 0 4.59-3.711 8.3-8.301 8.3Z'/%3e%3cpath d='M9.951 11.719c.46 0 .733-.264.742-.772l.147-5.156c.01-.498-.381-.87-.899-.87-.527 0-.898.362-.888.86l.127 5.166c.01.498.283.772.771.772Zm0 3.174c.557 0 1.045-.45 1.045-1.016 0-.567-.478-1.016-1.045-1.016-.576 0-1.055.46-1.055 1.016 0 .557.489 1.016 1.055 1.016Z'/%3e%3c/g%3e%3c/svg%3e")}.callout-icon .lucide-x{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3e%3cpath fill='black' d='M13.993.26.253 14a.875.875 0 0 0 0 1.23.896.896 0 0 0 1.24 0l13.74-13.74a.875.875 0 0 0 0-1.23.87.87 0 0 0-1.24 0ZM15.233 14 1.493.26a.87.87 0 0 0-1.24 0 .884.884 0 0 0 0 1.23l13.74 13.74c.332.333.908.342 1.24 0a.884.884 0 0 0 0-1.23Z'/%3e%3c/svg%3e")}.callout-icon .lucide-zap{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='21' height='19' fill='none' viewBox='0 0 21 19'%3e%3cg fill='black'%3e%3cpath d='M2.666 18.555h15.137c1.66 0 2.666-1.153 2.666-2.647 0-.459-.137-.937-.381-1.367L12.51 1.338A2.588 2.588 0 0 0 10.234 0C9.336 0 8.457.45 7.96 1.338L.381 14.54c-.264.44-.381.908-.381 1.367 0 1.494 1.006 2.647 2.666 2.647Zm.01-1.534c-.684 0-1.094-.527-1.094-1.123 0-.185.04-.42.147-.625L9.297 2.08c.205-.361.576-.518.937-.518.362 0 .723.157.928.518l7.568 13.203c.108.205.157.43.157.615 0 .596-.43 1.123-1.104 1.123H2.676Z'/%3e%3cpath d='M10.234 11.973c.47 0 .743-.274.752-.782l.137-5.146c.01-.498-.38-.87-.898-.87-.528 0-.899.362-.89.86l.128 5.156c.01.498.283.782.771.782Zm0 3.173c.567 0 1.055-.449 1.055-1.015 0-.576-.479-1.016-1.055-1.016s-1.054.45-1.054 1.016c0 .556.488 1.015 1.054 1.015Z'/%3e%3c/g%3e%3c/svg%3e")}.callout-icon .lucide-bug{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='23' height='23' fill='none' viewBox='0 0 23 23'%3e%3cpath fill='black' d='M11.065 22.94c5.156 0 8.583-3.515 8.583-8.818 0-2.93-1.298-5.927-3.369-7.744-.02-2.705-2.08-4.336-5.214-4.336-3.135 0-5.186 1.641-5.206 4.346-2.07 1.816-3.369 4.766-3.369 7.734 0 5.303 3.428 8.819 8.575 8.819Zm0-14.237c1.728 0 3.437-.333 4.55-.83 1.211 1.26 2.5 3.476 2.5 6.25 0 4.374-2.822 7.294-7.05 7.294-4.23 0-7.051-2.92-7.051-7.295 0-2.763 1.279-4.97 2.51-6.25 1.113.498 2.822.83 4.54.83Zm-.674 13.144h1.279V10.538a.642.642 0 0 0-.645-.634.634.634 0 0 0-.634.635v11.308ZM7.949 12.12a1.24 1.24 0 0 0 1.23-1.24 1.23 1.23 0 0 0-1.23-1.23 1.23 1.23 0 0 0-1.22 1.23c0 .674.546 1.24 1.22 1.24Zm-1.162 3.868a1.436 1.436 0 0 0 0-2.871c-.8 0-1.445.644-1.445 1.435a1.44 1.44 0 0 0 1.445 1.436Zm1.162 3.34a1.138 1.138 0 1 0 .01-2.275 1.138 1.138 0 0 0-.01 2.274Zm6.24-7.207c.674 0 1.221-.567 1.221-1.24a1.23 1.23 0 0 0-1.22-1.231c-.684 0-1.231.556-1.231 1.23 0 .674.547 1.24 1.23 1.24Zm1.163 3.867c.79 0 1.445-.645 1.445-1.436 0-.79-.654-1.435-1.445-1.435-.782 0-1.436.644-1.436 1.435s.654 1.436 1.436 1.436Zm-1.162 3.34c.625 0 1.132-.508 1.132-1.133a1.138 1.138 0 1 0-1.133 1.133ZM6.768 1.407l.664.244c.42.146.586.37.507.722l-.117.489 1.436-.01.068-.498c.108-.947-.332-1.65-1.299-1.992L7.256.05c-.967-.332-1.426 1.084-.488 1.358Zm8.603 0c.938-.274.479-1.69-.488-1.358l-.772.313c-.966.341-1.406 1.045-1.299 1.992l.069.498 1.435.01-.117-.489c-.078-.351.088-.576.508-.722l.664-.244ZM4.981 8.195 3.163 6.652c-.361-.303-.83-.342-1.133.02-.293.35-.185.83.176 1.122l1.846 1.553.927-1.152Zm-1.778 4.61-2.402.009c-.489 0-.801.303-.801.742 0 .45.313.752.81.752l2.393-.01v-1.494Zm.791 5.712L2.168 20.05c-.352.293-.459.762-.166 1.123.303.362.762.323 1.133.02l1.797-1.524-.938-1.152ZM17.148 8.195l.938 1.152 1.846-1.553c.351-.293.468-.771.175-1.123-.302-.361-.771-.322-1.132-.02l-1.827 1.544Zm1.788 4.61v1.493l2.392.01c.488 0 .81-.303.81-.752 0-.44-.322-.742-.8-.742l-2.402-.01Zm-.801 5.712-.938 1.143 1.807 1.533c.361.302.83.341 1.133-.02.293-.361.185-.83-.176-1.123l-1.826-1.533Z'/%3e%3c/svg%3e")}.callout-icon .lucide-list{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='19' height='23' fill='none' viewBox='0 0 19 23'%3e%3cpath fill='black' d='M8.486 4.756c.127 0 .196-.078.215-.195.293-1.582.264-1.66 1.963-1.963.117-.03.195-.098.195-.225 0-.117-.078-.195-.195-.215-1.7-.303-1.67-.38-1.963-1.963C8.681.078 8.613 0 8.486 0s-.195.078-.215.195c-.292 1.582-.263 1.66-1.962 1.963-.127.02-.196.098-.196.215 0 .127.069.195.196.225 1.699.302 1.67.38 1.962 1.963.02.117.088.195.215.195ZM3.76 11.475a.324.324 0 0 0 .332-.303c.351-2.608.44-2.608 3.135-3.125.166-.03.293-.147.293-.332a.32.32 0 0 0-.293-.322c-2.696-.381-2.793-.47-3.135-3.116-.02-.185-.147-.312-.332-.312-.176 0-.303.127-.332.322-.313 2.608-.46 2.598-3.135 3.106-.166.029-.293.146-.293.322 0 .195.127.303.332.332 2.656.43 2.783.498 3.096 3.105.029.196.156.323.332.323Zm6.62 10.8c.255 0 .44-.185.49-.449.693-5.342 1.445-6.162 6.737-6.748.274-.03.46-.224.46-.488 0-.254-.186-.45-.46-.479-5.292-.586-6.044-1.406-6.738-6.757-.049-.264-.234-.44-.488-.44s-.44.176-.479.44c-.693 5.351-1.455 6.171-6.738 6.757-.283.03-.469.225-.469.479 0 .264.186.459.47.488 5.272.694 6.005 1.406 6.737 6.748.04.264.225.45.479.45Z'/%3e%3c/svg%3e")}.callout-icon .lucide-quote{-webkit-mask-image:url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='22' height='14' fill='none' viewBox='0 0 22 14'%3e%3cpath fill='black' d='M0 4.697c0 2.598 1.934 4.668 4.404 4.668A4.09 4.09 0 0 0 7.48 8.008h.264C7.178 9.854 5.46 11.396 3.33 12.03c-.312.098-.537.186-.674.303a.604.604 0 0 0-.234.508c0 .41.303.693.752.693.322 0 .547-.059.976-.195a8.532 8.532 0 0 0 3.496-2.197c1.31-1.368 2.12-3.194 2.12-5.362C9.766 2.12 7.44 0 4.716 0 2.032 0 0 2.05 0 4.697Zm11.729 0c0 2.598 1.923 4.668 4.404 4.668a4.105 4.105 0 0 0 3.076-1.357h.254c-.557 1.846-2.276 3.388-4.414 4.023-.313.098-.527.186-.664.303a.612.612 0 0 0-.244.508c0 .41.312.693.771.693.303 0 .537-.059.957-.195a8.372 8.372 0 0 0 3.486-2.197c1.329-1.368 2.14-3.194 2.14-5.362C21.494 2.12 19.17 0 16.444 0 13.76 0 11.73 2.05 11.73 4.697Z'/%3e%3c/svg%3e")}body:not(.is-mobile):not(.zoom-off) .markdown-preview-view .image-embed:not(.canvas-node-content,[alt=banner]) img,body:not(.is-mobile):not(.zoom-off) .markdown-preview-view img[referrerpolicy=no-referrer]:not([alt=banner]){cursor:zoom-in}body:not(.is-mobile):not(.zoom-off) .markdown-preview-view .image-embed:not(.canvas-node-content,[alt=banner]):active img,body:not(.is-mobile):not(.zoom-off) .markdown-preview-view img[referrerpolicy=no-referrer]:not([alt=banner]):active{position:fixed;z-index:1000;cursor:zoom-out;inset:0;background-color:var(--background-primary);width:100%;height:100%;max-height:unset;object-fit:contain;mask:none;padding:0;border-radius:0 !important;border:none}body{--cards-min-width: 160px;--cards-max-width: 1fr;--cards-mobile-width: 120px;--cards-image-height: 400px;--cards-image-fit: contain;--cards-background: transparent;--cards-background-hover: transparent;--cards-padding: 4px;--cards-aspect-ratio: auto;--cards-columns: repeat(auto-fit, minmax(var(--cards-min-width), var(--cards-max-width)))}@media(max-width: 400pt){body{--cards-min-width: var(--cards-mobile-width)}}.cards.table-100 table.dataview tbody,.table-100 .cards table.dataview tbody{padding:0 8px}.cards table.dataview.table-view-table tbody{clear:both;display:grid;grid-template-columns:var(--cards-columns);grid-column-gap:8px;grid-row-gap:8px;background-color:rgba(0,0,0,0)}.cards table.dataview.table-view-table>tbody>tr{background-color:var(--cards-background);border:var(--table-border-width) solid var(--background-modifier-border);display:flex;flex-direction:column;margin:0;padding:var(--cards-padding);border-radius:var(--radius-s);overflow:hidden;transition:var(--anim-duration-moderate) var(--anim-motion-baseline);max-width:var(--cards-max-width);height:auto}.cards table.dataview.table-view-table>tbody>tr:hover{background-color:var(--cards-background-hover)}.cards table.dataview.table-view-table tbody>tr>td{text-wrap:wrap}.cards table.dataview.table-view-table tbody>tr>td:first-child{font-weight:calc(var(--font-weight) + var(--bold-modifier))}.cards table.dataview.table-view-table tbody>tr>td:not(:first-child){font-size:var(--font-small);color:var(--text-muted)}.cards table.dataview.table-view-table tbody>tr>td>ul{width:100%;margin:0 auto !important}.cards table.dataview.table-view-table tbody>tr>td img{aspect-ratio:var(--cards-aspect-ratio);width:100%;object-fit:var(--cards-image-fit);max-height:var(--cards-image-height);background-color:var(--background-secondary);vertical-align:bottom}.markdown-source-view.mod-cm6.cards .dataview.table-view-table>tbody>tr>td,.trim-cols .cards table.dataview tbody>tr>td{white-space:normal}.links-int-on .cards table{--link-decoration: none}.cards.table-100 table.dataview thead>tr,.table-100 .cards table.dataview thead>tr{right:8px}.table-100 .cards table.dataview thead:before,.cards.table-100 table.dataview thead:before{margin-right:8px}.cards table.dataview thead{-webkit-user-select:none;user-select:none;width:160px;height:24px;float:right;position:relative}.cards table.dataview thead:after,.cards table.dataview thead:before{content:"";position:absolute;right:0;top:0;width:var(--icon-size);height:var(--icon-size)}.cards table.dataview thead:before{background-color:var(--text-faint);-webkit-mask-repeat:no-repeat;-webkit-mask-size:16px;-webkit-mask-position:center center;-webkit-mask-image:url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="currentColor" d="M49.792 33.125l-5.892 5.892L33.333 28.45V83.333H25V28.45L14.438 39.017L8.542 33.125L29.167 12.5l20.625 20.625zm41.667 33.75L70.833 87.5l-20.625 -20.625l5.892 -5.892l10.571 10.567L66.667 16.667h8.333v54.883l10.567 -10.567l5.892 5.892z"></path></svg>')}.cards table.dataview thead>tr{transition:var(--anim-duration-moderate) var(--anim-motion-baseline);position:absolute;z-index:1;border:1px solid var(--background-modifier-border-hover);background-color:var(--background-secondary);box-shadow:var(--shadow-s);padding:4px;border-radius:var(--radius-s);flex-direction:column;margin-top:24px;width:100%}.cards table.dataview thead:not(:hover)>tr{opacity:0;filter:blur(4px);transform:translateY(-8px);pointer-events:none}.cards table.dataview thead:hover>tr{display:flex}.cards table.dataview thead>tr>th{display:block;padding:6px 8px;border-radius:var(--radius-s);font-weight:var(--font-normal);color:var(--text-normal);font-size:var(--font-ui-small)}.list-cards.markdown-preview-view .list-bullet,.list-cards.markdown-preview-view .list-collapse-indicator,.list-cards.markdown-preview-view.markdown-rendered.show-indentation-guide li>ul::before{display:none}.list-cards.markdown-preview-view div>ul{display:grid;gap:8px;grid-template-columns:var(--cards-columns);padding:0;line-height:var(--line-height-tight)}.list-cards.markdown-preview-view div>ul>li.task-list-item>.task-list-item-checkbox{margin-inline-start:4px}.list-cards.markdown-preview-view div>ul>li{background-color:var(--cards-background);border-radius:var(--radius-s);border:var(--table-border-width) solid var(--background-modifier-border);overflow:hidden;padding:8px;margin-inline-start:0;transition:var(--anim-duration-moderate) var(--anim-motion-baseline)}.list-cards.markdown-preview-view div>ul>li:hover{background-color:var(--cards-background-hover)}.list-cards.markdown-preview-view div>ul .image-embed{padding:0;display:block}.list-cards.markdown-preview-view div>ul .image-embed img{aspect-ratio:var(--cards-aspect-ratio);object-fit:var(--cards-image-fit);max-height:var(--cards-image-height);background-color:var(--background-secondary);vertical-align:bottom}.list-cards.markdown-preview-view div>ul>li>a{--link-decoration: none;--link-external-decoration: none;font-weight:calc(var(--font-weight) + var(--bold-modifier))}.list-cards.markdown-preview-view div ul ul{display:block;width:100%;color:var(--text-muted);font-size:var(--font-smallest)}.list-cards.markdown-preview-view div ul ul>li{display:block;margin-inline-start:0}.cards.cards-16-9,.list-cards.cards-16-9{--cards-aspect-ratio: 16/9}.cards.cards-1-1,.list-cards.cards-1-1{--cards-aspect-ratio: 1/1}.cards.cards-2-1,.list-cards.cards-2-1{--cards-aspect-ratio: 2/1}.cards.cards-2-3,.list-cards.cards-2-3{--cards-aspect-ratio: 2/3}.cards.cards-cols-1,.list-cards.cards-cols-1{--cards-columns: repeat(1, minmax(0, 1fr))}.cards.cards-cols-2,.list-cards.cards-cols-2{--cards-columns: repeat(2, minmax(0, 1fr))}.cards.cards-cover,.list-cards.cards-cover{--cards-image-fit: cover}.cards.cards-cover tbody>tr>td:first-child,.list-cards.cards-cover tbody>tr>td:first-child{padding:0 !important;background-color:var(--background-secondary);display:block;margin:calc(var(--cards-padding)*-1) calc(var(--cards-padding)*-1) 0;width:calc(100% + var(--cards-padding)*2)}.cards.cards-cover tbody>tr>td:first-child img,.list-cards.cards-cover tbody>tr>td:first-child img{border-radius:0}.cards.cards-align-bottom table.dataview tbody>tr>td:last-child,.list-cards.cards-align-bottom table.dataview tbody>tr>td:last-child{margin-top:auto}@media(max-width: 400pt){.cards table.dataview tbody>tr>td:not(:first-child){font-size:80%}}@media(min-width: 400pt){.cards-cols-3{--cards-columns: repeat(3, minmax(0, 1fr))}.cards-cols-4{--cards-columns: repeat(4, minmax(0, 1fr))}.cards-cols-5{--cards-columns: repeat(5, minmax(0, 1fr))}.cards-cols-6{--cards-columns: repeat(6, minmax(0, 1fr))}.cards-cols-7{--cards-columns: repeat(7, minmax(0, 1fr))}.cards-cols-8{--cards-columns: repeat(8, minmax(0, 1fr))}}.table-small{--table-text-size: var(--font-smaller)}.table-tiny{--table-text-size: var(--font-smallest)}.row-hover{--table-row-background-hover: var(--background-modifier-hover);--table-row-alt-background-hover: var(--background-modifier-hover)}.row-alt{--table-row-alt-background: var(--background-primary);--table-row-alt-background-hover: var(--background-primary)}.col-alt .markdown-rendered:not(.cards){--table-column-alt-background: var(--background-primary)}.table-tabular table:not(.calendar){font-variant-numeric:tabular-nums}.table-center .markdown-preview-sizer table,.table-center .table-wrapper{margin:0 auto}.table-nowrap{--table-white-space: nowrap}.table-nowrap-first table thead>tr>th:first-child,.table-nowrap-first table tbody>tr>td:first-child{--table-white-space: nowrap}.trim-cols,.table-nowrap .table-wrap{--table-white-space: normal}.table-numbers table{counter-reset:section}.table-numbers table:not(.table-editor)>:is(thead,tbody)>tr>:is(th,td):first-child,.table-numbers table.table-editor>:is(thead,tbody)>tr>:is(th,td):first-child .table-cell-wrapper{position:relative;padding-left:3em}.table-numbers table:not(.table-editor) tbody>tr>td:first-child::before,.table-numbers table.table-editor tbody>tr>td:first-child .table-cell-wrapper::before{display:inline-block;position:absolute;top:.5em;left:.5em;counter-increment:section;min-width:2em;content:counter(section);color:var(--text-faint);font-variant-numeric:tabular-nums;text-align:center}.row-lines div:not(.el-table):not(.table-wrapper)>table>tbody>tr>td{border-bottom:var(--table-border-width) solid var(--table-border-color)}.row-lines div:not(.el-table):not(.table-wrapper)>table>tbody>tr:last-child>td{border-bottom:none}.col-lines div:not(.el-table):not(.table-wrapper)>table>tbody>tr>td{border-right:var(--table-border-width) solid var(--table-border-color)}.col-lines div:not(.el-table):not(.table-wrapper)>table>tbody>tr>td:last-child{border-right:none}.theme-light img[src$="#blend"],.theme-light div[src$="#blend"] img,.theme-light span[src$="#blend"] img{mix-blend-mode:multiply}.theme-light img[src$="#invertW"],.theme-light div[src$="#invertW"] img,.theme-light span[src$=invertW] img{filter:invert(1) hue-rotate(180deg)}.theme-light .img-blend{mix-blend-mode:multiply}.theme-dark div[src$="#invert"],.theme-dark div[src$="#blend"]{background-color:var(--background-primary)}.theme-dark img[src$="#invert"],.theme-dark div[src$="#invert"] img,.theme-dark span[src$="#invert"] img{filter:invert(1) hue-rotate(180deg);mix-blend-mode:screen}.theme-dark img[src$="#blend"],.theme-dark div[src$="#blend"] img,.theme-dark span[src$="#blend"] img{mix-blend-mode:screen}.theme-dark .img-blend{mix-blend-mode:screen}img[alt=left]:not(.emoji),span[alt=left] img:not(.emoji),span[alt=left] img:not(.emoji){display:block;justify-self:left}img[alt=center]:not(.emoji),span[alt=center] img:not(.emoji),span[alt=center] img:not(.emoji){display:block;justify-self:center}img[alt=right]:not(.emoji),span[alt=right] img:not(.emoji),span[alt=right] img:not(.emoji){display:block;justify-self:right}img[src$="#circle"]:not(.emoji),span[src$="#circle"] img:not(.emoji),span[src$="#round"] img:not(.emoji){border-radius:50% !important;aspect-ratio:1/1;object-fit:cover}img[src$="#outline"],div[src$="#outline"] img,span[src$="#outline"] img{border:1px solid var(--background-modifier-border)}img[src$="#interface"],span[src$="#interface"] img{border:1px solid var(--background-modifier-border);box-shadow:var(--shadow-l);border-radius:var(--radius-m)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile):not(.is-translucent).colorful-frame.theme-light .mod-sidedock.mod-left-split{background-color:color-mix(in srgb, #fff, var(--color-accent) 2%)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile):not(.is-translucent).colorful-frame.theme-dark .mod-sidedock.mod-left-split{background-color:color-mix(in srgb, var(--background-modifier-cover), var(--color-accent) 2%)}body.focus-view:not(.is-mobile):not(.is-popout-window) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root{--view-top-spacing-markdown: var(--header-height);--file-margins: calc(var(--file-margins-y) + var(--header-height)) var(--file-margins-y)}body.focus-view:not(.is-mobile):not(.is-popout-window) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root .workspace-tab-header-container{height:0;border-width:0px}body.focus-view:not(.is-mobile):not(.is-popout-window) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root .workspace-tab-header-container>div:not(.sidebar-toggle-button){opacity:0}body.focus-view:not(.is-mobile):not(.is-popout-window) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root .view-header{-webkit-app-region:drag;position:absolute;left:calc(var(--frame-left-space) + var(--tab-action-width));right:calc(var(--frame-right-space) + var(--tab-action-width));background-color:rgba(0,0,0,0);transition:var(--anim-duration-fast)}body.focus-view:not(.is-mobile):not(.is-popout-window) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root .view-header:not(:hover){opacity:.5}body.focus-view:not(.is-mobile):not(.is-popout-window) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root .workspace-leaf-content:not([data-type=markdown])>.view-content{margin-top:var(--header-height)}body.focus-view:not(.is-mobile):not(.is-popout-window) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root .sidebar-toggle-button{position:absolute;height:var(--header-height);z-index:1}body.focus-view:not(.is-mobile):not(.is-popout-window) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root .sidebar-toggle-button.mod-left{left:calc(var(--frame-left-space) + 8px)}body.focus-view:not(.is-mobile):not(.is-popout-window) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root .sidebar-toggle-button.mod-right{right:calc(var(--frame-right-space) + 8px)}body.focus-view:not(.is-mobile):not(.is-popout-window) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root .sidebar-toggle-button:not(:hover){opacity:.5}body.focus-view.mod-macos:not(.is-mobile):not(.is-popout-window):not(.is-hidden-frameless) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root{--frame-left-space: 0px}body.focus-view:not(.mod-macos):not(.is-mobile):not(.is-popout-window):not(.is-hidden-frameless) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root{--frame-right-space: 0px}body:not(.is-mobile){--hover-sidedock-width: 320px;--hover-sidedock-delay: 160ms;--hover-sidedock-trigger-area: 4px}body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed.mod-left-split:hover+.mod-root div:is(.workspace-tab-header-container,.workspace-tab-header-container-inner),body:not(.is-mobile).hover-sidedock .mod-root:has(+.mod-sidedock.is-sidedock-collapsed.mod-right-split:hover) div:is(.workspace-tab-header-container,.workspace-tab-header-container-inner),body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed div:is(.workspace-tab-header-container,.workspace-tab-header-container-inner),body:not(.is-mobile).hover-ribbon .workspace-ribbon.mod-left:hover~.mod-root div:is(.workspace-tab-header-container,.workspace-tab-header-container-inner){-webkit-app-region:no-drag}body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display]{display:flex !important;position:absolute;opacity:0;z-index:11;background-color:rgba(0,0,0,0);width:var(--hover-sidedock-width) !important}body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display] .workspace-tabs{visibility:visible}body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display].mod-left-split{transform:translateX(calc(-1 * (var(--hover-sidedock-width) - var(--hover-sidedock-trigger-area))))}body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display].mod-right-split{transform:translateX(calc(var(--hover-sidedock-width) - var(--hover-sidedock-trigger-area)))}body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display].mod-left-split,body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display].mod-left-split::before{right:auto;left:0}body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display].mod-right-split,body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display].mod-right-split::before{right:0;left:auto}body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display]::before{position:absolute;z-index:0;transition:var(--anim-duration-moderate);inset-block:0;width:150%;content:"";pointer-events:none}body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display].mod-left-split::before{background:linear-gradient(to right, var(--background-primary) 50%, transparent)}body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display].mod-right-split::before{background:linear-gradient(to left, var(--background-primary) 50%, transparent)}body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display]:hover,body:not(.is-mobile).hover-sidedock.hover-ribbon .workspace-ribbon.mod-left.is-collapsed:hover+.mod-sidedock,body:not(.is-mobile).hover-sidedock:not(.hover-sidedock-active-off)>.app-container>.horizontal-main-container>.workspace>.mod-sidedock:has(>.workspace-tabs.mod-active){transition-delay:var(--hover-sidedock-delay);transform:none;opacity:1}body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display]:hover::before,body:not(.is-mobile).hover-sidedock.hover-ribbon .workspace-ribbon.mod-left.is-collapsed:hover+.mod-sidedock::before,body:not(.is-mobile).hover-sidedock:not(.hover-sidedock-active-off)>.app-container>.horizontal-main-container>.workspace>.mod-sidedock:has(>.workspace-tabs.mod-active)::before{opacity:1}body:not(.is-mobile).hover-ribbon.show-ribbon .workspace-ribbon.mod-left{position:absolute;z-index:12;height:-webkit-fill-available;opacity:0;transform:translateX(calc(-1 * var(--ribbon-width) + var(--hover-sidedock-trigger-area)));background-color:rgba(0,0,0,0)}body:not(.is-mobile).hover-ribbon.show-ribbon .workspace-ribbon.mod-left:hover{opacity:1;transform:none}body:not(.is-mobile).hover-ribbon.show-ribbon .workspace-ribbon.mod-left:hover+.mod-sidedock{padding-left:calc(var(--ribbon-width) - 8px)}body:not(.is-mobile).hover-ribbon.show-ribbon .workspace-ribbon.mod-left.is-collapsed:hover,body:not(.is-mobile).hover-ribbon.show-ribbon .workspace-ribbon.mod-left.is-collapsed:hover+.mod-sidedock{transition-delay:var(--hover-sidedock-delay) !important}body:not(.is-mobile).hover-ribbon.show-ribbon.hover-sidedock .workspace-ribbon.mod-left.is-collapsed{z-index:13}body:not(.is-mobile).hover-ribbon.show-ribbon.mod-macos:not(.is-fullscreen).is-hidden-frameless .mod-sidedock.mod-left-split .mod-top-left-space .workspace-tab-header-container{transition-timing-function:ease}body:not(.is-mobile).hover-ribbon.show-ribbon.mod-macos:not(.is-fullscreen).is-hidden-frameless .workspace-ribbon.mod-left:not(.is-collapsed):hover~.mod-sidedock.mod-left-split .mod-top-left-space .workspace-tab-header-container{padding-left:52px}body:not(.is-mobile).hover-ribbon.show-ribbon.mod-macos:not(.is-fullscreen).is-hidden-frameless .workspace-ribbon.mod-left:not(.is-collapsed):not(:hover)~.mod-sidedock.mod-left-split .mod-top-left-space .workspace-tab-header-container,body:not(.is-mobile).hover-ribbon.show-ribbon.mod-macos:not(.is-fullscreen).is-hidden-frameless .workspace-ribbon.mod-left.is-collapsed~.mod-root>div:first-of-type .workspace-tab-header-container{padding-left:88px}body.mod-windows:not(.adaptive-mode-off) .nav-files-container>div{--nav-item-background-active: var(--background-modifier-hover);--nav-item-color-active: var(--nav-item-color)}body.mod-windows:not(.adaptive-mode-off) .nav-files-container>div .tree-item-self.is-active::before{position:absolute;top:8px;bottom:8px;left:0;margin-left:0;border-radius:var(--button-radius);background-color:var(--interactive-accent);width:4px;height:auto;content:""}body.is-android:not(.adaptive-mode-off) .nav-files-container>div{--nav-item-background-active: var(--background-primary);--nav-item-background-selected: var(--background-primary);--nav-item-color-active: var(--text-normal)}body:is(.mod-macos,.adaptive-mode-off):not(.is-mobile) .nav-files-container>div{--nav-item-background-hover: transparent;--nav-item-background-active: var(--background-modifier-hover);--nav-item-color: var(--text-normal);--nav-item-color-hover: var(--text-normal);--nav-item-color-active: var(--text-accent)}body.mod-linux:not(.is-android):not(.adaptive-mode-off){--background-modifier-border: color-mix(in srgb, var(--background-secondary), var(--text-normal) 15%);--interactive-normal: color-mix(in srgb, var(--background-secondary), var(--text-normal) 10%);--interactive-hover: color-mix(in srgb, var(--background-secondary), var(--text-normal) 15%);--menu-border-color: color-mix(in srgb, var(--background-secondary), var(--text-normal) 10%)}body.mod-linux:not(.is-android):not(.adaptive-mode-off).theme-light{--color-red-rgb: 237, 51, 59;--color-orange-rgb: 255, 120, 0;--color-yellow-rgb: 246, 211, 45;--color-green-rgb: 46, 194, 126;--color-cyan-rgb: 35, 164, 173;--color-blue-rgb: 98, 160, 234;--color-purple-rgb: 192, 97, 203;--color-pink-rgb: 224, 97, 178;--color-base-00: #ffffff;--color-base-05: #fdfdfc;--color-base-10: #fbfafa;--color-base-20: #f6f5f4;--color-base-25: #eeedeb;--color-base-30: #e6e5e3;--color-base-35: #deddda;--color-base-40: #c0bfbc;--color-base-50: #9a9996;--color-base-60: #77767b;--color-base-70: #5e5c64;--color-base-100: #000000;--mono-rgb-adwaita: 0, 0, 6;--background-primary: #fff;--background-primary-alt: #fff;--background-secondary: #ebebed;--background-secondary-alt: #f3f3f5;--text-normal: #333338;--text-muted: #5c5c60;--text-faint: #858587;--menu-background: #fff;--modal-background: #fafafb;--code-background: var(--background-secondary-alt);--blockquote-background-color: var(--background-secondary-alt);--embed-background-color: var(--background-secondary-alt)}body.mod-linux:not(.is-android):not(.adaptive-mode-off).theme-light:not(.is-focused){--background-secondary: #f2f2f4}body.mod-linux:not(.is-android):not(.adaptive-mode-off).theme-dark{--color-red-rgb: 224, 27, 36;--color-orange-rgb: 230, 97, 0;--color-yellow-rgb: 245, 194, 17;--color-green-rgb: 38, 162, 105;--color-cyan-rgb: 33, 144, 164;--color-blue-rgb: 53, 132, 228;--color-purple-rgb: 145, 65, 172;--color-pink-rgb: 213, 97, 170;--color-base-00: #000000;--color-base-05: #121019;--color-base-10: #241f31;--color-base-20: #3d3846;--color-base-25: #4e4a55;--color-base-30: #5e5c64;--color-base-35: #6b6970;--color-base-40: #77767b;--color-base-50: #9a9996;--color-base-60: #c0bfbc;--color-base-70: #e6e5e3;--color-base-100: #ffffff;--mono-rgb-adwaita: 255, 255, 255;--background-primary: #1d1d20;--background-primary-alt: #2e2e32;--background-secondary: #2e2e32;--background-secondary-alt: #28282c;--text-normal: #fff;--text-muted: #d2d2d2;--text-faint: #99999b;--menu-background: #36363a;--modal-background: #222226}body.mod-linux:not(.is-android):not(.adaptive-mode-off).theme-dark:not(.is-focused){--background-secondary: #28282c}body:is(.mod-macos,.adaptive-mode-off).theme-light{--color-red-rgb: 255, 56, 60;--color-orange-rgb: 255, 141, 40;--color-yellow-rgb: 255, 204, 0;--color-green-rgb: 52, 199, 89;--color-cyan-rgb: 0, 192, 232;--color-blue-rgb: 0, 136, 255;--color-purple-rgb: 203, 48, 224;--color-pink-rgb: 255, 45, 85}body:is(.mod-macos,.adaptive-mode-off).theme-light:not(.is-mobile){--background-primary: #fff;--background-primary-alt: color-mix(in srgb, var(--background-primary), black 3%);--background-secondary: color-mix(in srgb, var(--background-primary), black 5%);--background-secondary-alt: color-mix(in srgb, var(--background-primary), black 8%);--interactive-normal: hsl(0 0% 0% / 5%);--interactive-hover: hsl(0 0% 0% / 5%);--text-normal: #262626;--text-muted: #737373;--text-faint: #bfbfbf}body:is(.mod-macos,.adaptive-mode-off).theme-light.is-mobile{--background-primary: #fff;--background-primary-alt: #f2f2f7;--background-secondary: #f2f2f7;--background-secondary-alt: #fff;--interactive-normal: rgba(118, 118, 128, 12%);--interactive-hover: rgba(120, 120, 120, 20%);--text-normal: #000;--text-muted: #8a8a8e;--text-faint: #c4c4c7}body:is(.mod-macos,.adaptive-mode-off).theme-dark{--color-red-rgb: 255, 66, 69;--color-orange-rgb: 255, 146, 48;--color-yellow-rgb: 255, 214, 0;--color-green-rgb: 48, 209, 88;--color-cyan-rgb: 60, 211, 254;--color-blue-rgb: 0, 145, 255;--color-purple-rgb: 107, 52, 242;--color-pink-rgb: 255, 55, 95}body:is(.mod-macos,.adaptive-mode-off).theme-dark:not(.is-mobile){--background-primary: #1e1e1e;--background-primary-alt: color-mix(in srgb, var(--background-primary), white 3%);--background-secondary: color-mix(in srgb, var(--background-primary), white 5%);--background-secondary-alt: color-mix(in srgb, var(--background-primary), white 8%);--interactive-normal: hsl(0 0% 100% / 5%);--interactive-hover: hsl(0 0% 100% / 5%);--text-normal: #dddddd;--text-muted: #9a9a9a;--text-faint: #565656}body:is(.mod-macos,.adaptive-mode-off).theme-dark.is-mobile{--background-primary: #000;--background-primary-alt: #1c1c1e;--background-secondary: #1c1c1e;--background-secondary-alt: #2c2c2e;--interactive-normal: rgba(118, 118, 128, 24%);--interactive-hover: rgba(120, 120, 120, 36%);--text-normal: #fff;--text-muted: #8d8d93;--text-faint: #47474a}body.is-android:not(.adaptive-mode-off).material-color .modal:where(.mod-settings) .vertical-tab-nav-item .vertical-tab-nav-item-icon{--setting-nav-icon-background: var(--neutral-60);background-color:var(--setting-nav-icon-background)}body.is-android:not(.adaptive-mode-off).material-color{--secondary-0: oklch(from hsl(var(--color-accent-hsl)) 0 0.07 h);--secondary-10: oklch(from hsl(var(--color-accent-hsl)) 0.17 0.07 h);--secondary-20: oklch(from hsl(var(--color-accent-hsl)) 0.29 0.07 h);--secondary-30: oklch(from hsl(var(--color-accent-hsl)) 0.41 0.07 h);--secondary-40: oklch(from hsl(var(--color-accent-hsl)) 0.53 0.07 h);--secondary-50: oklch(from hsl(var(--color-accent-hsl)) 0.64 0.07 h);--secondary-60: oklch(from hsl(var(--color-accent-hsl)) 0.73 0.07 h);--secondary-70: oklch(from hsl(var(--color-accent-hsl)) 0.81 0.07 h);--secondary-80: oklch(from hsl(var(--color-accent-hsl)) 0.87 0.07 h);--secondary-90: oklch(from hsl(var(--color-accent-hsl)) 0.93 0.07 h);--secondary-95: oklch(from hsl(var(--color-accent-hsl)) 0.96 0.06 h);--secondary-99: oklch(from hsl(var(--color-accent-hsl)) 0.99 0.04 h);--secondary-100: oklch(from hsl(var(--color-accent-hsl)) 1 0.02 h);--tertiary-0: oklch(from hsl(var(--color-accent-hsl)) 0 0.1 calc(h + 60));--tertiary-10: oklch(from hsl(var(--color-accent-hsl)) 0.17 0.1 calc(h + 60));--tertiary-20: oklch(from hsl(var(--color-accent-hsl)) 0.29 0.1 calc(h + 60));--tertiary-30: oklch(from hsl(var(--color-accent-hsl)) 0.41 0.1 calc(h + 60));--tertiary-40: oklch(from hsl(var(--color-accent-hsl)) 0.53 0.1 calc(h + 60));--tertiary-50: oklch(from hsl(var(--color-accent-hsl)) 0.64 0.1 calc(h + 60));--tertiary-60: oklch(from hsl(var(--color-accent-hsl)) 0.73 0.1 calc(h + 60));--tertiary-70: oklch(from hsl(var(--color-accent-hsl)) 0.81 0.1 calc(h + 60));--tertiary-80: oklch(from hsl(var(--color-accent-hsl)) 0.87 0.1 calc(h + 60));--tertiary-90: oklch(from hsl(var(--color-accent-hsl)) 0.93 0.1 calc(h + 60));--tertiary-95: oklch(from hsl(var(--color-accent-hsl)) 0.96 0.06 calc(h + 60));--tertiary-99: oklch(from hsl(var(--color-accent-hsl)) 0.99 0.04 calc(h + 60));--tertiary-100: oklch(from hsl(var(--color-accent-hsl)) 1 0.02 calc(h + 60));--neutral-0: oklch(from hsl(var(--color-accent-hsl)) 0 0.035 h);--neutral-4: oklch(from hsl(var(--color-accent-hsl)) 0.06 0.035 h);--neutral-6: oklch(from hsl(var(--color-accent-hsl)) 0.1 0.035 h);--neutral-10: oklch(from hsl(var(--color-accent-hsl)) 0.17 0.035 h);--neutral-12: oklch(from hsl(var(--color-accent-hsl)) 0.19 0.035 h);--neutral-17: oklch(from hsl(var(--color-accent-hsl)) 0.25 0.035 h);--neutral-20: oklch(from hsl(var(--color-accent-hsl)) 0.29 0.035 h);--neutral-22: oklch(from hsl(var(--color-accent-hsl)) 0.31 0.035 h);--neutral-24: oklch(from hsl(var(--color-accent-hsl)) 0.33 0.035 h);--neutral-30: oklch(from hsl(var(--color-accent-hsl)) 0.41 0.035 h);--neutral-40: oklch(from hsl(var(--color-accent-hsl)) 0.53 0.035 h);--neutral-50: oklch(from hsl(var(--color-accent-hsl)) 0.64 0.035 h);--neutral-60: oklch(from hsl(var(--color-accent-hsl)) 0.73 0.035 h);--neutral-70: oklch(from hsl(var(--color-accent-hsl)) 0.81 0.035 h);--neutral-80: oklch(from hsl(var(--color-accent-hsl)) 0.87 0.035 h);--neutral-87: oklch(from hsl(var(--color-accent-hsl)) 0.89 0.035 h);--neutral-90: oklch(from hsl(var(--color-accent-hsl)) 0.93 0.035 h);--neutral-92: oklch(from hsl(var(--color-accent-hsl)) 0.94 0.035 h);--neutral-94: oklch(from hsl(var(--color-accent-hsl)) 0.95 0.035 h);--neutral-95: oklch(from hsl(var(--color-accent-hsl)) 0.96 0.035 h);--neutral-96: oklch(from hsl(var(--color-accent-hsl)) 0.97 0.035 h);--neutral-98: oklch(from hsl(var(--color-accent-hsl)) 0.98 0.026 h);--neutral-99: oklch(from hsl(var(--color-accent-hsl)) 0.99 0.016 h);--neutral-100: oklch(from hsl(var(--color-accent-hsl)) 1 0.012 h);--neutral-variant-0: oklch(from hsl(var(--color-accent-hsl)) 0 0.04 h);--neutral-variant-10: oklch(from hsl(var(--color-accent-hsl)) 0.17 0.037 h);--neutral-variant-20: oklch(from hsl(var(--color-accent-hsl)) 0.29 0.037 h);--neutral-variant-30: oklch(from hsl(var(--color-accent-hsl)) 0.41 0.037 h);--neutral-variant-40: oklch(from hsl(var(--color-accent-hsl)) 0.53 0.037 h);--neutral-variant-50: oklch(from hsl(var(--color-accent-hsl)) 0.64 0.037 h);--neutral-variant-60: oklch(from hsl(var(--color-accent-hsl)) 0.73 0.037 h);--neutral-variant-70: oklch(from hsl(var(--color-accent-hsl)) 0.81 0.037 h);--neutral-variant-80: oklch(from hsl(var(--color-accent-hsl)) 0.87 0.037 h);--neutral-variant-90: oklch(from hsl(var(--color-accent-hsl)) 0.93 0.037 h);--neutral-variant-95: oklch(from hsl(var(--color-accent-hsl)) 0.96 0.026 h);--neutral-variant-99: oklch(from hsl(var(--color-accent-hsl)) 0.99 0.02 h);--neutral-variant-100: oklch(from hsl(var(--color-accent-hsl)) 1 0.01 h)}body.is-android:not(.adaptive-mode-off).theme-light.material-color .checkbox-container{--interactive-accent: var(--color-base-50);--text-muted: var(--neutral-30)}body.is-android:not(.adaptive-mode-off).theme-light.material-color.is-phone .mobile-navbar{background-color:var(--secondary-95) !important}body.is-android:not(.adaptive-mode-off).theme-light.material-color.is-phone .mobile-navbar-action{--icon-color: var(--secondary-30)}body.is-android:not(.adaptive-mode-off).theme-light.material-color.is-phone:not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2){background-color:var(--tertiary-95);color:var(--tertiary-30)}body.is-android:not(.adaptive-mode-off).theme-light.material-color{--color-red: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-red-rgb))) max(l, 0.82) min(c, 0.12) h);--color-orange: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-orange-rgb))) max(l, 0.82) min(c, 0.12) h);--color-yellow: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-yellow-rgb))) max(l, 0.82) min(c, 0.12) h);--color-green: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-green-rgb))) max(l, 0.82) min(c, 0.12) h);--color-cyan: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-cyan-rgb))) max(l, 0.82) min(c, 0.12) h);--color-blue: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-blue-rgb))) max(l, 0.82) min(c, 0.12) h);--color-purple: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-purple-rgb))) max(l, 0.82) min(c, 0.12) h);--color-pink: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-pink-rgb))) max(l, 0.82) min(c, 0.12) h);--color-base-00: oklch(from hsl(var(--color-accent-hsl)) 1 0.04 h);--color-base-05: oklch(from hsl(var(--color-accent-hsl)) 0.99 0.08 h);--color-base-10: oklch(from hsl(var(--color-accent-hsl)) 0.96 0.12 h);--color-base-20: oklch(from hsl(var(--color-accent-hsl)) 0.93 0.14 h);--color-base-25: oklch(from hsl(var(--color-accent-hsl)) 0.87 0.14 h);--color-base-30: oklch(from hsl(var(--color-accent-hsl)) 0.81 0.14 h);--color-base-35: oklch(from hsl(var(--color-accent-hsl)) 0.73 0.14 h);--color-base-40: oklch(from hsl(var(--color-accent-hsl)) 0.64 0.14 h);--color-base-50: oklch(from hsl(var(--color-accent-hsl)) 0.53 0.14 h);--color-base-60: oklch(from hsl(var(--color-accent-hsl)) 0.41 0.14 h);--color-base-70: oklch(from hsl(var(--color-accent-hsl)) 0.29 0.14 h);--color-base-100: oklch(from hsl(var(--color-accent-hsl)) 0.17 0.14 h);--text-muted: var(--neutral-40);--text-faint: var(--neutral-60);--text-accent: var(--color-base-50);--background-primary: var(--neutral-98);--background-primary-alt: var(--neutral-100);--background-secondary: var(--neutral-94);--background-secondary-alt: var(--neutral-96);--interactive-normal: var(--background-primary);--interactive-hover: var(--background-secondary);--interactive-accent: var(--tertiary-40);--interactive-accent-hover: oklch(from var(--tertiary-40) calc(l + 0.05) c h);--text-on-accent: var(--tertiary-100);--text-on-accent-inverted: var(--tertiary-100);--background-modifier-form-field: var(--neutral-90);--background-modifier-border: var(--neutral-variant-80);--background-modifier-border-hover: var(--neutral-variant-70);--background-modifier-border-focus: var(--neutral-variant-50);--tag-background: var(--secondary-95);--tag-color: var(--secondary-30)}body.is-android:not(.adaptive-mode-off).theme-dark.material-color .checkbox-container{--interactive-accent: var(--color-base-30);--text-muted: var(--neutral-60)}body.is-android:not(.adaptive-mode-off).theme-dark.material-color.is-phone .mobile-navbar{background-color:var(--secondary-20) !important}body.is-android:not(.adaptive-mode-off).theme-dark.material-color.is-phone .mobile-navbar-action{--icon-color: var(--secondary-80)}body.is-android:not(.adaptive-mode-off).theme-dark.material-color.is-phone:not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2){background-color:var(--tertiary-20);color:var(--tertiary-80)}body.is-android:not(.adaptive-mode-off).theme-dark.material-color{--color-accent: oklch(from hsl(var(--color-accent-hsl)) min(l, 0.82) min(c, 0.12) h);--color-accent-1: oklch(from hsl(calc(var(--accent-h) - 3), calc(var(--accent-s) * 1.02), calc(var(--accent-l) * 1.15)) min(l, 0.82) min(c, 0.12) h);--color-accent-2: oklch(from hsl(calc(var(--accent-h) - 5), calc(var(--accent-s) * 1.05), calc(var(--accent-l) * 1.29)) min(l, 0.82) min(c, 0.12) h);--color-red: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-red-rgb))) min(l, 0.82) min(c, 0.12) h);--color-orange: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-orange-rgb))) min(l, 0.82) min(c, 0.12) h);--color-yellow: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-yellow-rgb))) min(l, 0.82) min(c, 0.12) h);--color-green: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-green-rgb))) min(l, 0.82) min(c, 0.12) h);--color-cyan: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-cyan-rgb))) min(l, 0.82) min(c, 0.12) h);--color-blue: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-blue-rgb))) min(l, 0.82) min(c, 0.12) h);--color-purple: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-purple-rgb))) min(l, 0.82) min(c, 0.12) h);--color-pink: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-pink-rgb))) min(l, 0.82) min(c, 0.12) h);--color-base-00: oklch(from hsl(var(--color-accent-hsl)) 0 0.11 h);--color-base-05: oklch(from hsl(var(--color-accent-hsl)) 0.17 0.11 h);--color-base-10: oklch(from hsl(var(--color-accent-hsl)) 0.29 0.11 h);--color-base-20: oklch(from hsl(var(--color-accent-hsl)) 0.41 0.11 h);--color-base-25: oklch(from hsl(var(--color-accent-hsl)) 0.53 0.11 h);--color-base-30: oklch(from hsl(var(--color-accent-hsl)) 0.64 0.11 h);--color-base-35: oklch(from hsl(var(--color-accent-hsl)) 0.73 0.11 h);--color-base-40: oklch(from hsl(var(--color-accent-hsl)) 0.81 0.11 h);--color-base-50: oklch(from hsl(var(--color-accent-hsl)) 0.87 0.11 h);--color-base-60: oklch(from hsl(var(--color-accent-hsl)) 0.93 0.11 h);--color-base-70: oklch(from hsl(var(--color-accent-hsl)) 0.96 0.09 h);--color-base-100: oklch(from hsl(var(--color-accent-hsl)) 0.99 0.06 h);--text-muted: var(--neutral-60);--text-faint: var(--neutral-40);--background-primary: var(--neutral-10);--background-primary-alt: var(--neutral-17);--background-secondary: var(--neutral-17);--background-secondary-alt: var(--neutral-20);--interactive-normal: var(--background-primary);--interactive-hover: var(--background-secondary);--interactive-accent: var(--tertiary-60);--interactive-accent-hover: oklch(from var(--tertiary-80) calc(l + 0.05) c h);--text-on-accent: var(--tertiary-20);--text-on-accent-inverted: var(--tertiary-20);--background-modifier-form-field: var(--neutral-22);--background-modifier-border: var(--neutral-variant-30);--background-modifier-border-hover: var(--neutral-variant-40);--background-modifier-border-focus: var(--neutral-variant-60);--tag-background: var(--secondary-20);--tag-color: var(--secondary-80)}
+*/
+.view-content .style-settings-container .style-settings-container .setting-item {
+  align-items: center;
+  padding: 16px;
+}
+.view-content .style-settings-container .style-settings-container .setting-item:not(.setting-item-heading) {
+  flex-direction: row;
+}
+.view-content .style-settings-container .style-settings-container .setting-item .setting-item-control {
+  padding-top: 0;
+}
+
+.style-settings-heading:not(.is-collapsed) {
+  border-bottom: none;
+}
+
+.style-settings-heading,
+.style-settings-container {
+  margin-block: 0 !important;
+  padding-left: 32px;
+}
+
+.style-settings-heading {
+  border-radius: 0;
+  padding: 16px !important;
+}
+
+.style-settings-heading .setting-item-name {
+  color: var(--text-normal) !important;
+}
+
+.style-settings-container .setting-item {
+  margin-bottom: 0;
+  border-radius: 0;
+  gap: 4px !important;
+}
+
+.style-settings-container .setting-item-description > div:last-child {
+  display: none;
+}
+
+.style-settings-container .setting-item:not(.style-settings-heading) > .setting-item-control {
+  min-height: var(--input-height);
+}
+
+.style-settings-container .setting-item:nth-child(1 of .setting-item:not(.setting-item-heading)) {
+  border-top-right-radius: var(--setting-items-radius);
+  border-top-left-radius: var(--setting-items-radius);
+}
+
+.style-settings-container .setting-item:nth-last-child(1 of .setting-item:not(.setting-item-heading)) {
+  border-bottom-right-radius: var(--setting-items-radius);
+  border-bottom-left-radius: var(--setting-items-radius);
+}
+
+body:not(.mod-macos, .adaptive-mode-off) .setting-item[data-id=colorful-frame],
+body:not(.is-android:not(.adaptive-mode-off)) .setting-item[data-id=material-color] {
+  display: none;
+}
+
+@media screen, print {
+  body {
+    --heading-spacing: 2em;
+    --p-spacing: 1.75rem;
+    --line-height-normal: 1.6;
+    --list-spacing: 0.175em;
+    --inline-title-margin-bottom: calc(0.5em * var(--readable-spacing-modifier, 1));
+    --inline-title-color: inherit;
+    --h1-size: 1.5em;
+    --h2-size: 1.25em;
+    --h3-size: 1.125em;
+    --h4-size: 1em;
+    --h5-size: 1em;
+    --h6-size: 0.875em;
+    --file-margins-y: 32px;
+    --file-margins-x: 32px;
+    --file-margins: var(--file-margins-y) var(--file-margins-x);
+    --code-border-width: 1px;
+    --code-size: var(--font-smallest);
+    --embed-padding: 16px;
+    --embed-max-height: none;
+    --embed-background: var(--background-primary-alt);
+    --embed-border-start: var(--embed-border-thickness, 2px) solid var(--embed-border-color, var(--color-base-50));
+    --media-radius: var(--radius-s);
+    --checkbox-radius: 100px;
+    --metadata-gap: 8px;
+    --tag-padding-x: 8px;
+    --tag-padding-y: 4px;
+    --tag-radius: 8px;
+    --tag-weight: var(--font-medium);
+    --indentation-guide-width: 0px;
+    --file-header-border: none;
+  }
+  body:is(.mod-macos, .adaptive-mode-off):not(.font-variant-off) .markdown-reading-view,
+  body:is(.mod-macos, .adaptive-mode-off):not(.font-variant-off) .markdown-source-view {
+    font-feature-settings: "ss01" 1, "ss07" 1, "cv07" 1;
+  }
+  .workspace-split.mod-root .workspace-tab-container {
+    border-radius: var(--tab-radius);
+    transition: var(--anim-duration-moderate);
+    overflow: hidden;
+  }
+  body:not(.mod-macos, .adaptive-mode-off):not(.is-phone) .workspace-split.mod-vertical {
+    gap: 8px;
+  }
+  body:not(.mod-macos, .adaptive-mode-off):not(.is-phone) .workspace-split:not(.mod-sidedock) > * > .workspace-leaf-resize-handle:not(:hover) {
+    border-color: transparent;
+  }
+  .markdown-preview-view,
+  .markdown-source-view {
+    color: var(--text-normal-editor, var(--text-normal));
+  }
+  .view-header {
+    padding: 0 8px;
+    flex-shrink: 0;
+  }
+  .view-header-nav-buttons,
+  .view-actions {
+    --icon-size: var(--icon-m);
+    --icon-stroke: var(--icon-m-stroke-width);
+    gap: 0 !important;
+  }
+  .view-header-title-container {
+    height: auto !important;
+  }
+  .view-header-title-container > div {
+    transition: var(--anim-duration-moderate) var(--anim-motion-baseline);
+  }
+  .view-header-title-parent {
+    color: var(--text-faint);
+  }
+  .view-header-title {
+    font-weight: max(var(--file-header-font-weight), var(--font-medium));
+  }
+  .view-header:not(.view-header-always-show):not(:hover) .view-header-title-container > div:not(:focus-within) {
+    opacity: 0 !important;
+  }
+  body.is-phone .view-header-title {
+    font-size: inherit;
+  }
+  .document-search-buttons,
+  .document-replace-buttons {
+    flex-grow: 0 !important;
+  }
+  body:not(.active-line-off) .view-content > .markdown-source-view .cm-line.cm-active:not(:has(.cm-fold-indicator):hover)::before {
+    position: absolute;
+    top: 4px;
+    bottom: 4px;
+    inset-inline-start: -16px;
+    border-left: 4px solid var(--background-modifier-border-hover);
+    border-radius: var(--input-radius);
+    content: "";
+  }
+  .markdown-rendered pre {
+    corner-shape: var(--corner-shape);
+  }
+  .markdown-rendered code {
+    corner-shape: var(--corner-shape);
+    padding: 2px 4px;
+  }
+  .markdown-rendered pre code {
+    white-space: var(--code-white-space);
+  }
+  body:is(.mod-macos, .adaptive-mode-off) .markdown-rendered pre {
+    background: linear-gradient(var(--background-primary-alt), var(--background-secondary));
+    box-shadow: var(--shadow-tactile);
+  }
+  kbd {
+    box-shadow: var(--shadow-tactile);
+    border: 1px solid var(--background-modifier-border);
+    background-color: var(--background-secondary);
+    padding: var(--tag-padding-y) var(--tag-padding-x);
+    font-family: var(--font-text);
+    color: var(--text-muted);
+  }
+  .dataview .inline-field-standalone-value,
+  .dataview.inline-field-key,
+  .dataview.inline-field-value {
+    font-family: var(--font-text);
+    font-size: var(--font-smaller);
+    background: transparent;
+    color: var(--text-faint);
+    padding-inline: 2px;
+  }
+  .embed-strict {
+    --embed-border-start: none;
+    --embed-background: transparent;
+    --embed-padding: 0;
+  }
+  .embed-hide-title .embed-title,
+  .embed-title:empty {
+    display: none;
+  }
+  .markdown-embed {
+    corner-shape: var(--corner-shape);
+  }
+  .markdown-embed:not(.image-embed, .canvas-node-content) {
+    display: flex;
+    flex-direction: column;
+    max-height: var(--embed-max-height);
+    overflow: hidden;
+    border-start-end-radius: var(--media-radius);
+    border-end-end-radius: var(--media-radius);
+  }
+  .inline-embed > .markdown-embed-title {
+    padding-bottom: var(--inline-title-margin-bottom);
+  }
+  .inline-embed > .markdown-embed-content {
+    max-height: 100%;
+  }
+  .block-language-chart {
+    width: 100% !important;
+  }
+  body:not(.is-mobile) .inline-title:not([data-level]) {
+    position: relative;
+  }
+  body:not(.is-mobile) .inline-title:not([data-level])::before {
+    content: "";
+    position: absolute;
+    inset: -8px;
+    border-radius: var(--radius-s);
+    pointer-events: none;
+    transition: var(--anim-duration-fast);
+    border: var(--border-width) solid transparent;
+  }
+  body:not(.is-mobile) .inline-title:not([data-level]):hover::before, body:not(.is-mobile) .inline-title:not([data-level]):focus-within::before {
+    border-color: var(--background-modifier-border);
+  }
+  body:not(.is-mobile) .inline-title:not([data-level]):not(:focus-within) {
+    cursor: pointer;
+  }
+  .inline-title:not([data-level]),
+  .markdown-rendered :is(h1, h2, h3, h4, h5, h6),
+  .HyperMD-header {
+    letter-spacing: normal !important;
+    text-wrap: pretty;
+  }
+  .markdown-reading-view mark,
+  .markdown-source-view mark,
+  .markdown-rendered mark {
+    box-decoration-break: clone;
+    border-radius: var(--radius-s);
+    padding: 2px 4px;
+    color: var(--text-highlight, var(--text-normal));
+    font-weight: var(--font-medium);
+  }
+  .cm-s-obsidian span.cm-highlight {
+    box-decoration-break: clone;
+    padding-block: 2px;
+  }
+  .cm-line .cm-highlight:nth-child(1 of .cm-highlight) {
+    border-top-left-radius: var(--radius-s);
+    border-bottom-left-radius: var(--radius-s);
+    padding-left: 4px;
+  }
+  .cm-line .cm-highlight:nth-last-child(1 of .cm-highlight) {
+    border-top-right-radius: var(--radius-s);
+    border-bottom-right-radius: var(--radius-s);
+    padding-right: 4px;
+  }
+  img:not(.link-favicon),
+  iframe,
+  video,
+  .file-embed {
+    corner-shape: var(--corner-shape);
+    border-radius: var(--media-radius);
+  }
+  .image-embed {
+    padding-bottom: 0px;
+    padding-inline-end: 0px;
+  }
+  .workspace-leaf-content[data-type=markdown] {
+    --image-align-margin-start: auto;
+    --image-align-margin-end: auto;
+  }
+  body.image-align-left .workspace-leaf-content[data-type=markdown] {
+    --image-align-margin-start: 0;
+    --image-align-margin-end: auto;
+  }
+  body.image-align-center .workspace-leaf-content[data-type=markdown] {
+    --image-align-margin-start: auto;
+    --image-align-margin-end: auto;
+  }
+  body.image-align-right .workspace-leaf-content[data-type=markdown] {
+    --image-align-margin-start: auto;
+    --image-align-margin-end: 0;
+  }
+  .workspace-leaf-content[data-type=markdown] .image-embed,
+  .workspace-leaf-content[data-type=markdown] img:not(.link-favicon, .emoji, [alt=banner]) {
+    display: block;
+    margin-inline-start: var(--image-align-margin-start);
+    margin-inline-end: var(--image-align-margin-end);
+  }
+  body:not(.full-width-media-off) .workspace-leaf-content[data-type=markdown] img:not([width], .cm-widgetBuffer, .link-favicon, .emoji, [alt=banner]),
+  body:not(.full-width-media-off) .workspace-leaf-content[data-type=markdown] iframe,
+  body:not(.full-width-media-off) .workspace-leaf-content[data-type=markdown] video {
+    border-radius: var(--media-radius);
+  }
+  body:not(.full-width-media-off) .workspace-leaf-content[data-type=markdown] img:not([width], .cm-widgetBuffer, .link-favicon, .emoji, [alt=banner]) {
+    width: auto;
+    max-width: 100%;
+    height: auto;
+  }
+  body:not(.full-width-media-off) .workspace-leaf-content[data-type=markdown] iframe,
+  body:not(.full-width-media-off) .workspace-leaf-content[data-type=markdown] video {
+    width: 100%;
+  }
+  .img-grid .markdown-preview-section .el-p > p:has(> .image-embed):has(span:last-child),
+  .img-grid .markdown-preview-section .el-p > p:has(> img):not(:has(> :not(img))) {
+    --p-spacing: 4px;
+    display: flex;
+    gap: var(--img-grid-gap, 4px);
+    line-height: 0;
+  }
+  .img-grid .markdown-preview-section .el-p > p:has(> .image-embed):has(span:last-child) br,
+  .img-grid .markdown-preview-section .el-p > p:has(> img):not(:has(> :not(img))) br {
+    display: none;
+  }
+  .img-grid .markdown-preview-section .el-p > p:has(> .image-embed):has(span:last-child) > img,
+  .img-grid .markdown-preview-section .el-p > p:has(> .image-embed):has(span:last-child) > .image-embed,
+  .img-grid .markdown-preview-section .el-p > p:has(> img):not(:has(> :not(img))) > img,
+  .img-grid .markdown-preview-section .el-p > p:has(> img):not(:has(> :not(img))) > .image-embed {
+    flex: 1;
+    object-fit: cover;
+  }
+  .img-grid .markdown-preview-section .el-p > p:has(> .image-embed):has(span:last-child) img,
+  .img-grid .markdown-preview-section .el-p > p:has(> img):not(:has(> :not(img))) img {
+    height: -webkit-fill-available;
+    overflow: auto;
+    object-fit: cover;
+  }
+  body.unstyled-tags {
+    --tag-background: transparent;
+    --tag-background-hover: transparent;
+    --tag-border-width: 0px;
+    --tag-padding-x: 0;
+    --tag-padding-y: 0;
+    --tag-size: inherit;
+    --tag-color-hover: var(--text-accent-hover);
+  }
+  .task-list-item {
+    --indentation-guide-reading-indent: -1.05em;
+  }
+  .pdf-container .pdfViewer .canvasWrapper {
+    contain: content;
+    border-radius: var(--radius-s);
+    overflow: hidden;
+  }
+  body:not(.clean-link-off) {
+    --link-decoration: none;
+    --link-external-decoration: none;
+  }
+}
+@media screen, print {
+  body {
+    --metadata-label-width: calc(9em * var(--metadata-label-width-modifier, 1));
+  }
+  body.is-phone {
+    --metadata-label-width: calc(7.5em * var(--metadata-label-width-modifier, 1));
+  }
+  body.is-mobile .metadata-content {
+    background-color: transparent;
+    padding: 0;
+  }
+  .metadata-container {
+    --metadata-divider-width: 0 !important;
+  }
+  .metadata-properties-heading {
+    padding-inline: 0;
+    width: 100%;
+  }
+  .metadata-property-icon::before {
+    display: none;
+  }
+  .metadata-property-key {
+    padding-inline: 8px;
+  }
+  .metadata-property-key-input,
+  .metadata-input {
+    box-shadow: none !important;
+    border-bottom: none !important;
+  }
+  .metadata-input-longtext:not(:focus) {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+  .metadata-link {
+    width: 100%;
+  }
+  .metadata-property-value[data-property-type=tags] .multi-select-container {
+    padding-block: 0;
+  }
+  .multi-select-pill {
+    line-height: var(--line-height-tight) !important;
+  }
+  .workspace > .workspace-split:not(.mod-root) .metadata-container .metadata-properties {
+    --metadata-divider-width: 0px;
+    --metadata-gap: 8px;
+  }
+  .mod-root .metadata-container .text-icon-button {
+    gap: 8px;
+    transition: var(--anim-duration-moderate) var(--anim-motion-baseline);
+    margin-top: 4px;
+    background-color: transparent;
+    padding-inline: 8px;
+    color: var(--text-faint);
+    font-weight: normal;
+    text-transform: lowercase;
+  }
+  .mod-root .metadata-container .text-icon-button:hover {
+    color: var(--text-muted);
+  }
+  .mod-root .metadata-content {
+    transform: translateX(-8px) !important;
+    width: calc(100% + 16px) !important;
+  }
+  .metadata-properties-heading {
+    display: none;
+  }
+  .markdown-reading-view .metadata-container:not(:hover) .text-icon-button {
+    opacity: 0;
+    height: 0;
+    padding-block: 0px;
+    margin-block: 0px;
+    display: flex;
+  }
+  .markdown-source-view .metadata-container,
+  .markdown-preview-view .metadata-container {
+    transform: none;
+  }
+  body .workspace-split {
+    --metadata-gap: 0;
+    --metadata-padding: 0;
+    --metadata-property-radius: var(--radius-m);
+    --metadata-property-radius-hover: var(--radius-m);
+    --metadata-property-radius-focus: var(--radius-m);
+  }
+  body .workspace-split .metadata-container {
+    --input-padding: 8px;
+  }
+  body .workspace-split .metadata-container .metadata-properties-heading {
+    padding-inline: 0px;
+  }
+  body .workspace-split .metadata-container .metadata-properties {
+    border-radius: var(--radius-m);
+    background-color: var(--background-primary-alt);
+  }
+  body .workspace-split .metadata-container .metadata-property {
+    min-height: 44px;
+  }
+  body .workspace-split .metadata-container .metadata-property-icon,
+  body .workspace-split .metadata-container .text-icon-button {
+    --icon-size: var(--icon-s);
+    --icon-stroke: var(--icon-s-stroke-width);
+  }
+  body .workspace-split .metadata-container .metadata-property-key,
+  body .workspace-split .metadata-container .text-icon-button {
+    padding: 8px 16px;
+  }
+  body .workspace-split.is-mobile .metadata-container .metadata-property-key,
+  body .workspace-split.is-mobile .metadata-container .text-icon-button {
+    padding-inline-end: 4px;
+  }
+  body .workspace-split .workspace-split:not(.mod-root) .metadata-container {
+    padding: 8px !important;
+  }
+}
+@media screen, print {
+  body {
+    --blockquote-background-color: var(--background-primary-alt);
+    --blockquote-border-color: var(--color-base-50);
+    --blockquote-border-thickness: 2px;
+    --blockquote-size: var(--font-text-size);
+  }
+  .markdown-rendered blockquote,
+  .HyperMD-quote {
+    corner-shape: var(--corner-shape);
+    font-size: var(--blockquote-size);
+  }
+  .cm-formatting-quote {
+    margin-left: 8px;
+  }
+  .markdown-rendered blockquote {
+    position: relative;
+    border-radius: var(--radius-s);
+    border-inline-start: none;
+    padding-inline: calc(32px + var(--blockquote-border-thickness)) 16px;
+    padding-block: 16px;
+  }
+  .markdown-rendered blockquote > blockquote {
+    padding-inline-start: calc(16px + var(--blockquote-border-thickness));
+    padding-block: 0 !important;
+  }
+  .markdown-rendered blockquote > blockquote::before {
+    top: 0;
+    bottom: 0;
+    inset-inline-start: 0;
+  }
+  .markdown-rendered blockquote::before {
+    position: absolute;
+    top: 16px;
+    bottom: 16px;
+    inset-inline-start: 16px;
+    border-radius: var(--radius-s);
+    background-color: var(--blockquote-border-color);
+    width: var(--blockquote-border-thickness);
+    pointer-events: none;
+    content: "";
+  }
+  .HyperMD-quote {
+    border: solid var(--blockquote-background-color);
+    border-width: 0 16px 0 16px;
+    background-color: var(--blockquote-background-color);
+  }
+  .HyperMD-quote::before {
+    width: 0 !important;
+  }
+  .HyperMD-quote:first-child,
+  .cm-sizer > div > div > *:not(.HyperMD-quote) + .HyperMD-quote {
+    border-top-width: 16px;
+    border-start-start-radius: var(--radius-s);
+    border-start-end-radius: var(--radius-s);
+  }
+  .HyperMD-quote:first-child::before,
+  .cm-sizer > div > div > *:not(.HyperMD-quote) + .HyperMD-quote::before {
+    border-start-start-radius: var(--radius-s);
+    border-start-end-radius: var(--radius-s);
+  }
+  .HyperMD-quote:last-child,
+  .cm-sizer > div > div > .HyperMD-quote:has(+ *:not(.HyperMD-quote)) {
+    border-bottom-width: 16px;
+    border-end-start-radius: var(--radius-s);
+    border-end-end-radius: var(--radius-s);
+  }
+  .HyperMD-quote:last-child::before,
+  .cm-sizer > div > div > .HyperMD-quote:has(+ *:not(.HyperMD-quote))::before {
+    border-end-start-radius: var(--radius-s);
+    border-end-end-radius: var(--radius-s);
+  }
+}
+@media screen, print {
+  body {
+    --callout-blend-mode: normal;
+    --callout-border-width: var(--divider-width);
+    --callout-padding: 16px;
+    --callout-size: var(--font-text-size);
+  }
+  .callout:not([data-callout=note-toolbar]) {
+    corner-shape: var(--corner-shape);
+    font-size: var(--callout-size);
+  }
+  .callout:not([data-callout=note-toolbar]) .callout-content > *:first-child {
+    margin-block-start: 8px;
+  }
+  .callout:not([data-callout=note-toolbar]) .callout-content > *:last-child {
+    margin-block-end: 0 !important;
+  }
+  .callout:not([data-callout=note-toolbar]) pre {
+    box-shadow: none;
+    border: var(--border-width) solid var(--background-modifier-border);
+  }
+  .callout:not([data-callout=note-toolbar]) .callout-title {
+    align-items: center;
+    gap: 8px;
+  }
+  .callout:not([data-callout=note-toolbar]).is-collapsible .callout-title {
+    cursor: pointer;
+  }
+  .callout:not([data-callout=note-toolbar]) .callout-title-inner {
+    --p-spacing: 0;
+    color: color-mix(in srgb, rgb(var(--callout-color)), var(--text-normal) 15%);
+  }
+  .callout:not([data-callout=note-toolbar]) .callout-fold {
+    padding-inline-end: 0;
+  }
+  .callout:not([data-callout=note-toolbar]) .callout-content {
+    margin-left: calc(var(--icon-size) + 8px);
+  }
+  .callout:not([data-callout]) {
+    --callout-color: var(--color-accent);
+    background-color: hsla(var(--color-accent-hsl), 0.15);
+    border-color: hsla(var(--color-accent-hsl), var(--callout-border-opacity));
+  }
+  .callout:not([data-callout]) .callout-title {
+    color: var(--callout-color);
+  }
+  body:is(.mod-macos, .adaptive-mode-off) .callout:not([data-callout=note-toolbar]) {
+    box-shadow: var(--shadow-tactile);
+    background: linear-gradient(rgba(var(--callout-color), 0.1), rgba(var(--callout-color), 0.15));
+  }
+}
+@media screen, print {
+  body {
+    --table-text-size: var(--font-small);
+    --table-border-color: var(--background-modifier-border);
+    --table-add-button-border-width: 0;
+    --table-header-border-color: transparent;
+    --embed-block-shadow-hover: none;
+  }
+  body:not(.full-width-media-off) table,
+  body:not(.full-width-media-off) .markdown-source-view.mod-cm6 .cm-table-widget .table-wrapper {
+    min-width: 100%;
+  }
+  :root table {
+    border-collapse: separate;
+    border-spacing: 0;
+    word-break: break-word;
+  }
+  div:is(.markdown-preview-view, .is-live-preview) table {
+    position: relative;
+  }
+  div:is(.markdown-preview-view, .is-live-preview) table .table-cell-wrapper:active,
+  div:is(.markdown-preview-view, .is-live-preview) table .table-cell-wrapper:focus,
+  div:is(.markdown-preview-view, .is-live-preview) table .table-cell-wrapper:focus-within {
+    background-color: var(--background-modifier-hover);
+  }
+  div:is(.markdown-preview-view, .is-live-preview) table th,
+  div:is(.markdown-preview-view, .is-live-preview) table td {
+    corner-shape: var(--corner-shape);
+  }
+  div:is(.markdown-preview-view, .is-live-preview) table > thead:only-child,
+  div:is(.markdown-preview-view, .is-live-preview) table > tbody {
+    --table-header-border-color: var(--table-border-color);
+    background-color: var(--background-primary-alt);
+    position: relative;
+  }
+  div:is(.markdown-preview-view, .is-live-preview) table > thead:not(:only-child) > tr > th,
+  div:is(.markdown-preview-view, .is-live-preview) table > thead:not(:only-child) > tr > th .table-cell-wrapper {
+    border-radius: var(--radius-s);
+  }
+  div:is(.markdown-preview-view, .is-live-preview) table > tbody > tr:not(:last-child) > th,
+  div:is(.markdown-preview-view, .is-live-preview) table > tbody > tr:not(:last-child) > td {
+    border-bottom: none;
+  }
+  div:is(.markdown-preview-view, .is-live-preview) div:not([dir=rtl]) > table:not([dir=rtl]) > thead > tr > th:not(:last-child),
+  div:is(.markdown-preview-view, .is-live-preview) div:not([dir=rtl]) > table:not([dir=rtl]) > tbody > tr > th:not(:last-child),
+  div:is(.markdown-preview-view, .is-live-preview) div:not([dir=rtl]) > table:not([dir=rtl]) > tbody > tr > td:not(:last-child) {
+    border-right: none;
+  }
+  div:is(.markdown-preview-view, .is-live-preview) div:not([dir=rtl]) > table:not([dir=rtl]) > :is(thead, tbody) > tr:first-child > :is(th, td):first-child,
+  div:is(.markdown-preview-view, .is-live-preview) div:not([dir=rtl]) > table:not([dir=rtl]) > :is(thead, tbody) > tr:first-child > :is(th, td):first-child .table-cell-wrapper {
+    border-top-left-radius: var(--radius-s);
+  }
+  div:is(.markdown-preview-view, .is-live-preview) div:not([dir=rtl]) > table:not([dir=rtl]) > :is(thead, tbody) > tr:first-child > :is(th, td):last-child,
+  div:is(.markdown-preview-view, .is-live-preview) div:not([dir=rtl]) > table:not([dir=rtl]) > :is(thead, tbody) > tr:first-child > :is(th, td):last-child .table-cell-wrapper {
+    border-top-right-radius: var(--radius-s);
+  }
+  div:is(.markdown-preview-view, .is-live-preview) div:not([dir=rtl]) > table:not([dir=rtl]) > :is(thead, tbody) > tr:last-child > :is(th, td):first-child,
+  div:is(.markdown-preview-view, .is-live-preview) div:not([dir=rtl]) > table:not([dir=rtl]) > :is(thead, tbody) > tr:last-child > :is(th, td):first-child .table-cell-wrapper {
+    border-bottom-left-radius: var(--radius-s);
+  }
+  div:is(.markdown-preview-view, .is-live-preview) div:not([dir=rtl]) > table:not([dir=rtl]) > :is(thead, tbody) > tr:last-child > :is(th, td):last-child,
+  div:is(.markdown-preview-view, .is-live-preview) div:not([dir=rtl]) > table:not([dir=rtl]) > :is(thead, tbody) > tr:last-child > :is(th, td):last-child .table-cell-wrapper {
+    border-bottom-right-radius: var(--radius-s);
+  }
+  div:is(.markdown-preview-view, .is-live-preview) div[dir=rtl] > table > thead > tr > th:not(:last-child),
+  div:is(.markdown-preview-view, .is-live-preview) div[dir=rtl] > table > tbody > tr > th:not(:last-child),
+  div:is(.markdown-preview-view, .is-live-preview) div[dir=rtl] > table > tbody > tr > td:not(:last-child),
+  div:is(.markdown-preview-view, .is-live-preview) table[dir=rtl] > thead > tr > th:not(:last-child),
+  div:is(.markdown-preview-view, .is-live-preview) table[dir=rtl] > tbody > tr > th:not(:last-child),
+  div:is(.markdown-preview-view, .is-live-preview) table[dir=rtl] > tbody > tr > td:not(:last-child) {
+    border-left: none;
+  }
+  div:is(.markdown-preview-view, .is-live-preview) div[dir=rtl] > table > :is(thead, tbody) > tr:first-child > :is(th, td):first-child,
+  div:is(.markdown-preview-view, .is-live-preview) div[dir=rtl] > table > :is(thead, tbody) > tr:first-child > :is(th, td):first-child .table-cell-wrapper,
+  div:is(.markdown-preview-view, .is-live-preview) table[dir=rtl] > :is(thead, tbody) > tr:first-child > :is(th, td):first-child,
+  div:is(.markdown-preview-view, .is-live-preview) table[dir=rtl] > :is(thead, tbody) > tr:first-child > :is(th, td):first-child .table-cell-wrapper {
+    border-top-right-radius: var(--radius-s);
+  }
+  div:is(.markdown-preview-view, .is-live-preview) div[dir=rtl] > table > :is(thead, tbody) > tr:first-child > :is(th, td):last-child,
+  div:is(.markdown-preview-view, .is-live-preview) div[dir=rtl] > table > :is(thead, tbody) > tr:first-child > :is(th, td):last-child .table-cell-wrapper,
+  div:is(.markdown-preview-view, .is-live-preview) table[dir=rtl] > :is(thead, tbody) > tr:first-child > :is(th, td):last-child,
+  div:is(.markdown-preview-view, .is-live-preview) table[dir=rtl] > :is(thead, tbody) > tr:first-child > :is(th, td):last-child .table-cell-wrapper {
+    border-top-left-radius: var(--radius-s);
+  }
+  div:is(.markdown-preview-view, .is-live-preview) div[dir=rtl] > table > :is(thead, tbody) > tr:last-child > :is(th, td):first-child,
+  div:is(.markdown-preview-view, .is-live-preview) div[dir=rtl] > table > :is(thead, tbody) > tr:last-child > :is(th, td):first-child .table-cell-wrapper,
+  div:is(.markdown-preview-view, .is-live-preview) table[dir=rtl] > :is(thead, tbody) > tr:last-child > :is(th, td):first-child,
+  div:is(.markdown-preview-view, .is-live-preview) table[dir=rtl] > :is(thead, tbody) > tr:last-child > :is(th, td):first-child .table-cell-wrapper {
+    border-bottom-right-radius: var(--radius-s);
+  }
+  div:is(.markdown-preview-view, .is-live-preview) div[dir=rtl] > table > :is(thead, tbody) > tr:last-child > :is(th, td):last-child,
+  div:is(.markdown-preview-view, .is-live-preview) div[dir=rtl] > table > :is(thead, tbody) > tr:last-child > :is(th, td):last-child .table-cell-wrapper,
+  div:is(.markdown-preview-view, .is-live-preview) table[dir=rtl] > :is(thead, tbody) > tr:last-child > :is(th, td):last-child,
+  div:is(.markdown-preview-view, .is-live-preview) table[dir=rtl] > :is(thead, tbody) > tr:last-child > :is(th, td):last-child .table-cell-wrapper {
+    border-bottom-left-radius: var(--radius-s);
+  }
+  .cm-html-embed th,
+  .markdown-rendered th,
+  .cm-html-embed td,
+  .markdown-rendered td,
+  .markdown-source-view.mod-cm6 .cm-table-widget .table-cell-wrapper {
+    padding: 8px;
+  }
+  .cm-html-embed th,
+  .markdown-rendered th {
+    text-align: var(--table-text-align-header);
+  }
+  .cm-html-embed td,
+  .markdown-rendered td {
+    text-align: var(--table-text-align-body);
+  }
+  .dataview.table-view-table::before,
+  .block-language-datacorejsx.table-view-table::before {
+    border: none;
+  }
+  .dataview.table-view-table tr:first-child > td,
+  .block-language-datacorejsx.table-view-table tr:first-child > td {
+    border-top: none;
+  }
+  .dataview.table-view-table > thead > tr > th,
+  .dataview .datacore-table-header-cell,
+  .block-language-datacorejsx.table-view-table > thead > tr > th,
+  .block-language-datacorejsx .datacore-table-header-cell {
+    border-bottom: none;
+    font-weight: var(--table-header-weight);
+    font-size: var(--table-header-size);
+  }
+  .dataview.table-view-table > tbody > tr:not(:only-child) > td,
+  .block-language-datacorejsx.table-view-table > tbody > tr:not(:only-child) > td {
+    max-width: 20em;
+  }
+  .dataview.dataview-error-box,
+  .block-language-datacorejsx.dataview-error-box {
+    border: none;
+    border-radius: var(--radius-s);
+    background-color: var(--background-secondary);
+    min-height: 80px;
+  }
+  .dataview .dc-paging-control-page,
+  .block-language-datacorejsx .dc-paging-control-page {
+    padding: 0 !important;
+  }
+}
+body {
+  --bases-header-border-width: 0;
+  --bases-table-header-color: var(--text-faint);
+}
+
+.bases-view {
+  border-radius: var(--radius-s);
+}
+
+.mod-sidedock .bases-table-container,
+.mod-sidedock .bases-tbody {
+  background-color: transparent;
+}
+
+.bases-table-container.mod-multiline .bases-table-cell {
+  align-items: var(--bases-table-align-items, start);
+}
+
+.bases-thead .bases-table-header {
+  overflow: hidden;
+}
+
+.bases-thead .bases-td {
+  box-shadow: none;
+  border-radius: var(--radius-s);
+  overflow: visible;
+}
+
+.bases-thead .bases-td:hover {
+  --bases-table-header-color: var(--text-normal);
+}
+
+.bases-table-header-resizer {
+  border-radius: var(--radius-s);
+}
+
+.bases-table-cell > * {
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
+body.bases-row-alt .bases-tbody .bases-tr:nth-child(odd) {
+  background-color: var(--background-secondary);
+}
+
+body.bases-col-alt .bases-tbody .bases-tr > .bases-td:nth-child(2n+2) {
+  background-color: var(--background-secondary);
+}
+
+.bases-cards-item {
+  gap: 2px;
+}
+
+.bases-cards-label {
+  color: var(--text-faint);
+}
+
+.workspace-leaf-content[data-type=markdown] .bases-embed .bases-view {
+  border: none;
+  border-radius: 0;
+}
+.workspace-leaf-content[data-type=markdown] .bases-embed .bases-view .bases-thead,
+.workspace-leaf-content[data-type=markdown] .bases-embed .bases-view .bases-tbody,
+.workspace-leaf-content[data-type=markdown] .bases-embed .bases-view .bases-tbody > .bases-tr:first-child,
+.workspace-leaf-content[data-type=markdown] .bases-embed .bases-view .bases-tbody > .bases-tr > .bases-td:first-child {
+  box-shadow: none;
+}
+.workspace-leaf-content[data-type=markdown] .bases-embed .bases-view .bases-tbody {
+  border: var(--bases-embed-border-width) solid var(--bases-embed-border-color);
+  border-radius: var(--bases-embed-border-radius);
+  overflow: hidden;
+}
+
+.query-toolbar-menu,
+.bases-toolbar-menu,
+.cm-tooltip {
+  animation: none !important;
+  min-width: unset;
+}
+
+.text-icon-button {
+  border-radius: var(--clickable-icon-radius);
+}
+
+body:not(.is-phone) .menu.bases-toolbar-menu {
+  align-items: unset;
+}
+body:not(.is-phone) .menu.bases-toolbar-menu .search-input-container {
+  margin: var(--menu-padding) var(--menu-padding) 0;
+  padding-bottom: 0;
+  background: var(--background-modifier-form-field);
+  border: var(--input-border-width) solid var(--background-modifier-border);
+  border-radius: var(--input-radius);
+}
+
+body.is-phone {
+  --bases-embed-width: unset;
+  --bases-embed-transform: none;
+}
+body.is-phone .markdown-preview-sizer > .el-pre .bases-embed,
+body.is-phone .markdown-preview-sizer > .el-p .bases-embed,
+body.is-phone .cm-content > .bases-embed,
+body.is-phone .cm-content > .cm-lang-base {
+  max-width: 100cqw !important;
+  width: 100cqw !important;
+  justify-self: center;
+  margin-inline: calc(-1 * var(--file-margins-x)) !important;
+}
+
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .workspace-split.mod-root .workspace-tab-container {
+  border-radius: 0;
+}
+
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) {
+  --titlebar-border-width: 1px;
+  --tab-outline-width: 1px;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .workspace-tab-header-container {
+  border-bottom: var(--tab-outline-width) solid var(--tab-outline-color);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .mod-sidedock > .workspace-leaf-resize-handle {
+  border-color: var(--divider-color);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-left-split > .workspace-leaf-resize-handle {
+  border-color: var(--divider-color-alt);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile):not(.hover-ribbon) .workspace-ribbon.mod-left.is-collapsed {
+  border-right: var(--divider-width) solid var(--divider-color);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .workspace-ribbon.mod-left::before {
+  content: "";
+  height: var(--tab-outline-width);
+  background-color: var(--tab-outline-color);
+  position: absolute;
+  inset: calc(var(--header-height) - 1px) 0 auto;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .workspace-ribbon.mod-left .side-dock-actions {
+  margin-top: 12px;
+}
+
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-tablet .workspace-drawer.is-pinned {
+  border-width: var(--divider-width);
+}
+
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-translucent) .workspace {
+  background-color: var(--background-primary);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).show-ribbon:not(.is-translucent):not(.is-mobile) .workspace-ribbon:not(.is-collapsed) {
+  background-color: var(--background-secondary);
+  box-shadow: 0 calc(-1 * var(--header-height)) var(--background-secondary);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .mod-sidedock .workspace-tabs:not(.mod-top) .workspace-tab-header-container {
+  border-bottom: none;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .mod-sidedock.mod-left-split,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .workspace-drawer.mod-left {
+  background-color: var(--background-secondary);
+}
+
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-tablet .workspace {
+  background-color: transparent;
+}
+
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) {
+  --radius-window: 8px;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) {
+  background-color: var(--background-primary);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) {
+  --ribbon-background: transparent;
+  --ribbon-background-collapsed: var(--ribbon-background);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header {
+  height: 32px;
+  margin: auto 0;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display] {
+  box-shadow: var(--shadow-s);
+  border-radius: var(--radius-window, var(--radius-m));
+  background-color: var(--modal-background) !important;
+  backdrop-filter: var(--blur-m);
+  height: -webkit-fill-available;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display].mod-left-split {
+  margin: 8px 0 8px 8px;
+  overflow: visible;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display].mod-right-split {
+  margin: 8px 8px 8px 0;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display]::before {
+  background: none;
+  margin-inline: -8px;
+  pointer-events: auto;
+  width: 8px;
+}
+
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root {
+  padding-bottom: 0;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile):not(.show-ribbon:not(.hover-ribbon)) .workspace:not(.is-left-sidedock-open).is-right-sidedock-open .mod-root {
+  margin-left: 8px;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .workspace.is-left-sidedock-open:not(.is-right-sidedock-open) .mod-root {
+  margin-right: 8px;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-root {
+  padding-bottom: 8px;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile):not(.mod-macos).is-hidden-frameless .workspace.is-left-sidedock-open:not(.is-right-sidedock-open) .mod-root .workspace-tabs.mod-top-right-space .workspace-tab-header-container {
+  padding-right: var(--frame-right-space);
+}
+
+body:is(.mod-macos, .adaptive-mode-off):not(.is-phone) .workspace:is(.is-left-sidedock-open, .is-right-sidedock-open) .workspace-split.mod-vertical {
+  gap: 8px;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-phone) .workspace:is(.is-left-sidedock-open, .is-right-sidedock-open) .workspace-split:not(.mod-sidedock) > * > .workspace-leaf-resize-handle:not(:hover) {
+  border-color: transparent;
+}
+
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .workspace-drawer.mod-left.is-pinned + .mod-root:has(+ .workspace-drawer.mod-right:not(.is-pinned)) .workspace-tabs:last-of-type .workspace-tab-container {
+  margin-right: 8px;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .workspace-drawer.mod-left:not(.is-pinned) + .mod-root:has(+ .workspace-drawer.mod-right.is-pinned) .workspace-tabs:first-of-type .workspace-tab-container {
+  margin-left: 8px;
+}
+
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) {
+  --shadow-sidedock-spread: -32px 0 0 32px var(--background-primary);
+  --shadow-surface: 0 0 0 1px var(--background-modifier-hover);
+  --tab-outline-width: 1px;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile):not(.is-focused):not(.reduce-contrast-change) {
+  --workspace-background-translucent: var(--background-secondary);
+  --tab-outline-color: transparent;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile):not(.is-focused):not(.reduce-contrast-change) .modal.mod-settings .vertical-tab-header > div,
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile):not(.is-focused):not(.reduce-contrast-change) .workspace-ribbon,
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile):not(.is-focused):not(.reduce-contrast-change) .mod-sidedock > div {
+  opacity: 0.5;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile):not(.is-focused):not(.reduce-contrast-change) .modal.mod-settings .vertical-tab-header,
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile):not(.is-focused):not(.reduce-contrast-change) .mod-sidedock.mod-left-split,
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile):not(.is-focused):not(.reduce-contrast-change) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header {
+  background-color: var(--background-modifier-hover) !important;
+  box-shadow: none !important;
+  transition: none;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile).is-fullscreen .mod-sidedock.mod-left-split {
+  border-radius: var(--radius-m);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile).is-fullscreen .mod-sidedock.mod-left-split .mod-sidedock.mod-left-split .mod-top-left-space .workspace-tab-header-container {
+  height: calc(var(--header-height) - 8px);
+  padding-left: var(--frame-left-space);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile).show-ribbon:not(.mod-macos) .workspace-ribbon.mod-left:not(.is-collapsed), body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile).show-ribbon.mod-macos.is-frameless:not(.is-hidden-frameless) .workspace-ribbon.mod-left:not(.is-collapsed) {
+  margin-block: 8px;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile).show-ribbon:not(.mod-macos) .workspace-ribbon.mod-left:not(.is-collapsed) .sidebar-toggle-button {
+  height: calc(var(--header-height) - 24px);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile).show-ribbon:not(.hover-ribbon) .workspace-ribbon.mod-left:not(.is-collapsed) {
+  padding-left: 16px;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile).show-ribbon:not(.hover-ribbon) .mod-sidedock.mod-left-split:not(.is-sidedock-collapsed) {
+  margin-left: calc(-1 * var(--ribbon-width) + 8px);
+  padding-left: var(--ribbon-width);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile).show-ribbon .workspace-ribbon.mod-left .sidebar-toggle-button .clickable-icon:hover,
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile).show-ribbon .workspace-ribbon.mod-left .side-dock-actions .side-dock-ribbon-action:hover {
+  box-shadow: none !important;
+  background-color: transparent !important;
+  color: var(--text-normal);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile):not(.is-translucent).theme-dark .mod-sidedock {
+  background-color: hsl(from var(--background-primary) h s calc(l - 2));
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile).is-translucent .mod-sidedock.mod-left-split {
+  background-color: rgba(from var(--background-primary) r g b/50%) !important;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock {
+  transition: var(--anim-duration-moderate), background-color 0s, box-shadow 0s;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-left-split {
+  corner-shape: var(--corner-shape);
+  z-index: var(--layer-sidedock);
+  margin: 8px 0 8px 8px;
+  box-shadow: var(--shadow-surface), var(--shadow-sidedock-spread);
+  border-radius: var(--radius-window, var(--radius-m));
+  height: -webkit-fill-available;
+  overflow: hidden;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-left-split .mod-top-left-space .workspace-tab-header-container {
+  padding-block: 0px;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-left-split .mod-top-left-space .workspace-tab-header-container,
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-left-split .mod-top-left-space .workspace-tab-header-container .sidebar-toggle-button {
+  min-height: calc(var(--header-height) - 16px);
+  max-height: calc(var(--header-height) - 16px);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-left-split .mod-top-left-space .workspace-tab-header-container div:is(.workspace-tab-header-inner, .clickable-icon),
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-left-split .mod-top-left-space .workspace-tab-header-container .sidebar-toggle-button div:is(.workspace-tab-header-inner, .clickable-icon) {
+  padding-block: 4px;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-right-split > .workspace-leaf-resize-handle {
+  border-color: var(--divider-color);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .modal.mod-settings .vertical-tab-header {
+  margin: 8px 0 8px 8px;
+  box-shadow: var(--shadow-surface);
+  border-radius: max(var(--modal-radius) - 8px, var(--radius-s));
+  background-color: rgba(from var(--background-primary) r g b/75%);
+}
+
+body:is(.mod-macos, .adaptive-mode-off).is-tablet.theme-light {
+  --shadow-surface: inset 1px 1px 2px rgba(255, 255, 255, 0.5), inset -1px -1px 2px rgba(255, 255, 255, 0.5), inset 0 4px 16px rgba(255, 255, 255, 0.025), 0 0 1px rgba(0, 0, 0, 0.25), 0 8px 16px 0 rgba(0, 0, 0, 0.05);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-tablet.theme-dark {
+  --shadow-surface: 0 0 1px rgba(255, 255, 255, 0.3), 0 0 1px rgba(255, 255, 255, 0.5);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .workspace {
+  background-color: var(--background-primary);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .workspace-drawer .workspace-drawer-header-name-text {
+  font-size: var(--font-ui-small);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .workspace-drawer .workspace-drawer-header-info {
+  color: var(--text-faint);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .workspace-drawer:not(.is-pinned) {
+  background-color: var(--modal-background);
+  box-shadow: var(--shadow-xs);
+  backdrop-filter: var(--blur-l);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .workspace-drawer.is-pinned.mod-left {
+  background-color: var(--raised-background);
+  box-shadow: var(--shadow-surface);
+  border: none;
+  margin: calc(var(--safe-area-inset-top) + 8px) 0 8px 8px;
+  border-radius: calc(env(safe-area-inset-bottom) - 8px);
+  height: auto;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .workspace-drawer.is-pinned.mod-left .workspace-drawer-ribbon,
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .workspace-drawer.is-pinned.mod-left .workspace-drawer-inner {
+  padding-block: 0px 16px;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .modal.mod-settings .vertical-tab-header {
+  margin: 8px 0 8px 8px;
+  border-radius: var(--radius-m);
+  border: none;
+  z-index: 1;
+  background-color: var(--raised-background);
+  box-shadow: var(--shadow-surface);
+}
+
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-root {
+  z-index: 5;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .workspace-tabs {
+  overflow: visible;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) {
+  --shadow-sidedock-spread: 0 0 transparent;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-left-split {
+  margin-right: 8px;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-right-split {
+  background-color: transparent !important;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock.mod-right-split > .workspace-leaf-resize-handle {
+  border-color: transparent;
+}
+
+body:is(.mod-macos, .adaptive-mode-off):not(.is-phone).theme-light {
+  --shadow-tab: var(--shadow-base), 0 0 1px rgba(0, 0, 0, 0.2), inset 0 -8px 48px rgba(0, 0, 0, 0.02), 0 2px 4px rgba(0, 0, 0, 0.025), 0 2px 4px rgba(0, 0, 0, 0.025);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-phone).theme-dark {
+  --shadow-tab: var(--shadow-base), 0 4px 8px rgba(0, 0, 0, 0.1);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-phone) .mod-root .workspace-tab-container {
+  background-color: rgba(from var(--background-primary) r g b/75%);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-phone) .mod-root .view-header,
+body:is(.mod-macos, .adaptive-mode-off):not(.is-phone) .mod-root .view-content,
+body:is(.mod-macos, .adaptive-mode-off):not(.is-phone) .mod-root .document-search-container {
+  background-color: transparent;
+}
+@starting-style {
+  body:is(.mod-macos, .adaptive-mode-off):not(.is-phone):is(.mod-macos, .adaptive-mode-off) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header {
+    filter: blur(4px);
+    scale: 0.75;
+    opacity: 0;
+  }
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-phone):is(.mod-macos, .adaptive-mode-off) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header {
+  corner-shape: var(--corner-shape);
+  border-radius: 100vh;
+  transition: opacity var(--anim-duration-moderate), filter var(--anim-duration-moderate), background-color 0s;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-phone):is(.mod-macos, .adaptive-mode-off) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header:first-child {
+  margin-inline-start: 2px;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-phone):is(.mod-macos, .adaptive-mode-off) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header:last-child {
+  margin-inline-end: 2px;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-phone):is(.mod-macos, .adaptive-mode-off) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header:not(.is-active) {
+  background-color: transparent;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-phone):is(.mod-macos, .adaptive-mode-off) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header-inner {
+  border-radius: inherit;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-phone):is(.mod-macos, .adaptive-mode-off) .workspace:is(.is-left-sidedock-open, .is-right-sidedock-open) .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header.is-active {
+  background-color: rgba(from var(--background-primary) r g b/75%);
+  box-shadow: var(--shadow-tab);
+}
+
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .workspace-drawer.mod-left.is-pinned {
+  margin-right: 8px;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .mod-root .workspace-tabs:not(.mod-stacked) .workspace-tab-header.is-active {
+  background-color: var(--raised-background) !important;
+  box-shadow: var(--shadow-tab);
+}
+
+body {
+  --input-height: 32px;
+  --radius-modifier: 1;
+  --input-radius: var(--radius-s);
+  --radius-s: calc(8px * var(--radius-modifier));
+  --radius-m: calc(12px * var(--radius-modifier));
+  --radius-l: calc(20px * var(--radius-modifier));
+  --radius-xl: calc(28px * var(--radius-modifier));
+  --background-modifier-form-field: var(--interactive-normal);
+  --button-radius: calc(8px * var(--radius-modifier));
+}
+
+.theme-light {
+  --input-shadow: inset 0 0 0 var(--input-border-width) var(--background-modifier-border);
+  --input-shadow-hover: inset 0 0 0 var(--input-border-width) var(--background-modifier-border-hover);
+}
+
+.theme-dark {
+  --input-shadow: inset 0 0 0 var(--input-border-width) var(--background-modifier-border);
+  --input-shadow-hover: inset 0 0 0 var(--input-border-width) var(--background-modifier-border-hover);
+  --background-modifier-form-field: var(--interactive-normal);
+}
+
+button,
+.clickable-icon,
+select,
+.dropdown {
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline), background-color var(--anim-duration-fast);
+}
+
+button:where(:not(.clickable-icon, .ant-switch, .workspace-leaf-content:not([data-type=markdown]) button, .copy-code-button)) {
+  padding: 16px;
+  display: inline-flex;
+}
+
+.clickable-icon {
+  corner-shape: round;
+  padding: 8px;
+  max-height: 100%;
+}
+
+body.obsidian-app .checkbox-container {
+  transition: var(--anim-duration-moderate);
+  box-shadow: none;
+}
+body.obsidian-app .checkbox-container:focus-within {
+  outline: none;
+}
+body.obsidian-app .checkbox-container::after {
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline), background-color 0s;
+}
+body.obsidian-app .checkbox-container:active:after {
+  box-shadow: none;
+  width: calc(var(--toggle-thumb-width) + var(--toggle-border-width));
+  height: var(--toggle-thumb-height);
+  margin-top: var(--toggle-border-width);
+}
+body.obsidian-app .checkbox-container.is-enabled:active:after {
+  left: calc(var(--toggle-border-width) * -1);
+}
+
+input[type=range]::-webkit-slider-thumb {
+  box-shadow: none;
+}
+
+body:is(.mod-macos, .adaptive-mode-off) {
+  --side-padding: 20px;
+  --p-spacing: 1rem;
+  --input-shadow: none;
+  --input-shadow-hover: none;
+  --blur-s: blur(2px) saturate(1.5) brightness(1.025);
+  --blur-m: blur(4px) saturate(1.5) brightness(1.025);
+  --blur-l: blur(8px) saturate(1.5) brightness(1.025);
+  --clickable-icon-radius: 100vh;
+  --button-radius: var(--input-radius);
+  --input-radius: var(--radius-s);
+  --input-height: 24px;
+  --interactive-hover: var(--interactive-normal);
+  --background-modifier-border: rgba(var(--mono-rgb-100), 0.075);
+  --background-modifier-border-hover: var(--background-modifier-border);
+  --background-modifier-border-focus: hsla(var(--interactive-accent-hsl), 0.5);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile {
+  --titlebar-background: transparent;
+  --titlebar-background-focused: transparent;
+  --background-modifier-form-field: var(--interactive-normal);
+  --radius-s: calc(16px * var(--radius-modifier));
+  --radius-m: calc(24px * var(--radius-modifier));
+  --radius-l: calc(32px * var(--radius-modifier));
+  --radius-xl: calc(40px * var(--radius-modifier));
+  --input-radius: var(--radius-l);
+  --input-height: 48px;
+  --input-padding: 0 var(--side-padding);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone {
+  --nav-item-padding: calc(16px * var(--density-modifier)) var(--side-padding);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile.theme-light {
+  --background-modifier-form-field: var(--interactive-normal);
+  --interactive-normal: var(--background-secondary);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile.theme-dark {
+  --settings-background: var(--background-secondary);
+  --setting-items-background: var(--background-secondary-alt);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile.theme-dark .modal.mod-sidebar-layout {
+  --background-modifier-border: color-mix(in srgb, var(--background-secondary), white 15%);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone.theme-dark {
+  --modal-sidebar-background: var(--background-secondary);
+  --mobile-sidebar-background: var(--background-primary);
+}
+body:is(.mod-macos, .adaptive-mode-off).theme-light {
+  --divider-color: color-mix(in srgb, var(--background-secondary), black 7.5%);
+  --blur-background: rgba(255, 255, 255, 0.5);
+  --shadow-base: inset 1px 1px 2px rgba(255, 255, 255, 0.5), inset -1px -1px 2px rgba(255, 255, 255, 0.5), inset 0 4px 16px rgba(255, 255, 255, 0.025);
+  --shadow-edges: 0 0 1px rgba(0, 0, 0, 0.4);
+  --shadow-surface: 0 0 1px rgba(0, 0, 0, 0.4), inset 0 0 1px 1px rgba(255, 255, 255, 0.8), 0 4px 24px rgba(0, 0, 0, 0.075);
+  --shadow-xs: var(--shadow-base), inset 0 -8px 48px rgba(0, 0, 0, 0.02), 0 0 8px rgba(0, 0, 0, 0.025), 0 4px 24px rgba(0, 0, 0, 0.075);
+  --shadow-s: var(--shadow-base), inset 0 0 1px 1px white, var(--shadow-edges), 0 8px 16px rgba(0, 0, 0, 0.2);
+  --shadow-l: var(--shadow-edges), inset 0 0 1px 1px white, 0 16px 64px rgba(0, 0, 0, 0.15);
+}
+body:is(.mod-macos, .adaptive-mode-off).theme-dark {
+  --divider-color: color-mix(in srgb, var(--background-secondary), white 7.5%);
+  --blur-background: rgba(255, 255, 255, 0.075);
+  --shadow-base: inset 1px 1.5px 1px -1px rgba(255, 255, 255, 0.2), inset -1px -1.5px 1px -1px rgba(255, 255, 255, 0.15), inset 0 4px 16px rgba(255, 255, 255, 0.025);
+  --shadow-edges: 0 0 1px rgba(255, 255, 255, 0.3);
+  --shadow-surface: 0 0 1px rgba(255, 255, 255, 0.5), 0 0 1px rgba(0, 0, 0, 0.4), 0 8px 16px rgba(0, 0, 0, 0.2);
+  --shadow-xs: var(--shadow-base), 0 4px 8px rgba(0, 0, 0, 0.1);
+  --shadow-s: var(--shadow-edges), 0 0 1px rgba(255, 255, 255, 0.5), 0 0 1px rgba(0, 0, 0, 0.4), 0 8px 16px rgba(0, 0, 0, 0.2);
+  --shadow-l: var(--shadow-edges), 0 0 1px rgba(255, 255, 255, 0.5), 0 0 1px rgba(0, 0, 0, 0.7), 0 16px 64px rgba(0, 0, 0, 0.3);
+}
+body:is(.mod-macos, .adaptive-mode-off) button:where(:not(.clickable-icon, .ant-switch, .workspace-leaf-content:not([data-type=markdown]) button, .copy-code-button)) {
+  padding: 4px 12px;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone button:where(:not(.clickable-icon, .ant-switch, .workspace-leaf-content:not([data-type=markdown]) button, .copy-code-button)) {
+  padding: 0 var(--side-padding);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-tablet button:where(:not(.clickable-icon, .ant-switch, .workspace-leaf-content:not([data-type=markdown]) button, .copy-code-button)) {
+  padding: 4px var(--side-padding);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) {
+  --tab-action-width: 40px;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .clickable-icon {
+  min-width: var(--tab-action-width);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .clickable-icon:not([aria-disabled=true]):hover,
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .clickable-icon.has-active-menu,
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .modal-close-button:hover {
+  box-shadow: var(--shadow-xs);
+  background-color: var(--raised-background);
+}
+body:is(.mod-macos, .adaptive-mode-off) {
+  --slider-thumb-border-width: 0;
+  --slider-thumb-y: -5px;
+  --slider-thumb-height: 16px;
+  --slider-thumb-width: 20px;
+  --slider-thumb-radius: var(--toggle-thumb-radius);
+  --slider-track-height: 6px;
+  --slider-track-background: var(--background-modifier-border-hover);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile {
+  --slider-thumb-y: -9px;
+  --slider-thumb-height: 24px;
+  --slider-thumb-width: 37px;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile input[type=range]::-webkit-slider-thumb:active {
+  scale: 1.4;
+}
+body:is(.mod-macos, .adaptive-mode-off) input[type=range]::-webkit-slider-thumb {
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline) !important;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.075), 0 1px 16px rgba(0, 0, 0, 0.1) !important;
+}
+body:is(.mod-macos, .adaptive-mode-off) input[type=range]::-webkit-slider-thumb:active {
+  scale: 1.2;
+  box-shadow: inset 1px 1px 2px -2px rgba(var(--mono-rgb-100), 1), inset -1px -1px 2px -2px rgba(var(--mono-rgb-100), 1), var(--shadow-xs) !important;
+  background-color: var(--raised-background);
+}
+body:is(.mod-macos, .adaptive-mode-off) {
+  --toggle-border-width: 1.5px;
+  --toggle-thumb-height: 13px;
+  --toggle-thumb-width: 21px;
+  --toggle-width: 36px;
+  --toggle-s-border-width: var(--toggle-border-width);
+  --toggle-s-thumb-height: var(--toggle-thumb-height);
+  --toggle-s-thumb-width: var(--toggle-thumb-width);
+  --toggle-s-width: var(--toggle-width);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile {
+  --toggle-border-width: 2px;
+  --toggle-thumb-height: 24px;
+  --toggle-thumb-width: 37px;
+  --toggle-width: 68px;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .checkbox-container {
+  --interactive-accent: var(--color-green);
+}
+body:is(.mod-macos, .adaptive-mode-off) .checkbox-container {
+  box-shadow: none;
+}
+body:is(.mod-macos, .adaptive-mode-off) .checkbox-container:not(:active) {
+  overflow: hidden;
+}
+body:is(.mod-macos, .adaptive-mode-off) .checkbox-container::after {
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline) !important;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.075), 0 1px 16px rgba(0, 0, 0, 0.1);
+}
+body:is(.mod-macos, .adaptive-mode-off) .checkbox-container:active:after {
+  --toggle-border-width: -2.5px;
+  --toggle-thumb-height: 21px;
+  --toggle-thumb-width: 35.5px;
+  --toggle-s-border-width: var(--toggle-border-width);
+  --toggle-s-thumb-height: var(--toggle-thumb-height);
+  --toggle-s-thumb-width: var(--toggle-thumb-width);
+  box-shadow: inset 1px 1px 2px -2px rgba(var(--mono-rgb-100), 1), inset -1px -1px 2px -2px rgba(var(--mono-rgb-100), 1), var(--shadow-xs);
+  background-color: var(--raised-background);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .checkbox-container:active:after {
+  --toggle-border-width: -6px;
+  --toggle-thumb-height: 40px;
+  --toggle-thumb-width: 59px;
+  --toggle-s-border-width: var(--toggle-border-width);
+  --toggle-s-thumb-height: var(--toggle-thumb-height);
+  --toggle-s-thumb-width: var(--toggle-thumb-width);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile {
+  --dropdown-padding-start: var(--side-padding);
+}
+body:is(.mod-macos, .adaptive-mode-off) select:focus,
+body:is(.mod-macos, .adaptive-mode-off) .combobox-button:focus,
+body:is(.mod-macos, .adaptive-mode-off) .dropdown:focus {
+  box-shadow: none;
+}
+body:is(.mod-macos, .adaptive-mode-off) .search-input-container {
+  display: flex;
+  align-items: center;
+  overflow: visible;
+}
+body:is(.mod-macos, .adaptive-mode-off) .search-input-container:before {
+  top: unset !important;
+  inset-inline-start: calc((var(--input-height) - var(--icon-s)) / 2);
+  height: var(--icon-s);
+  width: var(--icon-s);
+}
+body:is(.mod-macos, .adaptive-mode-off) .search-input-container input {
+  padding-inline-start: var(--input-height) !important;
+}
+body:is(.mod-macos, .adaptive-mode-off) .mod-sidedock .search-input-container,
+body:is(.mod-macos, .adaptive-mode-off) .mod-sidedock input[type=search],
+body:is(.mod-macos, .adaptive-mode-off) .vertical-tab-header .search-input-container,
+body:is(.mod-macos, .adaptive-mode-off) .vertical-tab-header input[type=search],
+body:is(.mod-macos, .adaptive-mode-off) .community-modal-controls .search-input-container,
+body:is(.mod-macos, .adaptive-mode-off) .community-modal-controls input[type=search] {
+  --input-height: 32px;
+}
+body:is(.mod-macos, .adaptive-mode-off) .mod-sidedock .search-input-container input[type=search],
+body:is(.mod-macos, .adaptive-mode-off) .vertical-tab-header .search-input-container input[type=search],
+body:is(.mod-macos, .adaptive-mode-off) .community-modal-controls .search-input-container input[type=search] {
+  border: none;
+  border-radius: 100vh;
+  background-color: var(--background-modifier-hover);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .search-input-container::before {
+  inset-inline-start: 12px;
+}
+body:is(.mod-macos, .adaptive-mode-off) .workspace-ribbon.mod-left .sidebar-toggle-button .clickable-icon:hover,
+body:is(.mod-macos, .adaptive-mode-off) .workspace-ribbon.mod-left .side-dock-actions .side-dock-ribbon-action:hover {
+  box-shadow: none !important;
+  background-color: transparent !important;
+  color: var(--text-normal);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header-container-inner {
+  -webkit-app-region: no-drag;
+  gap: 0px;
+  transition: var(--anim-duration-moderate);
+  border-radius: var(--clickable-icon-radius);
+  padding: 0;
+  outline: 2px solid transparent;
+  background-clip: content-box;
+  height: auto;
+  z-index: 1;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header-container-inner:hover {
+  background-color: var(--background-modifier-hover);
+  outline-color: var(--background-modifier-hover);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header-container-inner:hover .workspace-tab-header.is-active {
+  background-color: var(--background-primary);
+  box-shadow: var(--shadow-xs);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header-container-inner:hover .workspace-tab-header.is-active .workspace-tab-header-inner-icon {
+  color: var(--text-normal) !important;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header {
+  border-radius: var(--clickable-icon-radius);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header-inner {
+  padding: 8px;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header:not(.is-active):hover .workspace-tab-header-inner {
+  background-color: var(--background-modifier-hover);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .sidebar-toggle-button,
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header-inner {
+  border-radius: var(--clickable-icon-radius);
+  width: var(--tab-action-width);
+  height: fit-content;
+  z-index: 1;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header-status-container {
+  margin-left: -8px;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header-status-icon,
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-tabs .workspace-tab-header-inner-close-button {
+  --icon-size: 12px;
+  color: var(--text-muted);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child .nav-buttons-container {
+  border-radius: var(--clickable-icon-radius);
+  background-color: var(--background-modifier-hover);
+  padding: 2px;
+  gap: 0;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child .nav-buttons-container .nav-action-button {
+  position: relative;
+  padding: 8px;
+  border-radius: var(--clickable-icon-radius);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child .nav-buttons-container .nav-action-button:hover:not([aria-disabled=true]) {
+  background-color: var(--background-modifier-hover);
+  box-shadow: none;
+}
+body:is(.mod-macos, .adaptive-mode-off) .mod-sidedock .workspace-tab-container,
+body:is(.mod-macos, .adaptive-mode-off) .mod-sidedock .workspace-leaf,
+body:is(.mod-macos, .adaptive-mode-off) .mod-sidedock .workspace-leaf-content {
+  contain: size !important;
+  overflow: visible;
+}
+body:is(.mod-macos, .adaptive-mode-off) .markdown-source-view,
+body:is(.mod-macos, .adaptive-mode-off) .markdown-preview-view {
+  transition: transform var(--anim-duration-slow) var(--anim-motion-baseline);
+}
+body:is(.mod-macos, .adaptive-mode-off) .workspace-leaf-content[data-mode=source] > .view-content > .markdown-reading-view > .markdown-preview-view {
+  transform: scale(0.995);
+  opacity: 0;
+}
+body:is(.mod-macos, .adaptive-mode-off) .workspace-leaf-content[data-mode=preview] > .view-content > .markdown-source-view {
+  transform: scale(0.995);
+  opacity: 0;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown][data-mode=source] .view-header .view-actions button:nth-last-child(2) {
+  background-color: rgb(from var(--interactive-accent) r g b/95%);
+  color: oklch(from var(--interactive-accent) 0.95 c h);
+  box-shadow: var(--shadow-xs);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.tab-icon) .mod-sidedock .workspace-tabs:not(.mod-top) .workspace-tab-header-container:not(:hover) .workspace-tab-header-container-inner {
+  gap: calc(8px * var(--density-modifier));
+}
+
+body:is(.mod-macos, .adaptive-mode-off) {
+  --background-modifier-message: var(--modal-background);
+  --modal-background: rgb(from var(--background-secondary) r g b / 75%) !important;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-translucent {
+  --modal-background: var(--background-primary) !important;
+}
+body:is(.mod-macos, .adaptive-mode-off) .menu,
+body:is(.mod-macos, .adaptive-mode-off) .prompt,
+body:is(.mod-macos, .adaptive-mode-off) .modal:not(.mod-sidebar-layout) {
+  backdrop-filter: var(--blur-l);
+  border: none;
+  background-color: var(--modal-background);
+}
+body:is(.mod-macos, .adaptive-mode-off) .suggestion-container,
+body:is(.mod-macos, .adaptive-mode-off) .popover {
+  backdrop-filter: var(--blur-m);
+  border: none;
+  background-color: var(--modal-background);
+}
+body:is(.mod-macos, .adaptive-mode-off) .cm-tooltip,
+body:is(.mod-macos, .adaptive-mode-off) .notice {
+  backdrop-filter: var(--raised-blur);
+  border: none;
+  background-color: var(--modal-background);
+}
+
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .menu,
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .suggestion-container {
+  animation: none;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .menu svg.svg-icon,
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .suggestion-container svg.svg-icon {
+  transition: none;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .menu .menu-item,
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .menu .suggestion-item,
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .suggestion-container .menu-item,
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .suggestion-container .suggestion-item {
+  padding: calc(4px * var(--density-modifier)) 12px;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .menu .suggestion-item,
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .suggestion-container .suggestion-item {
+  min-height: 32px;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .menu .menu-separator,
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .suggestion-container .menu-separator {
+  margin: 6px 8px;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .menu:hover .menu-item.selected:not(.is-label):not(.is-disabled),
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .suggestion-container:hover .menu-item.selected:not(.is-label):not(.is-disabled) {
+  background-color: var(--interactive-accent);
+  color: var(--text-on-accent);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .menu:hover .menu-item.selected:not(.is-label):not(.is-disabled) .menu-item-icon,
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .suggestion-container:hover .menu-item.selected:not(.is-label):not(.is-disabled) .menu-item-icon {
+  color: var(--text-on-accent);
+}
+
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .menu .menu-scroll,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .suggestion-container .menu-scroll {
+  background-color: transparent;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .menu .menu-item,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .menu .suggestion-item,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .suggestion-container .menu-item,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .suggestion-container .suggestion-item {
+  padding: calc(8px * var(--density-modifier)) var(--side-padding);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .menu .menu-item:not([class*=is-]) .menu-item-icon,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .menu .suggestion-item:not([class*=is-]) .menu-item-icon,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .suggestion-container .menu-item:not([class*=is-]) .menu-item-icon,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .suggestion-container .suggestion-item:not([class*=is-]) .menu-item-icon {
+  color: var(--text-normal);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .menu .menu-item .menu-item-icon .svg-icon,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .menu .suggestion-item .menu-item-icon .svg-icon,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .suggestion-container .menu-item .menu-item-icon .svg-icon,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .suggestion-container .suggestion-item .menu-item-icon .svg-icon {
+  --icon-size: var(--icon-m);
+  --icon-stroke: var(--icon-m-stroke-width);
+}
+
+body:is(.mod-macos, .adaptive-mode-off).is-phone {
+  --menu-shadow: var(--shadow-s);
+  --menu-padding: 32px var(--safe-area-inset-side);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .menu {
+  margin: 8px;
+  border-radius: var(--modal-radius) var(--modal-radius) calc(var(--safe-area-inset-top) - 8px) calc(var(--safe-area-inset-top) - 8px);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .menu .menu-item {
+  min-height: 48px;
+  font-size: var(--font-ui-medium);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .menu .menu-item::after {
+  content: none;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .menu .menu-item:not(:last-child) {
+  border-bottom: none;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .menu .menu-item:not(:last-child) .menu-item-title {
+  position: relative;
+  overflow: visible;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .menu .menu-item:not(:last-child) .menu-item-title::after {
+  position: absolute;
+  inset: auto 0 -14px;
+  background-color: rgba(var(--mono-rgb-100), 0.1);
+  height: var(--border-width);
+  content: "";
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .menu-group .menu-item.is-label + .menu-item:not(.is-label),
+body:is(.mod-macos, .adaptive-mode-off).is-phone .menu-group .menu-item:first-child {
+  border-top-left-radius: var(--radius-m);
+  border-top-right-radius: var(--radius-m);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .menu-group .menu-item:last-child {
+  border-bottom-left-radius: var(--radius-m);
+  border-bottom-right-radius: var(--radius-m);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .suggestion-container {
+  border-radius: var(--radius-m);
+}
+
+body:is(.mod-macos, .adaptive-mode-off).is-tablet {
+  --menu-shadow: var(--shadow-l);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .menu .menu-separator,
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .suggestion-container .menu-separator {
+  margin: 4px 16px;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .menu .menu-item,
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .menu .suggestion-item,
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .suggestion-container .menu-item,
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .suggestion-container .suggestion-item {
+  gap: 16px;
+  padding: calc(12px * var(--density-modifier)) var(--side-padding);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .suggestion-container {
+  border-radius: var(--radius-m);
+}
+
+@keyframes modalInCupertino {
+  from {
+    opacity: 1;
+    filter: none;
+    transform: scale(0.99);
+  }
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .modal {
+  animation: modalInCupertino var(--anim-duration-moderate) var(--anim-motion-baseline) forwards;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .modal:not(.mod-sidebar-layout) .modal-title {
+  width: 100%;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .modal:not(.mod-sidebar-layout) .modal-button-container button {
+  flex: 1;
+  margin: 0;
+  border-radius: 100vh;
+  min-height: 32px;
+}
+
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .modal-setting-back-button,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .modal-close-button {
+  --icon-size: var(--icon-xl);
+  padding: 6px;
+}
+
+body:is(.mod-macos, .adaptive-mode-off).is-phone {
+  --modal-radius: var(--radius-xl);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .modal-container.mod-confirmation .modal {
+  border-radius: var(--radius-xl) var(--radius-xl) calc(var(--safe-area-inset-top) - 8px) calc(var(--safe-area-inset-top) - 8px);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .modal:not(.mod-sidebar-layout) {
+  --modal-radius: var(--radius-xl);
+  margin: 0 8px 8px;
+  width: calc(100vw - 16px) !important;
+  left: 0 !important;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .modal:not(.mod-sidebar-layout) .modal-close-button {
+  top: 16px !important;
+  inset-inline-end: 16px !important;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .modal:not(.mod-sidebar-layout) .modal-content {
+  padding: 0 var(--safe-area-inset-side);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .modal:not(.mod-sidebar-layout) .modal-button-container {
+  gap: 8px;
+  padding: 16px var(--safe-area-inset-side) 0;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .modal:not(.mod-sidebar-layout) .modal-button-container button {
+  margin-top: 0;
+}
+
+body:is(.mod-macos, .adaptive-mode-off) .notice {
+  box-shadow: var(--shadow-l);
+  border-radius: var(--radius-m);
+  padding: calc(16px * var(--density-modifier)) var(--side-padding);
+  color: var(--text-muted);
+}
+body:is(.mod-macos, .adaptive-mode-off) .tooltip {
+  --background-modifier-message: var(--background-primary);
+  filter: drop-shadow(0 0 16px var(--background-modifier-box-shadow));
+  animation: none;
+  box-shadow: none;
+  border-radius: var(--radius-l);
+  padding: 8px 16px;
+  color: var(--text-muted);
+  font-weight: var(--font-normal);
+}
+
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .notice {
+  transition: var(--anim-duration-moderate) !important;
+}
+
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .notice {
+  box-shadow: var(--shadow-xs);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .notice:last-child {
+  transition: var(--anim-duration-slow) var(--anim-motion-baseline) !important;
+}
+@starting-style {
+  body:is(.mod-macos, .adaptive-mode-off).is-mobile .notice:last-child {
+    transform: translateY(-50%) scaleX(0.5) !important;
+    filter: blur(4px);
+    opacity: 0;
+  }
+}
+
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) {
+  --drag-ghost-background: var(--background-primary);
+  --drag-ghost-text-color: var(--text-normal);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .drag-ghost {
+  box-shadow: var(--shadow-l);
+  padding: 8px 12px;
+  border-radius: var(--radius-m);
+}
+
+body:is(.mod-macos, .adaptive-mode-off) {
+  --setting-nav-icon-background: var(--color-base-50);
+}
+body:is(.mod-macos, .adaptive-mode-off) .modal.mod-sidebar-layout.mod-settings .vertical-tab-nav-item .vertical-tab-nav-item-icon {
+  --icon-size: var(--icon-xs);
+  --icon-stroke: var(--icon-xs-stroke-width);
+  box-shadow: inset 0.5px 0.5px 0.5px rgba(255, 255, 255, 0.25), inset -0.5px -0.5px 0.5px rgba(255, 255, 255, 0.25), 0 0 2px rgba(0, 0, 0, 0.25), 0 1px 4px rgba(0, 0, 0, 0.15);
+  border-radius: 6px;
+  background-image: linear-gradient(oklch(from var(--setting-nav-icon-background) calc(l * 1.125) c h), oklch(from var(--setting-nav-icon-background) calc(l * 0.975) c h));
+  background-color: var(--setting-nav-icon-background);
+  padding: 4px;
+  color: var(--setting-nav-icon-color, white);
+}
+body:is(.mod-macos, .adaptive-mode-off) .modal.mod-sidebar-layout.mod-settings .vertical-tab-nav-item[data-setting-id=canvas] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-color: var(--color-red);
+  --setting-nav-icon-background: var(--color-base-10);
+}
+body:is(.mod-macos, .adaptive-mode-off) .modal.mod-sidebar-layout.mod-settings .vertical-tab-nav-item[data-setting-id=command-palette] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-background: #242424;
+}
+body:is(.mod-macos, .adaptive-mode-off) .modal.mod-sidebar-layout.mod-settings .vertical-tab-nav-item[data-setting-id=sync] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-color: var(--color-green);
+  --setting-nav-icon-background: var(--color-base-10);
+}
+body:is(.mod-macos, .adaptive-mode-off) .modal.mod-sidebar-layout.mod-settings .vertical-tab-nav-item[data-setting-id=webviewer] .vertical-tab-nav-item-icon {
+  --setting-nav-icon-color: var(--color-blue);
+  --setting-nav-icon-background: var(--color-base-10);
+}
+
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) {
+  --setting-items-padding: calc(12px * var(--density-modifier)) var(--side-padding);
+  --setting-group-heading-color: var(--text-normal);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .modal.mod-sidebar-layout {
+  background-color: var(--background-primary);
+  border: none;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .modal.mod-settings .vertical-tab-nav-item.is-active {
+  --text-normal: var(--text-on-accent);
+  color: var(--text-on-accent);
+  background-color: var(--interactive-accent);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .modal.mod-settings .vertical-tab-nav-item:not(.is-active):hover {
+  background-color: transparent;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .modal.mod-settings .vertical-tab-header-group-title,
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .modal.mod-settings .vertical-tab-nav-item {
+  padding: 6px 8px;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .modal.mod-settings .setting-group-search + .setting-items {
+  border-radius: var(--setting-items-radius);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .modal.mod-settings .setting-items .setting-item {
+  padding: 12px 0;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .modal.mod-settings .setting-items .setting-item:first-child {
+  padding-top: 0;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .modal.mod-settings .setting-items .setting-item:last-child {
+  padding-bottom: 0;
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .modal.mod-settings .setting-item:not(.setting-item-heading, .setting-items .setting-item) {
+  padding: var(--setting-items-padding);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .modal.mod-settings .installed-plugins-container .extra-setting-button {
+  min-width: unset;
+}
+
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .modal.mod-settings .vertical-tab-nav-item .vertical-tab-nav-item-icon {
+  padding: 5px;
+  border-radius: 8px;
+  box-shadow: 0 0 0 0.5px var(--background-modifier-border);
+  margin-left: -4px;
+}
+
+body:is(.mod-macos, .adaptive-mode-off).is-phone {
+  --setting-items-radius: var(--radius-m);
+  --setting-group-heading-size: var(--font-ui-medium);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .modal.mod-sidebar-layout {
+  --modal-radius: var(--radius-xl) var(--radius-xl) 0 0;
+  max-height: calc(100% - var(--safe-area-inset-top));
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .modal.mod-sidebar-layout .modal-setting-back-button {
+  inset-inline-start: var(--safe-area-inset-side);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .modal.mod-sidebar-layout .modal-close-button {
+  top: var(--safe-area-inset-side);
+  inset-inline-end: var(--safe-area-inset-side) !important;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .modal.mod-sidebar-layout .vertical-tab-header,
+body:is(.mod-macos, .adaptive-mode-off).is-phone .modal.mod-sidebar-layout .vertical-tab-content {
+  padding-top: var(--modal-header-height);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .modal.mod-sidebar-layout .vertical-tab-nav-item {
+  height: var(--touch-size-xl);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .modal.mod-settings {
+  --modal-header-height: 76px;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .modal.mod-settings .modal-title {
+  margin-top: 16px;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .modal.mod-community-modal .modal-header {
+  position: absolute;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .modal.mod-community-modal .modal-title {
+  height: calc(var(--touch-size-m) + 32px);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .modal.mod-community-modal .modal-content .modal-sidebar,
+body:is(.mod-macos, .adaptive-mode-off).is-phone .modal.mod-community-modal .modal-content .community-modal-info {
+  padding-top: calc(var(--touch-size-m) + 32px);
+  border-radius: var(--modal-radius);
+}
+
+body:is(.mod-macos, .adaptive-mode-off).is-tablet {
+  --setting-items-padding: calc(16px * var(--density-modifier)) var(--side-padding);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .modal.mod-settings .vertical-tab-header-group-title {
+  display: none;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .modal.mod-settings .vertical-tab-nav-item {
+  padding: calc(12px * var(--density-modifier)) var(--side-padding);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .modal.mod-settings .vertical-tab-nav-item.is-active {
+  color: var(--interactive-accent);
+  background-color: var(--background-modifier-hover);
+}
+
+body:is(.mod-macos, .adaptive-mode-off) .prompt-input-container {
+  align-items: center;
+}
+body:is(.mod-macos, .adaptive-mode-off) .prompt-input-container::before,
+body:is(.mod-macos, .adaptive-mode-off) .omnisearch-input-field::before {
+  position: absolute;
+  left: var(--side-padding);
+  -webkit-mask-position: 50% 50%;
+  -webkit-mask-size: 100% 100%;
+  -webkit-mask-repeat: no-repeat;
+  background-color: var(--search-icon-color);
+  width: var(--search-icon-size);
+  height: var(--search-icon-size);
+  content: "";
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cg clip-path='url(%23a)'%3e%3cpath fill='white' d='M0 7.793c0 4.297 3.496 7.793 7.793 7.793 1.7 0 3.252-.547 4.531-1.465l4.805 4.815c.224.224.517.332.83.332.664 0 1.123-.498 1.123-1.153a1.118 1.118 0 0 0-.322-.8l-4.776-4.805a7.703 7.703 0 0 0 1.602-4.717C15.586 3.496 12.09 0 7.793 0 3.496 0 0 3.496 0 7.793Zm1.67 0A6.127 6.127 0 0 1 7.793 1.67a6.127 6.127 0 0 1 6.123 6.123 6.127 6.127 0 0 1-6.123 6.123A6.127 6.127 0 0 1 1.67 7.793Z'/%3e%3c/g%3e%3cdefs%3e%3cclipPath id='a'%3e%3cpath fill='white' d='M0 0h20v20H0z'/%3e%3c/clipPath%3e%3c/defs%3e%3c/svg%3e");
+  z-index: 1;
+}
+body:is(.mod-macos, .adaptive-mode-off) .prompt-input {
+  border-bottom: none;
+  padding-inline-start: calc(var(--search-icon-size) + var(--side-padding) + 12px) !important;
+}
+body:is(.mod-macos, .adaptive-mode-off) .prompt .suggestion-item {
+  border-radius: var(--radius-m);
+  padding: calc(12px * var(--density-modifier)) var(--side-padding);
+}
+body:is(.mod-macos, .adaptive-mode-off) .prompt-instructions {
+  border-top: none;
+}
+
+body:is(.mod-macos, .adaptive-mode-off):not(.is-phone) {
+  --prompt-input-height: 56px;
+}
+@keyframes bounceInScale {
+  from {
+    transform: scale(1.15);
+    opacity: 0;
+  }
+  50% {
+    transform: scale(0.99);
+  }
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-phone) .prompt {
+  animation: var(--anim-duration-moderate) bounceInScale var(--anim-motion-baseline) forwards;
+  border-radius: var(--radius-xl);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-phone) .prompt-input-container::after {
+  content: "";
+  position: absolute;
+  inset: auto var(--side-padding) 0;
+  height: var(--border-width);
+  background-color: var(--background-modifier-border);
+  pointer-events: none;
+}
+
+body:is(.mod-macos, .adaptive-mode-off).is-phone {
+  --prompt-input-height: 48px;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .prompt {
+  --prompt-top: 0;
+  border-radius: 0;
+  height: 100vh;
+  padding-bottom: 0;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .prompt .prompt-input-container {
+  width: calc(100% - var(--safe-area-inset-side) * 2);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .prompt .prompt-input-container,
+body:is(.mod-macos, .adaptive-mode-off).is-phone .prompt .suggester-input {
+  border: none;
+  gap: 8px;
+  position: absolute;
+  inset: auto var(--safe-area-inset-side) calc(var(--safe-area-inset-side) + var(--safe-area-inset-bottom));
+  z-index: 1;
+  background-color: transparent;
+  box-shadow: none;
+  backdrop-filter: none;
+  margin: 0;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .prompt .prompt-input {
+  border-radius: 100vh;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .prompt .prompt-input-container .prompt-input-cta:not(:empty),
+body:is(.mod-macos, .adaptive-mode-off).is-phone .prompt .prompt-input-container .search-input-clear-button {
+  border-radius: 100vh;
+  position: relative;
+  inset-inline-end: 0;
+  width: var(--prompt-input-height);
+  height: var(--prompt-input-height);
+  flex-shrink: 0;
+  margin: 0;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .prompt .prompt-input-container .search-input-clear-button:after {
+  -webkit-mask-position: 50% 50%;
+  -webkit-mask-size: 100% 100%;
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3e%3cpath fill='black' d='M13.993.26.253 14a.875.875 0 0 0 0 1.23.896.896 0 0 0 1.24 0l13.74-13.74a.875.875 0 0 0 0-1.23.87.87 0 0 0-1.24 0ZM15.233 14 1.493.26a.87.87 0 0 0-1.24 0 .884.884 0 0 0 0 1.23l13.74 13.74c.332.333.908.342 1.24 0a.884.884 0 0 0 0-1.23Z'/%3e%3c/svg%3e");
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .prompt .prompt-results {
+  mask: linear-gradient(to bottom, transparent, black calc(var(--safe-area-inset-top) + 16px), black calc(100vh - var(--side-padding) - var(--safe-area-inset-bottom) - 96px), transparent calc(100vh - var(--side-padding) - var(--safe-area-inset-bottom)));
+  padding: calc(var(--safe-area-inset-top) + 16px) var(--side-padding) 128px;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .prompt .suggestion-item {
+  padding: var(--nav-item-padding);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .prompt {
+  transition: var(--anim-duration-moderate) !important;
+  transform: none !important;
+  overflow: visible;
+  box-shadow: none;
+}
+@starting-style {
+  body:is(.mod-macos, .adaptive-mode-off).is-phone .prompt {
+    opacity: 0;
+  }
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .prompt-results {
+  transition: var(--anim-duration-slow) var(--anim-motion-baseline);
+}
+@starting-style {
+  body:is(.mod-macos, .adaptive-mode-off).is-phone .prompt-results {
+    transform: translateY(var(--safe-area-inset-top));
+  }
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .prompt[style*="transform: translateY"] {
+  opacity: 0;
+}
+
+body:is(.mod-macos, .adaptive-mode-off).is-tablet .prompt {
+  border-radius: var(--radius-l);
+}
+
+body:is(.mod-macos, .adaptive-mode-off).is-mobile:where(.is-phone):not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2), body:is(.mod-macos, .adaptive-mode-off).is-mobile:where(.is-phone) .prompt-input, body:is(.mod-macos, .adaptive-mode-off).is-mobile:where(.is-phone) .prompt-input-container .prompt-input-cta:not(:empty), body:is(.mod-macos, .adaptive-mode-off).is-mobile:where(.is-phone) .prompt-input-container .search-input-clear-button, body:is(.mod-macos, .adaptive-mode-off).is-mobile:where(.is-phone) .workspace-drawer-header-icon,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .mobile-tab-switcher-menu-button,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .mobile-tab-switcher-menu-spacer .clickable-icon,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .modal-setting-back-button,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .modal-close-button,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .pull-action {
+  backdrop-filter: var(--raised-blur);
+  box-shadow: var(--shadow-xs);
+  border: none;
+  background-color: var(--raised-background);
+  color: var(--text-normal);
+  transition: var(--anim-duration-moderate);
+}
+@starting-style {
+  body:is(.mod-macos, .adaptive-mode-off).is-mobile:where(.is-phone):not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2), body:is(.mod-macos, .adaptive-mode-off).is-mobile:where(.is-phone) .prompt-input, body:is(.mod-macos, .adaptive-mode-off).is-mobile:where(.is-phone) .prompt-input-container .prompt-input-cta:not(:empty), body:is(.mod-macos, .adaptive-mode-off).is-mobile:where(.is-phone) .prompt-input-container .search-input-clear-button, body:is(.mod-macos, .adaptive-mode-off).is-mobile:where(.is-phone) .workspace-drawer-header-icon,
+  body:is(.mod-macos, .adaptive-mode-off).is-mobile .mobile-tab-switcher-menu-button,
+  body:is(.mod-macos, .adaptive-mode-off).is-mobile .mobile-tab-switcher-menu-spacer .clickable-icon,
+  body:is(.mod-macos, .adaptive-mode-off).is-mobile .modal-setting-back-button,
+  body:is(.mod-macos, .adaptive-mode-off).is-mobile .modal-close-button,
+  body:is(.mod-macos, .adaptive-mode-off).is-mobile .pull-action {
+    opacity: 0;
+    filter: blur(4px);
+    transform: scale(0.75);
+  }
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .workspace-leaf-content:not([data-type=empty]) .mod-left-split-toggle svg.svg-icon {
+  --icon-size: var(--icon-l);
+  background-color: currentColor;
+  content: "";
+  -webkit-mask-position: 25% 50%;
+  -webkit-mask-size: 80% 80%;
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='12' height='21' fill='none' viewBox='0 0 12 21'%3e%3cpath fill='white' d='M0 10.372c0 .397.141.732.459 1.046l9.137 8.934c.256.266.575.395.953.395a1.35 1.35 0 0 0 1.372-1.354c0-.382-.163-.718-.422-.983l-8.24-8.04 8.24-8.036c.261-.266.422-.61.422-.98A1.349 1.349 0 0 0 10.549 0c-.38 0-.697.129-.953.385L.459 9.327A1.397 1.397 0 0 0 0 10.372Z'/%3e%3c/svg%3e");
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .workspace-drawer .nav-buttons-container {
+  justify-self: center;
+  gap: 0;
+  backdrop-filter: blur(4px);
+  border-radius: 100vh;
+  background-color: var(--background-modifier-hover);
+  padding-inline: 8px;
+  width: fit-content;
+  margin-bottom: 8px;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile:not(.is-floating-nav) .workspace-drawer .nav-buttons-container {
+  margin-bottom: 0;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile.theme-dark .mod-raised::after {
+  content: none !important;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile.mod-macos.theme-light .mod-raised::after, body:is(.mod-macos, .adaptive-mode-off).is-mobile.mod-macos.theme-light.is-phone:not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2)::after, body:is(.mod-macos, .adaptive-mode-off).is-mobile.mod-macos.theme-light.is-phone .prompt-input-container::after, body:is(.mod-macos, .adaptive-mode-off).is-mobile.mod-macos.theme-light.is-phone .prompt-input-container .prompt-input-cta:not(:empty)::before, body:is(.mod-macos, .adaptive-mode-off).is-mobile.mod-macos.theme-light.is-phone .prompt-input-container .search-input-clear-button::before, body:is(.mod-macos, .adaptive-mode-off).is-mobile.mod-macos.theme-light.is-tablet .menu::after, body:is(.mod-macos, .adaptive-mode-off).is-mobile.mod-macos.theme-light.is-tablet .workspace-drawer:not(.is-pinned)::after,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile.mod-macos.theme-light .mobile-tab-switcher-menu-button::after,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile.mod-macos.theme-light .mobile-tab-switcher-menu-spacer .clickable-icon::before,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile.mod-macos.theme-light .modal-setting-back-button::after,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile.mod-macos.theme-light .modal-close-button::after,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile.mod-macos.theme-light .notice::after {
+  position: absolute;
+  z-index: 1;
+  backdrop-filter: brightness(var(--blur-brightness));
+  mask: var(--raised-mask);
+  mask-composite: var(--raised-mask-composite);
+  filter: blur(1px);
+  inset: 0;
+  border: var(--raised-mask-border-width) solid transparent;
+  border-radius: inherit;
+  background: var(--raised-mask-background);
+  pointer-events: none;
+  content: "";
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile.mod-macos.theme-light.is-phone .prompt-input-container::after {
+  height: auto;
+  border-radius: 100vh;
+  margin-right: 56px;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .bases-cards-item {
+  padding: var(--side-padding);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .bases-cards-line,
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .bases-cards-label {
+  padding: 0;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-mobile .nav-files-container > div {
+  --nav-item-color: var(--text-normal);
+}
+
+body:is(.mod-macos, .adaptive-mode-off).is-phone .mod-root .view-header-left,
+body:is(.mod-macos, .adaptive-mode-off).is-phone .mod-root .view-actions {
+  flex: 0;
+  position: relative;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .mod-root .view-header {
+  padding-inline: var(--safe-area-inset-side);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .mod-root .view-header-title-parent {
+  font-size: var(--font-ui-smaller);
+  opacity: 1;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .mod-root .view-header-title {
+  font-weight: var(--font-medium);
+  opacity: 1;
+  height: 1lh;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .mod-root .view-header-breadcrumb {
+  padding: 0;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .mod-root .view-header-breadcrumb-separator {
+  padding: 0 4px;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .mod-root .view-header-breadcrumb-separator:last-child {
+  display: none;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone.theme-light .nav-files-container > div {
+  background-color: var(--background-primary);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone.theme-dark .nav-files-container > div {
+  background-color: var(--background-secondary);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .nav-files-container > div {
+  --nav-item-size: var(--font-ui-medium);
+  --nav-item-color: var(--text-normal);
+  --nav-item-color-hover: var(--text-normal);
+  --nav-item-color-active: var(--text-normal);
+  --nav-item-background-hover: transparent;
+  --nav-item-background-active: var(--background-modifier-hover);
+  --nav-item-weight-hover: var(--font-normal);
+  --nav-item-weight-active: var(--font-normal);
+  border-radius: var(--radius-m);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .nav-files-container > div .tree-item {
+  position: relative;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .nav-files-container > div .tree-item .tree-item-self {
+  padding-inline-end: var(--side-padding);
+  margin-bottom: 0;
+  border-radius: 0;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .nav-files-container > div .tree-item .tree-item-self .tree-item-icon {
+  position: relative;
+  order: 1;
+  margin-inline-start: unset;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .nav-files-container > div .tree-item .tree-item-inner {
+  flex: 1;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .nav-files-container > div .tree-item-self.has-active-menu,
+body:is(.mod-macos, .adaptive-mode-off).is-phone .nav-files-container > div .tree-item-self.is-being-renamed {
+  box-shadow: none;
+  color: var(--text-accent);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .nav-files-container > div .tree-item:has(> .tree-item-self.is-active)::before,
+body:is(.mod-macos, .adaptive-mode-off).is-phone .nav-files-container > div .tree-item:has(> .tree-item-self.is-active) + .tree-item::before {
+  content: none !important;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .nav-files-container > div .tree-item:not(.nav-files-container > div > div:nth-child(2)):not(:last-child:only-child):before {
+  position: absolute;
+  inset: calc(-1 * var(--border-width) / 2) var(--side-padding) auto;
+  background: var(--background-modifier-border);
+  height: var(--border-width);
+  content: "";
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .nav-files-container > div .tree-item-self.is-active::before {
+  content: none;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .mobile-navbar {
+  border: none !important;
+  background-color: var(--raised-background) !important;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone {
+  --tab-switcher-background: transparent;
+  --tab-switcher-preview-background-shadow: 0 4px 16px rgba(0, 0, 0, 0.2);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .mobile-tab-switcher {
+  background: linear-gradient(rgba(var(--mono-rgb-0), 0.5), var(--mobile-sidebar-background)) !important;
+  backdrop-filter: var(--blur-l);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .mobile-tab-switcher-menubar {
+  padding: 0 var(--navbar-side-offset) var(--navbar-bottom-offset);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .mobile-tab-switcher-menu-button {
+  flex: 1;
+  height: var(--input-height);
+  border-radius: var(--clickable-icon-radius);
+  justify-content: center;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .mobile-tab-switcher-menu-spacer .clickable-icon {
+  position: relative;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .mobile-tab-switcher-menu-spacer:first-child .clickable-icon {
+  width: var(--input-height);
+  height: var(--input-height);
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .mobile-tab-switcher-menu-spacer:last-child .clickable-icon {
+  padding: var(--input-padding);
+  height: var(--input-height);
+  backdrop-filter: none;
+}
+body:is(.mod-macos, .adaptive-mode-off).is-phone .mobile-tab .mobile-tab-pin,
+body:is(.mod-macos, .adaptive-mode-off).is-phone .mobile-tab .close-button {
+  width: 32px;
+  height: 32px;
+}
+
+body.mod-windows:not(.adaptive-mode-off) {
+  --font-interface-theme: "Segoe UI Variable Display", "Segoe UI Variable";
+  --font-text-theme: "Segoe UI Variable Text", "Segoe UI Variable";
+  --h1-size: 1.75rem;
+  --h2-size: 1.5rem;
+  --h3-size: 1.25rem;
+  --radius-s: calc(4px * var(--radius-modifier));
+  --radius-m: calc(4px * var(--radius-modifier));
+  --radius-l: calc(8px * var(--radius-modifier));
+  --radius-xl: calc(8px * var(--radius-modifier));
+  --input-radius: var(--radius-m);
+  --button-radius: var(--input-radius);
+  --clickable-icon-radius: var(--radius-m);
+  --checkbox-radius: var(--radius-m);
+  --tab-radius: var(--radius-l);
+  --toggle-thumb-height: 12px;
+  --toggle-thumb-width: 12px;
+  --toggle-width: 40px;
+  --toggle-border-width: 4px;
+  --slider-thumb-border-width: 4px;
+  --slider-thumb-width: 18px;
+  --slider-thumb-height: 18px;
+  --slider-track-background: var(--color-base-50);
+  --slider-track-height: 4px;
+  --blur-s: blur(8px) saturate(0.75);
+  --blur-m: blur(16px) saturate(0.75);
+  --blur-l: blur(32px) saturate(0.75);
+}
+body.mod-windows:not(.adaptive-mode-off).is-mobile {
+  --input-border-width: var(--border-width);
+  --slider-thumb-width: 24px;
+  --slider-thumb-height: 24px;
+}
+body.mod-windows:not(.adaptive-mode-off).theme-light {
+  --input-shadow: 0px 0px 0px var(--input-border-width) rgba(0, 0, 0, 0.05), 0 -0.5px 0 0 rgba(0, 0, 0, 0.25) inset !important;
+  --input-shadow-hover: var(--input-shadow) !important;
+  --input-shadow-active: inset 0 0 0 1px var(--background-modifier-border);
+  --slider-thumb-border-color: var(--color-base-00);
+  --shadow-s: 0px 1px 2px rgba(0, 0, 0, 0.028), 0px 3.4px 6.7px rgba(0, 0, 0, 0.042), 0px 15px 30px rgba(0, 0, 0, 0.07);
+  --shadow-l: 0px 32px 64px 0px rgba(0, 0, 0, 0.19), 0px 2px 21px 0px rgba(0, 0, 0, 0.15);
+  --modal-background: rgb(from white r g b / 85%);
+  --setting-items-background: var(--background-primary);
+}
+body.mod-windows:not(.adaptive-mode-off).theme-dark {
+  --input-shadow: 0px 0px 0px var(--input-border-width) rgba(0, 0, 0, 0.1), 0 0.5px 0 rgba(255, 255, 255, 0.1) inset !important;
+  --input-shadow-hover: var(--input-shadow) !important;
+  --input-shadow-active: inset 0 0 1px var(--background-modifier-border);
+  --slider-thumb-border-color: var(--color-base-35);
+  --shadow-s: 0px 1px 2px rgba(0, 0, 0, 0.028), 0px 3.4px 6.7px rgba(0, 0, 0, 0.042), 0px 15px 30px rgba(0, 0, 0, 0.07);
+  --shadow-l: 0px 32px 64px 0px rgba(0, 0, 0, 0.37), 0px 2px 21px 0px rgba(0, 0, 0, 0.37);
+  --modal-background: rgb(from var(--color-base-20) r g b / 65%);
+  --setting-items-background: var(--background-secondary);
+}
+body.mod-windows:not(.adaptive-mode-off).is-translucent {
+  --modal-background: var(--background-secondary);
+}
+body.mod-windows:not(.adaptive-mode-off) button:active,
+body.mod-windows:not(.adaptive-mode-off) select:focus,
+body.mod-windows:not(.adaptive-mode-off) .combobox-button:focus,
+body.mod-windows:not(.adaptive-mode-off) .dropdown:focus {
+  opacity: 0.75;
+  box-shadow: var(--input-shadow-active);
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .clickable-icon.is-active {
+  color: var(--icon-color-focused);
+  background-color: var(--background-primary);
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .clickable-icon:not([aria-disabled=true], .modal-close-button):hover,
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .clickable-icon.has-active-menu {
+  background-color: var(--background-modifier-hover);
+}
+body.mod-windows:not(.adaptive-mode-off) input:is([type=text], [type=search], [type=email], [type=password], [type=number]):not(.prompt-input) {
+  box-shadow: 0 -0.5px 0 var(--color-base-50) inset;
+}
+body.mod-windows:not(.adaptive-mode-off) input:is([type=text], [type=search], [type=email], [type=password], [type=number]):not(.prompt-input):active, body.mod-windows:not(.adaptive-mode-off) input:is([type=text], [type=search], [type=email], [type=password], [type=number]):not(.prompt-input):focus, body.mod-windows:not(.adaptive-mode-off) input:is([type=text], [type=search], [type=email], [type=password], [type=number]):not(.prompt-input):focus-visible {
+  box-shadow: 0 -2px 0 var(--interactive-accent) inset;
+  border-color: var(--background-modifier-border);
+}
+body.mod-windows:not(.adaptive-mode-off) input[type=range]::-webkit-slider-thumb {
+  transition: var(--anim-duration-fast);
+  box-shadow: 0 0.5px 1px 1px rgba(0, 0, 0, 0.1);
+  background-color: var(--interactive-accent);
+}
+body.mod-windows:not(.adaptive-mode-off) input[type=range]::-webkit-slider-thumb:hover,
+body.mod-windows:not(.adaptive-mode-off) input[type=range]::-webkit-slider-thumb:active {
+  --slider-thumb-border-width: 3px;
+  border-color: var(--slider-thumb-border-color);
+}
+body.mod-windows:not(.adaptive-mode-off) .checkbox-container:not(.is-enabled) {
+  --toggle-thumb-color: var(--text-muted);
+  outline: 1px solid var(--text-faint);
+  background-color: var(--color-base-10);
+}
+body.mod-windows:not(.adaptive-mode-off) .checkbox-container:hover {
+  --toggle-thumb-height: 16px;
+  --toggle-thumb-width: 16px;
+  --toggle-border-width: 2px;
+}
+body.mod-windows:not(.adaptive-mode-off) .menu,
+body.mod-windows:not(.adaptive-mode-off) .suggestion-container,
+body.mod-windows:not(.adaptive-mode-off) .popover,
+body.mod-windows:not(.adaptive-mode-off) .prompt,
+body.mod-windows:not(.adaptive-mode-off) .modal,
+body.mod-windows:not(.adaptive-mode-off) .cm-tooltip,
+body.mod-windows:not(.adaptive-mode-off) .notice {
+  background-color: var(--modal-background) !important;
+  backdrop-filter: var(--blur-l);
+  border: none;
+}
+body.mod-windows:not(.adaptive-mode-off) .modal.mod-settings {
+  --setting-items-padding: 0px;
+}
+body.mod-windows:not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-header-group-title,
+body.mod-windows:not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-nav-item {
+  padding: calc(8px * var(--density-modifier)) 16px;
+  position: relative;
+  border-radius: var(--setting-items-radius);
+}
+body.mod-windows:not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-nav-item.is-active {
+  background-color: var(--background-modifier-hover);
+  color: var(--text-normal);
+}
+body.mod-windows:not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-nav-item.is-active::before {
+  position: absolute;
+  top: 8px;
+  bottom: 8px;
+  left: 0;
+  border-radius: var(--button-radius);
+  background-color: var(--interactive-accent);
+  width: 4px;
+  content: "";
+  margin-left: unset;
+  height: unset;
+}
+body.mod-windows:not(.adaptive-mode-off) .modal.mod-settings .setting-items {
+  background-color: transparent;
+  padding-block: 0;
+}
+body.mod-windows:not(.adaptive-mode-off) .modal.mod-settings .setting-item:not(.setting-item-heading) {
+  border: var(--border-width) solid rgba(0, 0, 0, 0.1);
+  border-radius: var(--radius-m);
+  padding: calc(16px * var(--density-modifier));
+  background-color: var(--setting-items-background);
+}
+body.mod-windows:not(.adaptive-mode-off) .modal.mod-settings .setting-item:not(.setting-item-heading):not(:first-child) {
+  margin-top: 4px;
+}
+body.mod-windows:not(.adaptive-mode-off) .notice {
+  color: var(--text-muted);
+}
+
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) {
+  --menu-padding: 4px;
+  --prompt-input-height: 64px;
+  --tab-outline-color: rgba(var(--mono-rgb-100), 0.05);
+}
+@keyframes workspaceLeafInFluent {
+  from {
+    transform: translateY(16px);
+    opacity: 0;
+  }
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .mod-sidedock .workspace-leaf {
+  animation: workspaceLeafInFluent var(--anim-duration-moderate);
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile):not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child .nav-buttons-container {
+  padding: 0;
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile):not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child .nav-buttons-container .nav-action-button {
+  flex: 1;
+  padding: 12px;
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile):not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child .nav-buttons-container .nav-action-button.is-active {
+  background-color: var(--interactive-normal);
+  color: var(--icon-color);
+  box-shadow: inset 0 0 0 1px var(--background-modifier-hover);
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile):not(.nav-action-center) .mod-sidedock .workspace-leaf-content .nav-header:first-child .nav-buttons-container .nav-action-button.is-active::after {
+  position: absolute;
+  bottom: 0;
+  border-radius: var(--button-radius);
+  background-color: var(--interactive-accent);
+  width: 24px;
+  height: 3px;
+  content: "";
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal-bg {
+  background-color: black;
+  opacity: 0.3 !important;
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .menu,
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .suggestion-container {
+  animation: none;
+  border-radius: var(--radius-l);
+  border: var(--border-width) solid var(--background-modifier-border);
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .menu .menu-separator,
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .suggestion-container .menu-separator {
+  margin: var(--menu-padding) calc(-1 * var(--menu-padding));
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .menu .menu-item,
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .menu .suggestion-item,
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .suggestion-container .menu-item,
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .suggestion-container .suggestion-item {
+  border-radius: var(--radius-m);
+  padding: 8px;
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .menu .menu-item-icon .svg-icon,
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .suggestion-container .menu-item-icon .svg-icon {
+  --icon-size: var(--icon-s);
+  --icon-stroke: var(--icon-s-stroke-width);
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .prompt {
+  animation: none;
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .prompt .prompt-results {
+  position: relative;
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .prompt .prompt-results .suggestion-item {
+  position: relative;
+  padding: calc(12px * var(--density-modifier)) 20px;
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .prompt .prompt-results .suggestion-item.is-selected::after {
+  position: absolute;
+  top: 12px;
+  bottom: 12px;
+  left: 0;
+  border-radius: var(--button-radius);
+  background-color: var(--interactive-accent);
+  width: 4px;
+  content: "";
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal {
+  animation: none;
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal-close-button {
+  top: 0;
+  inset-inline-end: 0 !important;
+  padding-inline: 16px;
+  border-radius: 0;
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal-close-button:empty::before {
+  margin: 0;
+  width: var(--icon-s);
+  height: var(--icon-s);
+  font-size: var(--icon-xs);
+  font-weight: 100;
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal-close-button:hover {
+  background-color: var(--color-red);
+  color: white;
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal:not(.mod-sidebar-layout) {
+  padding: 0;
+  min-width: 480px;
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal:not(.mod-sidebar-layout) .modal-title {
+  padding: 24px 24px 4px;
+  font-size: var(--font-ui-large);
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal:not(.mod-sidebar-layout) .modal-content {
+  padding: 4px 24px 16px;
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal:not(.mod-sidebar-layout) .modal-button-container {
+  margin: 0;
+  border-top: var(--border-width) solid var(--background-modifier-border);
+  background-color: rgba(0, 0, 0, 0.05);
+  padding: 24px;
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal:not(.mod-sidebar-layout) .modal-button-container button {
+  border-radius: var(--button-radius);
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal:not(.mod-sidebar-layout) .modal-content > .modal-button-container {
+  margin: 0 -24px -16px;
+}
+body.mod-windows:not(.adaptive-mode-off):not(.is-mobile) .modal.mod-sidebar-layout .vertical-tab-content {
+  animation: workspaceLeafInFluent var(--anim-duration-moderate);
+}
+
+body.mod-windows:not(.adaptive-mode-off).is-phone .mobile-navbar, body.mod-windows:not(.adaptive-mode-off).is-phone:not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2) {
+  backdrop-filter: var(--blur-l);
+  box-shadow: var(--shadow-s);
+  border-radius: var(--radius-l);
+  background-color: var(--modal-background) !important;
+}
+body.mod-windows:not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-header-group-items {
+  background-color: transparent;
+}
+body.mod-windows:not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-nav-item-chevron,
+body.mod-windows:not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-nav-item-title {
+  border-bottom: none;
+}
+body.mod-windows:not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-content {
+  background-color: var(--settings-background);
+}
+
+@font-face {
+  font-family: "Google Sans System";
+  font-style: normal;
+  font-weight: 1 1000;
+  src: local("GoogleSansFlex-Regular"), local("Google Sans Flex");
+}
+@font-face {
+  font-family: "Google Sans System";
+  font-style: italic;
+  font-weight: 1 1000;
+  src: local("GoogleSans-Italic"), local("Google Sans Italic");
+}
+body.is-android:not(.adaptive-mode-off) {
+  --font-interface-theme: "Google Sans System", "Google Sans Flex", "Google Sans";
+  --font-text-theme: "Google Sans System", "Google Sans Flex", "Google Sans";
+  --h1-size: 2.25rem;
+  --h1-weight: 400;
+  --h2-size: 1.75rem;
+  --h2-weight: 400;
+  --h3-size: 1.375rem;
+  --h3-weight: 400;
+  --h4-weight: 500;
+  --h5-weight: 500;
+  --h6-weight: 500;
+  --input-font-weight: var(--font-medium);
+  --input-border-width: 1px;
+  --input-height: 40px;
+  --radius-xs: calc(4px * var(--radius-modifier));
+  --radius-s: calc(8px * var(--radius-modifier));
+  --radius-m: calc(12px * var(--radius-modifier));
+  --radius-l: calc(16px * var(--radius-modifier));
+  --radius-xl: calc(28px * var(--radius-modifier));
+  --input-radius: var(--radius-s);
+  --button-radius: 100vh;
+  --clickable-icon-radius: 100vh;
+  --tab-radius: var(--radius-m);
+  --toggle-border-width: 4px;
+  --toggle-thumb-height: 24px;
+  --toggle-thumb-width: 24px;
+  --toggle-width: 52px;
+  --toggle-s-border-width: var(--toggle-border-width);
+  --toggle-s-thumb-height: var(--toggle-thumb-height);
+  --toggle-s-thumb-width: var(--toggle-thumb-width);
+  --toggle-s-width: var(--toggle-width);
+  --slider-thumb-border-width: 0;
+  --slider-thumb-height: 44px;
+  --slider-thumb-width: 4px;
+  --slider-thumb-y: -19px;
+  --slider-thumb-radius: 100vh;
+  --slider-track-height: 16px;
+  --tab-font-weight: var(--font-medium);
+  --nav-item-weight: var(--font-medium);
+  --nav-item-weight-hover: var(--font-medium);
+  --nav-item-weight-active: var(--font-medium);
+  --nav-item-radius: 100vh;
+  --background-modifier-border: var(--color-base-30);
+  --background-modifier-form-field: var(--background-modifier-hover);
+  --interactive-hover: var(--color-base-25);
+  --interactive-normal: var(--background-primary);
+  --dropdown-background: var(--background-modifier-form-field);
+  --dropdown-background-hover: var(--background-modifier-form-field);
+  --menu-radius: var(--radius-l);
+  --shadow-s: rgba(0, 0, 0, 0.2) 0px 3px 3px -2px, rgba(0, 0, 0, 0.14) 0px 3px 4px 0px, rgba(0, 0, 0, 0.12) 0px 1px 8px 0px !important;
+  --shadow-l: rgba(0, 0, 0, 0.2) 0px 3px 5px -1px, rgba(0, 0, 0, 0.14) 0px 6px 10px 0px, rgba(0, 0, 0, 0.12) 0px 1px 18px 0px !important;
+}
+body.is-android:not(.adaptive-mode-off).theme-light {
+  --setting-items-background: var(--background-primary);
+}
+body.is-android:not(.adaptive-mode-off).theme-dark {
+  --setting-items-background: var(--background-secondary);
+}
+body.is-android:not(.adaptive-mode-off) button:not([aria-disabled=true]),
+body.is-android:not(.adaptive-mode-off) .clickable-icon:not([aria-disabled=true]),
+body.is-android:not(.adaptive-mode-off) .tappable,
+body.is-android:not(.adaptive-mode-off) .is-clickable {
+  cursor: pointer;
+}
+body.is-android:not(.adaptive-mode-off) textarea,
+body.is-android:not(.adaptive-mode-off) input:is([type=text], [type=search], [type=email], [type=password], [type=number]):not(.prompt-input),
+body.is-android:not(.adaptive-mode-off) select,
+body.is-android:not(.adaptive-mode-off) .combobox-button,
+body.is-android:not(.adaptive-mode-off) .dropdown {
+  transition: var(--anim-duration-fast);
+  box-shadow: inset 0 0 var(--interactive-accent);
+  border-width: 0 0 var(--border-width);
+  border-style: solid;
+  border-color: var(--background-modifier-border-focus);
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+body.is-android:not(.adaptive-mode-off) textarea:focus,
+body.is-android:not(.adaptive-mode-off) input:is([type=text], [type=search], [type=email], [type=password], [type=number]):not(.prompt-input):focus,
+body.is-android:not(.adaptive-mode-off) select:focus,
+body.is-android:not(.adaptive-mode-off) .combobox-button:focus,
+body.is-android:not(.adaptive-mode-off) .dropdown:focus {
+  box-shadow: inset 0 -2px var(--interactive-accent);
+  border-color: transparent;
+  border-bottom-right-radius: 0;
+  border-bottom-left-radius: 0;
+}
+body.is-android:not(.adaptive-mode-off) input[type=range]::-webkit-slider-thumb {
+  outline: 6px solid var(--setting-items-background);
+  background-color: var(--interactive-accent);
+}
+body.is-android:not(.adaptive-mode-off) input[type=range]:active {
+  --slider-thumb-y: -23px;
+  --slider-thumb-height: 52px;
+}
+body.is-android:not(.adaptive-mode-off) .checkbox-container {
+  cursor: pointer;
+}
+body.is-android:not(.adaptive-mode-off) .checkbox-container:not(.is-enabled) {
+  --toggle-thumb-color: var(--text-muted);
+  box-shadow: inset 0 0 0 2px var(--text-muted);
+}
+body.is-android:not(.adaptive-mode-off) .checkbox-container:not(.is-enabled):not(:hover, :active) {
+  --toggle-s-border-width: 8px;
+  --toggle-s-thumb-height: 16px;
+  --toggle-s-thumb-width: 16px;
+  --toggle-border-width: 8px;
+  --toggle-thumb-height: 16px;
+  --toggle-thumb-width: 16px;
+}
+body.is-android:not(.adaptive-mode-off) .menu,
+body.is-android:not(.adaptive-mode-off) .suggestion-container,
+body.is-android:not(.adaptive-mode-off) .popover,
+body.is-android:not(.adaptive-mode-off) .prompt,
+body.is-android:not(.adaptive-mode-off) .modal,
+body.is-android:not(.adaptive-mode-off) .cm-tooltip {
+  border: none;
+}
+body.is-android:not(.adaptive-mode-off) .menu .menu-item-icon .svg-icon,
+body.is-android:not(.adaptive-mode-off) .suggestion-container .menu-item-icon .svg-icon {
+  --icon-size: var(--icon-m);
+  --icon-stroke: var(--icon-m-stroke-width);
+}
+body.is-android:not(.adaptive-mode-off) {
+  --setting-items-radius: var(--radius-l);
+}
+body.is-android:not(.adaptive-mode-off).theme-light .modal.mod-sidebar-layout {
+  background-color: var(--background-secondary);
+}
+body.is-android:not(.adaptive-mode-off).theme-dark .modal.mod-sidebar-layout {
+  background-color: var(--background-primary);
+}
+body.is-android:not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-header-group-title {
+  display: none;
+}
+body.is-android:not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-header-group-items {
+  gap: 0;
+}
+body.is-android:not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-nav-item {
+  border-radius: var(--button-radius);
+  padding: calc(12px * var(--density-modifier)) 16px;
+  width: fit-content;
+  font-weight: var(--font-medium);
+  border-bottom: 0;
+  cursor: pointer;
+  align-items: center;
+}
+body.is-android:not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-nav-item.is-active {
+  background-color: var(--setting-items-background);
+}
+body.is-android:not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-nav-item .vertical-tab-nav-item-icon {
+  --icon-size: 20px;
+  --setting-nav-icon-background: var(--color-base-50);
+  padding: 10px;
+  border-radius: var(--clickable-icon-radius);
+  color: hsl(from var(--setting-nav-icon-background) h calc(s * 1.05) calc(l * 0.35));
+  background-color: hsl(from var(--setting-nav-icon-background) h calc(s * 0.9) calc(l * 1.15));
+  margin-top: -4px;
+  margin-left: -8px;
+  margin-bottom: -4px;
+}
+body.is-android:not(.adaptive-mode-off) .modal.mod-settings .setting-items {
+  padding: 0;
+  background-color: transparent;
+}
+body.is-android:not(.adaptive-mode-off) .modal.mod-settings .setting-item:not(.setting-item-heading) {
+  border-top: none;
+  border-radius: var(--radius-xs);
+  background-color: var(--setting-items-background);
+  padding: var(--setting-items-padding);
+  margin-bottom: 2px;
+}
+body.is-android:not(.adaptive-mode-off) .modal.mod-settings .setting-item:nth-child(1 of .setting-item:not(.setting-item-heading)),
+body.is-android:not(.adaptive-mode-off) .modal.mod-settings .setting-item-heading + .setting-item {
+  border-top-left-radius: var(--setting-items-radius);
+  border-top-right-radius: var(--setting-items-radius);
+}
+body.is-android:not(.adaptive-mode-off) .modal.mod-settings .setting-item:nth-last-child(1 of .setting-item:not(.setting-item-heading)),
+body.is-android:not(.adaptive-mode-off) .modal.mod-settings .setting-item:has(+ .setting-item-heading) {
+  border-bottom-left-radius: var(--setting-items-radius);
+  border-bottom-right-radius: var(--setting-items-radius);
+}
+body.is-android:not(.adaptive-mode-off) .modal.mod-settings .setting-item-name {
+  font-weight: var(--font-medium);
+}
+body.is-android:not(.adaptive-mode-off) .modal.mod-settings .setting-item-description {
+  font-size: var(--font-ui-small);
+}
+
+body.is-android:not(.adaptive-mode-off).is-mobile .modal.mod-settings .setting-group .setting-item:not(:last-child):not(.setting-item-heading) {
+  margin-bottom: 2px;
+}
+body.is-android:not(.adaptive-mode-off).is-mobile .modal.mod-settings .setting-item-control button:not(.clickable-icon) {
+  width: fit-content;
+  padding: 16px;
+}
+
+@keyframes menuInMaterial {
+  from {
+    opacity: 0;
+    transform: translateY(-4px) scaleY(95%);
+  }
+}
+body.is-android:not(.adaptive-mode-off):not(.is-phone) .menu,
+body.is-android:not(.adaptive-mode-off):not(.is-phone) .suggestion-container {
+  transform-origin: top center;
+  animation: menuInMaterial var(--anim-duration-fast) forwards;
+}
+body.is-android:not(.adaptive-mode-off):not(.is-phone) .menu .menu-item,
+body.is-android:not(.adaptive-mode-off):not(.is-phone) .menu .suggestion-item,
+body.is-android:not(.adaptive-mode-off):not(.is-phone) .suggestion-container .menu-item,
+body.is-android:not(.adaptive-mode-off):not(.is-phone) .suggestion-container .suggestion-item {
+  padding: calc(8px * var(--density-modifier)) 12px;
+  font-weight: var(--font-medium);
+  cursor: pointer;
+  gap: 12px;
+}
+body.is-android:not(.adaptive-mode-off):not(.is-phone) .prompt {
+  border-radius: var(--radius-l);
+}
+body.is-android:not(.adaptive-mode-off):not(.is-phone) .prompt .prompt-input-container {
+  margin: 16px 16px 0;
+}
+body.is-android:not(.adaptive-mode-off):not(.is-phone) .prompt .prompt-input {
+  border: none;
+  border-radius: 100vh;
+  background-color: var(--interactive-normal);
+  font-size: var(--font-ui-large);
+}
+body.is-android:not(.adaptive-mode-off):not(.is-phone) .prompt .prompt-results {
+  padding: 16px;
+}
+body.is-android:not(.adaptive-mode-off):not(.is-phone) .prompt .suggestion-item {
+  border-radius: 100vh;
+}
+
+body.is-android:not(.adaptive-mode-off).is-phone .mobile-navbar, body.is-android:not(.adaptive-mode-off).is-phone:not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2) {
+  border: none !important;
+  box-shadow: var(--shadow-s);
+}
+body.is-android:not(.adaptive-mode-off).is-phone.is-floating-nav .mod-root .workspace-leaf-content[data-type=markdown] > .view-content::before, body.is-android:not(.adaptive-mode-off).is-phone.is-floating-nav .mod-root .workspace-leaf-content[data-type=markdown] > .view-content::after {
+  content: none;
+}
+body.is-android:not(.adaptive-mode-off).is-phone .menu .menu-item:not(.is-label) {
+  border-radius: var(--radius-xs);
+}
+body.is-android:not(.adaptive-mode-off).is-phone .menu .menu-item.is-label + .menu-item:not(.is-label),
+body.is-android:not(.adaptive-mode-off).is-phone .menu .menu-item:first-child {
+  border-top-left-radius: var(--setting-items-radius);
+  border-top-right-radius: var(--setting-items-radius);
+}
+body.is-android:not(.adaptive-mode-off).is-phone .menu .menu-item:last-child {
+  border-bottom-left-radius: var(--setting-items-radius);
+  border-bottom-right-radius: var(--setting-items-radius);
+}
+body.is-android:not(.adaptive-mode-off).is-phone .menu .menu-item:not(:last-child) {
+  margin-bottom: 2px;
+}
+body.is-android:not(.adaptive-mode-off).is-phone .menu .menu-item::after {
+  content: none;
+}
+body.is-android:not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-header-group-items {
+  gap: 2px;
+  background-color: transparent;
+}
+body.is-android:not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-nav-item {
+  width: 100%;
+  border-radius: var(--radius-xs);
+  padding: calc(16px * var(--density-modifier)) 20px;
+  height: auto;
+  background-color: var(--setting-items-background);
+}
+body.is-android:not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-nav-item-title,
+body.is-android:not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-nav-item-chevron {
+  border-bottom: none;
+}
+body.is-android:not(.adaptive-mode-off).is-phone .prompt .prompt-input {
+  box-shadow: none;
+  border: none;
+  border-radius: 100vh;
+}
+body.is-android:not(.adaptive-mode-off).is-phone .prompt .prompt-input-container {
+  margin: auto var(--safe-area-inset-side) var(--safe-area-inset-side);
+}
+body.is-android:not(.adaptive-mode-off).is-phone .prompt .suggestion-item {
+  border-radius: 100vh;
+}
+
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) {
+  --font-interface-theme: "Adwaita Sans", "Adwaita Sans Text";
+  --font-text-theme: "Adwaita Sans", "Adwaita Sans Text";
+  --shadow-s: 0 0 0 1px rgba(0, 0, 6, 3%), 0 1px 3px 1px rgba(0, 0, 6, 7%), 0 2px 6px 2px rgba(0, 0, 6, 3%);
+  --shadow-l: 0 0 14px 5px rgba(0, 0, 0, 15%), 0 0 5px 2px rgba(0, 0, 0, 10%), 0 0 0 1px rgba(0, 0, 0, 5%);
+  --input-border-width: 0;
+  --input-shadow: none;
+  --input-shadow-hover: none;
+  --input-font-weight: calc(var(--font-weight) + var(--bold-modifier));
+  --radius-s: calc(9px * var(--radius-modifier));
+  --radius-m: calc(12px * var(--radius-modifier));
+  --radius-l: calc(15px * var(--radius-modifier));
+  --radius-xl: calc(18px * var(--radius-modifier));
+  --button-radius: var(--radius-s);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.dynamic-type-off) {
+  --font-ui-smaller: calc(var(--font-ui-medium) * 0.82 + var(--font-ui-modifier));
+  --font-ui-small: calc(11px + var(--font-ui-modifier));
+  --font-ui-medium: calc(11px + var(--font-ui-modifier));
+  --font-ui-large: calc(var(--font-ui-medium) * 1.36 + var(--font-ui-modifier));
+  --icon-m: calc(18px * var(--radius-modifier));
+  --icon-l: calc(18px * var(--radius-modifier));
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) button:where(:not(.clickable-icon, .ant-switch, .workspace-leaf-content:not([data-type=markdown]) button, .copy-code-button)) {
+  padding: 5px 17px;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) {
+  --toggle-border-width: 3px;
+  --toggle-thumb-height: 20px;
+  --toggle-thumb-width: 20px;
+  --toggle-thumb-color: color-mix(in srgb, white 80%, var(--background-primary));
+  --toggle-width: 46px;
+  --toggle-s-border-width: var(--toggle-border-width);
+  --toggle-s-thumb-height: var(--toggle-thumb-height);
+  --toggle-s-thumb-width: var(--toggle-thumb-width);
+  --toggle-s-width: var(--toggle-width);
+  --slider-thumb-border-width: 0;
+  --slider-thumb-y: -8px;
+  --slider-thumb-height: var(--toggle-thumb-height);
+  --slider-thumb-width: var(--toggle-thumb-width);
+  --slider-thumb-radius: var(--toggle-thumb-radius);
+  --slider-track-height: 4px;
+  --slider-track-background: rgb(from var(--text-normal) r g b / 15%);
+  --slider-track-background-hover: rgb(from var(--text-normal) r g b / 20%);
+  --slider-track-background-active: rgb(from var(--text-normal) r g b / 25%);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .checkbox-container::after {
+  box-shadow: 0 2px 4px rgba(0, 0, 6, 0.2);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) input[type=range]::-webkit-slider-thumb {
+  box-shadow: 0 0 0 1px rgba(0, 0, 6, 0.1), 0 2px 4px rgba(0, 0, 6, 0.2) !important;
+  background-color: var(--toggle-thumb-color);
+  transition: none;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .checkbox-container:not(.is-enabled) {
+  background-color: var(--slider-track-background);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .checkbox-container:not(.is-enabled):hover,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) input[type=range]:hover {
+  background-color: var(--slider-track-background-hover);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .checkbox-container:not(.is-enabled):active,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) input[type=range]:active {
+  background-color: var(--slider-track-background-active);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .checkbox-container.is-enabled::after,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .checkbox-container:hover::after,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) input[type=range]:hover::-webkit-slider-thumb,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .checkbox-container:active::after,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) input[type=range]:active::-webkit-slider-thumb {
+  opacity: 1;
+  background-color: white;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) {
+  --dropdown-padding-end: 2.4em;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) select,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .dropdown {
+  background-color: transparent;
+  field-sizing: content;
+  font-weight: var(--font-normal);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) select:focus-visible,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .dropdown:focus-visible {
+  box-shadow: none;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .dropdown {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3e%3cpath stroke='black' stroke-linecap='round' stroke-linejoin='round' stroke-width='4' d='m4 8 8 8 8-8'/%3e%3c/svg%3e");
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).theme-dark .dropdown {
+  background-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='24' height='24' fill='none' viewBox='0 0 24 24'%3e%3cpath stroke='white' stroke-linecap='round' stroke-linejoin='round' stroke-width='4' d='m4 8 8 8 8-8'/%3e%3c/svg%3e");
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .menu,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .suggestion-container,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .popover,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .prompt,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .cm-tooltip {
+  border: none;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) {
+  --modal-background: var(--background-primary);
+  --setting-group-heading-color: var(--text-normal);
+  --setting-group-heading-size: var(--font-ui-medium);
+  --setting-group-heading-weight: calc(var(--font-weight) + var(--bold-modifier));
+  --setting-items-padding: 0px;
+  --setting-items-shadow: 0 0 0 1px rgba(0, 0, 6, 3%), 0 1px 3px 1px rgba(0, 0, 6, 7%), 0 2px 6px 2px rgba(0, 0, 6, 3%);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).theme-light {
+  --divider-color-alt: rgba(0, 0, 6, 7%);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).theme-dark {
+  --divider-color-alt: rgba(0, 0, 6, 36%);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-header {
+  background-color: var(--background-secondary);
+  border-right: var(--border-width) solid var(--divider-color-alt);
+  padding: 6px;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-header-group {
+  padding-block: 6px;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-header-group:first-child {
+  padding-top: 0px;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-header-group:not(:last-child) {
+  border-bottom: var(--border-width) solid rgb(from var(--text-normal) r g b/15%);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-header-group-title {
+  display: none;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-nav-item {
+  padding: calc(12px * var(--density-modifier)) 14px;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .vertical-tab-nav-item-icon {
+  color: var(--text-normal);
+  margin-inline-end: 12px;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .setting-group .setting-items,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings div:not(.setting-items, .hotkey-list-container, .style-settings-container) > .setting-item:not(.setting-item-heading),
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .installed-plugins-container .setting-item:not(.setting-item-heading) {
+  box-shadow: var(--setting-items-shadow);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .setting-item-heading {
+  padding-left: 0;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .setting-item:not(.setting-item-heading) {
+  border-color: var(--divider-color-alt);
+  padding: calc(12px * var(--density-modifier)) 14px;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .setting-item-description {
+  color: var(--text-faint);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .setting-group-search + .setting-items {
+  border-radius: var(--setting-items-radius);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-settings .setting-items .mobile-option-setting-item {
+  padding-inline: 16px;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .installed-plugins-container .setting-items {
+  box-shadow: none !important;
+  background-color: transparent;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-community-modal .community-item {
+  box-shadow: var(--setting-items-shadow);
+  border: none;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) .modal.mod-community-modal .modal-setting-nav-bar {
+  padding: 4px;
+}
+
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) {
+  --frame-right-space: 124px;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .titlebar-button-container.mod-right {
+  align-items: center;
+  justify-content: space-evenly;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .titlebar-button-container.mod-right .titlebar-button {
+  width: fit-content;
+  height: fit-content;
+  background-color: rgb(from var(--text-normal) r g b/10%);
+  border-radius: 100vh !important;
+  padding: 4px;
+  flex: 0;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .titlebar-button-container.mod-right .titlebar-button svg {
+  height: 16px;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .titlebar-button-container.mod-right .titlebar-button:hover {
+  background-color: rgb(from var(--text-normal) r g b/15%);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .titlebar-button.mod-minimize svg {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3e%3cpath fill='%232E3436' d='M4 10.008h8v1.988H4v-1.988Z'/%3e%3c/svg%3e");
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .titlebar-button.mod-maximize svg {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3e%3cpath fill='%232E3436' d='M3.988 3.992v8.012H12V3.992H3.988Zm2 2H10v4.012H5.988V5.992Z'/%3e%3c/svg%3e");
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .titlebar-button.mod-close svg {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3e%3cpath fill='%232E3436' d='M4 4h1.031c.254.012.512.129.688.313L8 6.592l2.313-2.28c.265-.231.445-.305.687-.313h1v1c0 .285-.035.55-.25.75L9.469 8.031l2.25 2.25c.187.188.281.453.281.719v1h-1c-.266 0-.531-.094-.719-.281L8 9.438l-2.281 2.28A1.016 1.016 0 0 1 5 12H4v-1c0-.266.094-.531.281-.719l2.282-2.25L4.28 5.75A.904.904 0 0 1 4 5V4Z'/%3e%3c/svg%3e");
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile).is-maximized .titlebar-button.mod-maximize svg {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3e%3cpath fill='%232E3434' d='M4.988 4.992v6.012H11V4.992H4.988Zm2 2H9v2.012H6.988V6.992Z'/%3e%3c/svg%3e");
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) {
+  --menu-padding: 6px;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .menu,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .suggestion-container {
+  animation: none;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .menu .menu-item,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .menu .suggestion-item,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .suggestion-container .menu-item,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .suggestion-container .suggestion-item {
+  padding: calc(8px * var(--density-modifier)) 12px;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .menu .menu-separator,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .suggestion-container .menu-separator {
+  border-bottom-color: rgb(from var(--text-normal) r g b/15%);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .prompt {
+  border-radius: var(--radius-xl);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .modal .modal-close-button {
+  --icon-stroke: 4px;
+  color: var(--text-normal);
+  width: 24px;
+  height: 24px;
+  padding: 4px;
+  background-color: rgb(from var(--text-normal) r g b/10%);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .modal .modal-close-button path,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .modal .modal-close-button rect,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .modal .modal-close-button circle {
+  visibility: hidden;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .modal .modal-close-button svg {
+  background-color: currentcolor;
+  margin: 0;
+  -webkit-mask-size: 100% 100%;
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3e%3cpath fill='%232E3436' d='M4 4h1.031c.254.012.512.129.688.313L8 6.592l2.313-2.28c.265-.231.445-.305.687-.313h1v1c0 .285-.035.55-.25.75L9.469 8.031l2.25 2.25c.187.188.281.453.281.719v1h-1c-.266 0-.531-.094-.719-.281L8 9.438l-2.281 2.28A1.016 1.016 0 0 1 5 12H4v-1c0-.266.094-.531.281-.719l2.282-2.25L4.28 5.75A.904.904 0 0 1 4 5V4Z'/%3e%3c/svg%3e");
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-mobile) .modal .modal-close-button:hover {
+  background-color: rgb(from var(--text-normal) r g b/15%);
+}
+
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-phone) .prompt .prompt-input {
+  box-shadow: none;
+  border: none;
+  font-size: var(--font-ui-large);
+  font-weight: calc(var(--font-weight) + var(--bold-modifier));
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off):not(.is-phone) .prompt .prompt-results {
+  padding: 8px;
+  margin-inline: 8px;
+  border-radius: var(--radius-l);
+  background: var(--background-secondary-alt);
+}
+
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-mobile {
+  --dropdown-padding-start: 0;
+}
+
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone {
+  --mobile-sidebar-background: var(--modal-background);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .mobile-navbar, body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone:not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2) {
+  border: none !important;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .mod-root .workspace-leaf-content[data-type=markdown] > .view-content::before,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .mod-root .workspace-leaf-content[data-type=markdown] > .view-content::after {
+  content: none;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .menu,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .suggestion-container {
+  --interactive-normal: transparent;
+  background-color: var(--menu-background);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .menu .menu-group .menu-item:not(.is-label):after,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .suggestion-container .menu-group .menu-item:not(.is-label):after {
+  content: none;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .menu .menu-item,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .suggestion-container .menu-item {
+  padding: calc(12px * var(--density-modifier)) 14px;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .menu .menu-separator,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .suggestion-container .menu-separator {
+  margin: calc(12px * var(--density-modifier)) 0;
+  border-bottom: var(--border-width) solid var(--background-modifier-border);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone {
+  --prompt-background: var(--modal-background);
+  --settings-background: var(--modal-background);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-header {
+  background-color: var(--settings-background);
+  padding-inline: 16px;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-header-group {
+  padding-inline: 0;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-header-group-items {
+  background-color: transparent;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-nav-item {
+  border-radius: var(--radius-s);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-nav-item-title,
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .modal.mod-settings .vertical-tab-nav-item-chevron {
+  border-bottom: none;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .modal.mod-settings .setting-item {
+  gap: calc(12px * var(--density-modifier));
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .modal.mod-settings .setting-item-heading {
+  padding-left: 8px;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).is-phone .modal.mod-settings .setting-item:not(.setting-item-heading) {
+  padding: calc(16px * var(--density-modifier)) 16px;
+}
+
+/* https://github.com/damiankorcz/Alternative-Checkboxes-Reference-Set */
+input[type=checkbox]:checked {
+  border: none;
+}
+
+input[type=checkbox]:checked::after,
+.checklist-plugin-main .checked:after {
+  top: 0;
+  inset-inline-start: 0;
+  -webkit-mask-position: 50% 50%;
+  -webkit-mask-size: 100% 100%;
+}
+
+input[type=checkbox][data-indeterminate=true]:not(:checked) {
+  --checkbox-color: var(--checkbox-border-color) !important;
+  background-color: var(--checkbox-color);
+}
+input[type=checkbox][data-indeterminate=true]:not(:checked):after {
+  top: 0;
+  inset-inline-start: 0;
+  -webkit-mask-position: 50% 50%;
+  -webkit-mask-size: 100% 100%;
+  background-color: var(--checkbox-marker-color);
+  width: var(--checkbox-size);
+  height: var(--checkbox-size);
+}
+
+li[data-task][data-task=">"],
+li[data-task][data-task=">"] input[type=checkbox]:checked, li[data-task][data-task="<"],
+li[data-task][data-task="<"] input[type=checkbox]:checked, li[data-task][data-task="*"],
+li[data-task][data-task="*"] input[type=checkbox]:checked, li[data-task][data-task='"'],
+li[data-task][data-task='"'] input[type=checkbox]:checked, li[data-task][data-task=“],
+li[data-task][data-task=“] input[type=checkbox]:checked, li[data-task][data-task=l],
+li[data-task][data-task=l] input[type=checkbox]:checked, li[data-task][data-task=b],
+li[data-task][data-task=b] input[type=checkbox]:checked, li[data-task][data-task=S],
+li[data-task][data-task=S] input[type=checkbox]:checked, li[data-task][data-task=I],
+li[data-task][data-task=I] input[type=checkbox]:checked, li[data-task][data-task=p],
+li[data-task][data-task=p] input[type=checkbox]:checked, li[data-task][data-task=c],
+li[data-task][data-task=c] input[type=checkbox]:checked, li[data-task][data-task=f],
+li[data-task][data-task=f] input[type=checkbox]:checked, li[data-task][data-task=k],
+li[data-task][data-task=k] input[type=checkbox]:checked, li[data-task][data-task=w],
+li[data-task][data-task=w] input[type=checkbox]:checked, li[data-task][data-task=u],
+li[data-task][data-task=u] input[type=checkbox]:checked, li[data-task][data-task=d],
+li[data-task][data-task=d] input[type=checkbox]:checked, li[data-task][data-task=B],
+li[data-task][data-task=B] input[type=checkbox]:checked, li[data-task][data-task=a],
+li[data-task][data-task=a] input[type=checkbox]:checked, li[data-task][data-task=n],
+li[data-task][data-task=n] input[type=checkbox]:checked, li[data-task][data-task=R],
+li[data-task][data-task=R] input[type=checkbox]:checked, li[data-task][data-task=t],
+li[data-task][data-task=t] input[type=checkbox]:checked, li[data-task][data-task=P],
+li[data-task][data-task=P] input[type=checkbox]:checked, li[data-task][data-task=L],
+li[data-task][data-task=L] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task=">"],
+input[type=checkbox][data-task]:checked[data-task=">"] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task="<"],
+input[type=checkbox][data-task]:checked[data-task="<"] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task="*"],
+input[type=checkbox][data-task]:checked[data-task="*"] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task='"'],
+input[type=checkbox][data-task]:checked[data-task='"'] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task=“],
+input[type=checkbox][data-task]:checked[data-task=“] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task=l],
+input[type=checkbox][data-task]:checked[data-task=l] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task=b],
+input[type=checkbox][data-task]:checked[data-task=b] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task=S],
+input[type=checkbox][data-task]:checked[data-task=S] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task=I],
+input[type=checkbox][data-task]:checked[data-task=I] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task=p],
+input[type=checkbox][data-task]:checked[data-task=p] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task=c],
+input[type=checkbox][data-task]:checked[data-task=c] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task=f],
+input[type=checkbox][data-task]:checked[data-task=f] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task=k],
+input[type=checkbox][data-task]:checked[data-task=k] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task=w],
+input[type=checkbox][data-task]:checked[data-task=w] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task=u],
+input[type=checkbox][data-task]:checked[data-task=u] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task=d],
+input[type=checkbox][data-task]:checked[data-task=d] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task=B],
+input[type=checkbox][data-task]:checked[data-task=B] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task=a],
+input[type=checkbox][data-task]:checked[data-task=a] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task=n],
+input[type=checkbox][data-task]:checked[data-task=n] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task=R],
+input[type=checkbox][data-task]:checked[data-task=R] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task=t],
+input[type=checkbox][data-task]:checked[data-task=t] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task=P],
+input[type=checkbox][data-task]:checked[data-task=P] input[type=checkbox]:checked,
+input[type=checkbox][data-task]:checked[data-task=L],
+input[type=checkbox][data-task]:checked[data-task=L] input[type=checkbox]:checked {
+  --checkbox-color: transparent;
+}
+li[data-task][data-task=">"]:hover,
+li[data-task][data-task=">"] input[type=checkbox]:checked:hover, li[data-task][data-task="<"]:hover,
+li[data-task][data-task="<"] input[type=checkbox]:checked:hover, li[data-task][data-task="*"]:hover,
+li[data-task][data-task="*"] input[type=checkbox]:checked:hover, li[data-task][data-task='"']:hover,
+li[data-task][data-task='"'] input[type=checkbox]:checked:hover, li[data-task][data-task=“]:hover,
+li[data-task][data-task=“] input[type=checkbox]:checked:hover, li[data-task][data-task=l]:hover,
+li[data-task][data-task=l] input[type=checkbox]:checked:hover, li[data-task][data-task=b]:hover,
+li[data-task][data-task=b] input[type=checkbox]:checked:hover, li[data-task][data-task=S]:hover,
+li[data-task][data-task=S] input[type=checkbox]:checked:hover, li[data-task][data-task=I]:hover,
+li[data-task][data-task=I] input[type=checkbox]:checked:hover, li[data-task][data-task=p]:hover,
+li[data-task][data-task=p] input[type=checkbox]:checked:hover, li[data-task][data-task=c]:hover,
+li[data-task][data-task=c] input[type=checkbox]:checked:hover, li[data-task][data-task=f]:hover,
+li[data-task][data-task=f] input[type=checkbox]:checked:hover, li[data-task][data-task=k]:hover,
+li[data-task][data-task=k] input[type=checkbox]:checked:hover, li[data-task][data-task=w]:hover,
+li[data-task][data-task=w] input[type=checkbox]:checked:hover, li[data-task][data-task=u]:hover,
+li[data-task][data-task=u] input[type=checkbox]:checked:hover, li[data-task][data-task=d]:hover,
+li[data-task][data-task=d] input[type=checkbox]:checked:hover, li[data-task][data-task=B]:hover,
+li[data-task][data-task=B] input[type=checkbox]:checked:hover, li[data-task][data-task=a]:hover,
+li[data-task][data-task=a] input[type=checkbox]:checked:hover, li[data-task][data-task=n]:hover,
+li[data-task][data-task=n] input[type=checkbox]:checked:hover, li[data-task][data-task=R]:hover,
+li[data-task][data-task=R] input[type=checkbox]:checked:hover, li[data-task][data-task=t]:hover,
+li[data-task][data-task=t] input[type=checkbox]:checked:hover, li[data-task][data-task=P]:hover,
+li[data-task][data-task=P] input[type=checkbox]:checked:hover, li[data-task][data-task=L]:hover,
+li[data-task][data-task=L] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task=">"]:hover,
+input[type=checkbox][data-task]:checked[data-task=">"] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task="<"]:hover,
+input[type=checkbox][data-task]:checked[data-task="<"] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task="*"]:hover,
+input[type=checkbox][data-task]:checked[data-task="*"] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task='"']:hover,
+input[type=checkbox][data-task]:checked[data-task='"'] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task=“]:hover,
+input[type=checkbox][data-task]:checked[data-task=“] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task=l]:hover,
+input[type=checkbox][data-task]:checked[data-task=l] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task=b]:hover,
+input[type=checkbox][data-task]:checked[data-task=b] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task=S]:hover,
+input[type=checkbox][data-task]:checked[data-task=S] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task=I]:hover,
+input[type=checkbox][data-task]:checked[data-task=I] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task=p]:hover,
+input[type=checkbox][data-task]:checked[data-task=p] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task=c]:hover,
+input[type=checkbox][data-task]:checked[data-task=c] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task=f]:hover,
+input[type=checkbox][data-task]:checked[data-task=f] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task=k]:hover,
+input[type=checkbox][data-task]:checked[data-task=k] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task=w]:hover,
+input[type=checkbox][data-task]:checked[data-task=w] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task=u]:hover,
+input[type=checkbox][data-task]:checked[data-task=u] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task=d]:hover,
+input[type=checkbox][data-task]:checked[data-task=d] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task=B]:hover,
+input[type=checkbox][data-task]:checked[data-task=B] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task=a]:hover,
+input[type=checkbox][data-task]:checked[data-task=a] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task=n]:hover,
+input[type=checkbox][data-task]:checked[data-task=n] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task=R]:hover,
+input[type=checkbox][data-task]:checked[data-task=R] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task=t]:hover,
+input[type=checkbox][data-task]:checked[data-task=t] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task=P]:hover,
+input[type=checkbox][data-task]:checked[data-task=P] input[type=checkbox]:checked:hover,
+input[type=checkbox][data-task]:checked[data-task=L]:hover,
+input[type=checkbox][data-task]:checked[data-task=L] input[type=checkbox]:checked:hover {
+  background-color: transparent;
+}
+li[data-task][data-task=">"]:hover::after,
+li[data-task][data-task=">"] input[type=checkbox]:checked:hover::after, li[data-task][data-task="<"]:hover::after,
+li[data-task][data-task="<"] input[type=checkbox]:checked:hover::after, li[data-task][data-task="*"]:hover::after,
+li[data-task][data-task="*"] input[type=checkbox]:checked:hover::after, li[data-task][data-task='"']:hover::after,
+li[data-task][data-task='"'] input[type=checkbox]:checked:hover::after, li[data-task][data-task=“]:hover::after,
+li[data-task][data-task=“] input[type=checkbox]:checked:hover::after, li[data-task][data-task=l]:hover::after,
+li[data-task][data-task=l] input[type=checkbox]:checked:hover::after, li[data-task][data-task=b]:hover::after,
+li[data-task][data-task=b] input[type=checkbox]:checked:hover::after, li[data-task][data-task=S]:hover::after,
+li[data-task][data-task=S] input[type=checkbox]:checked:hover::after, li[data-task][data-task=I]:hover::after,
+li[data-task][data-task=I] input[type=checkbox]:checked:hover::after, li[data-task][data-task=p]:hover::after,
+li[data-task][data-task=p] input[type=checkbox]:checked:hover::after, li[data-task][data-task=c]:hover::after,
+li[data-task][data-task=c] input[type=checkbox]:checked:hover::after, li[data-task][data-task=f]:hover::after,
+li[data-task][data-task=f] input[type=checkbox]:checked:hover::after, li[data-task][data-task=k]:hover::after,
+li[data-task][data-task=k] input[type=checkbox]:checked:hover::after, li[data-task][data-task=w]:hover::after,
+li[data-task][data-task=w] input[type=checkbox]:checked:hover::after, li[data-task][data-task=u]:hover::after,
+li[data-task][data-task=u] input[type=checkbox]:checked:hover::after, li[data-task][data-task=d]:hover::after,
+li[data-task][data-task=d] input[type=checkbox]:checked:hover::after, li[data-task][data-task=B]:hover::after,
+li[data-task][data-task=B] input[type=checkbox]:checked:hover::after, li[data-task][data-task=a]:hover::after,
+li[data-task][data-task=a] input[type=checkbox]:checked:hover::after, li[data-task][data-task=n]:hover::after,
+li[data-task][data-task=n] input[type=checkbox]:checked:hover::after, li[data-task][data-task=R]:hover::after,
+li[data-task][data-task=R] input[type=checkbox]:checked:hover::after, li[data-task][data-task=t]:hover::after,
+li[data-task][data-task=t] input[type=checkbox]:checked:hover::after, li[data-task][data-task=P]:hover::after,
+li[data-task][data-task=P] input[type=checkbox]:checked:hover::after, li[data-task][data-task=L]:hover::after,
+li[data-task][data-task=L] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task=">"]:hover::after,
+input[type=checkbox][data-task]:checked[data-task=">"] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task="<"]:hover::after,
+input[type=checkbox][data-task]:checked[data-task="<"] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task="*"]:hover::after,
+input[type=checkbox][data-task]:checked[data-task="*"] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task='"']:hover::after,
+input[type=checkbox][data-task]:checked[data-task='"'] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task=“]:hover::after,
+input[type=checkbox][data-task]:checked[data-task=“] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task=l]:hover::after,
+input[type=checkbox][data-task]:checked[data-task=l] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task=b]:hover::after,
+input[type=checkbox][data-task]:checked[data-task=b] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task=S]:hover::after,
+input[type=checkbox][data-task]:checked[data-task=S] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task=I]:hover::after,
+input[type=checkbox][data-task]:checked[data-task=I] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task=p]:hover::after,
+input[type=checkbox][data-task]:checked[data-task=p] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task=c]:hover::after,
+input[type=checkbox][data-task]:checked[data-task=c] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task=f]:hover::after,
+input[type=checkbox][data-task]:checked[data-task=f] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task=k]:hover::after,
+input[type=checkbox][data-task]:checked[data-task=k] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task=w]:hover::after,
+input[type=checkbox][data-task]:checked[data-task=w] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task=u]:hover::after,
+input[type=checkbox][data-task]:checked[data-task=u] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task=d]:hover::after,
+input[type=checkbox][data-task]:checked[data-task=d] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task=B]:hover::after,
+input[type=checkbox][data-task]:checked[data-task=B] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task=a]:hover::after,
+input[type=checkbox][data-task]:checked[data-task=a] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task=n]:hover::after,
+input[type=checkbox][data-task]:checked[data-task=n] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task=R]:hover::after,
+input[type=checkbox][data-task]:checked[data-task=R] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task=t]:hover::after,
+input[type=checkbox][data-task]:checked[data-task=t] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task=P]:hover::after,
+input[type=checkbox][data-task]:checked[data-task=P] input[type=checkbox]:checked:hover::after,
+input[type=checkbox][data-task]:checked[data-task=L]:hover::after,
+input[type=checkbox][data-task]:checked[data-task=L] input[type=checkbox]:checked:hover::after {
+  background-color: var(--checkbox-color-hover);
+}
+
+input[data-task="/"]:checked,
+li[data-task="/"] > input:checked,
+li[data-task="/"] > p > input:checked {
+  border: 1px solid var(--interactive-accent);
+  background: linear-gradient(to right, var(--interactive-accent) 50%, transparent 50%);
+}
+input[data-task="/"]:checked::after,
+li[data-task="/"] > input:checked::after,
+li[data-task="/"] > p > input:checked::after {
+  display: none;
+}
+
+.task-list-item:not([data-task]) input[type=checkbox],
+.checked:after,
+div:checked::after,
+input[type=checkbox]:checked::after,
+.tasks-modal-checkbox:checked::after {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cpath fill='black' d='m12.998 6.084-4.17 6.7-1.982-2.56c-.244-.322-.46-.41-.742-.41a.788.788 0 0 0-.782.801c0 .225.088.44.235.635l2.45 3.008c.255.342.528.478.86.478.332 0 .615-.156.82-.478l4.59-7.227c.118-.205.245-.43.245-.644 0-.46-.4-.752-.83-.752-.255 0-.508.156-.694.449Z'/%3e%3c/svg%3e");
+}
+
+input[data-task="-"]:checked,
+li[data-task="-"] > input:checked,
+li[data-task="-"] > p > input:checked {
+  --checkbox-color: var(--checkbox-border-color);
+}
+input[data-task="-"]:checked:after,
+li[data-task="-"] > input:checked:after,
+li[data-task="-"] > p > input:checked:after {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cpath fill='black' d='M6.025 9.121c-.595 0-.966.313-.966.86 0 .537.39.84.966.84h7.891c.566 0 .947-.303.947-.84 0-.547-.361-.86-.947-.86h-7.89Z'/%3e%3c/svg%3e");
+}
+
+input[data-task="-"],
+li[data-task="-"],
+.HyperMD-list-line[data-task="-"] .cm-list-1 {
+  text-decoration: var(--checklist-done-decoration);
+  color: var(--text-faint);
+}
+
+input[data-task=">"]:checked::after,
+li[data-task=">"] > input:checked::after,
+li[data-task=">"] > p > input:checked::after {
+  background-color: var(--color-cyan);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='22' height='18' fill='none' viewBox='0 0 22 18'%3e%3cpath fill='black' d='M11.533 0c.479 0 .801.205 1.319.693L20.557 7.9c.38.362.498.723.498 1.055 0 .322-.127.693-.498 1.045l-7.705 7.275c-.47.44-.86.635-1.338.635-.664 0-1.153-.488-1.153-1.142v-3.73h-.283c-3.78 0-6.172.956-7.871 4.15-.342.625-.791.722-1.201.722C.479 17.91 0 17.441 0 16.602c0-7.217 3.057-11.72 10.078-11.72h.283v-3.69C10.361.536 10.85 0 11.533 0Z'/%3e%3c/svg%3e");
+}
+
+input[data-task="<"]:checked::after,
+li[data-task="<"] > input:checked::after,
+li[data-task="<"] > p > input:checked::after {
+  background-color: var(--color-blue);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='18' fill='none' viewBox='0 0 20 18'%3e%3cpath fill='black' d='M3.066 17.979h13.34c2.041 0 3.057-1.016 3.057-3.028V3.027C19.463 1.016 18.447 0 16.406 0H3.066C1.026 0 0 1.006 0 3.027v11.924c0 2.022 1.025 3.027 3.066 3.027Zm-.146-1.573c-.87 0-1.348-.459-1.348-1.367V5.83c0-.898.479-1.367 1.348-1.367h13.613c.87 0 1.358.469 1.358 1.367v9.21c0 .907-.489 1.366-1.358 1.366H2.92ZM7.832 7.97h.576c.342 0 .45-.098.45-.44v-.576c0-.342-.108-.45-.45-.45h-.576c-.342 0-.459.108-.459.45v.576c0 .342.117.44.459.44Zm3.242 0h.576c.342 0 .46-.098.46-.44v-.576c0-.342-.118-.45-.46-.45h-.576c-.342 0-.459.108-.459.45v.576c0 .342.117.44.46.44Zm3.242 0h.577c.341 0 .459-.098.459-.44v-.576c0-.342-.118-.45-.46-.45h-.576c-.341 0-.449.108-.449.45v.576c0 .342.108.44.45.44ZM4.59 11.162h.566c.352 0 .46-.098.46-.44v-.575c0-.342-.108-.44-.46-.44H4.59c-.352 0-.46.098-.46.44v.576c0 .341.108.44.46.44Zm3.242 0h.576c.342 0 .45-.098.45-.44v-.575c0-.342-.108-.44-.45-.44h-.576c-.342 0-.459.098-.459.44v.576c0 .341.117.44.459.44Zm3.242 0h.576c.342 0 .46-.098.46-.44v-.575c0-.342-.118-.44-.46-.44h-.576c-.342 0-.459.098-.459.44v.576c0 .341.117.44.46.44Zm3.242 0h.577c.341 0 .459-.098.459-.44v-.575c0-.342-.118-.44-.46-.44h-.576c-.341 0-.449.098-.449.44v.576c0 .341.108.44.45.44ZM4.59 14.365h.566c.352 0 .46-.107.46-.449v-.576c0-.342-.108-.44-.46-.44H4.59c-.352 0-.46.098-.46.44v.576c0 .342.108.45.46.45Zm3.242 0h.576c.342 0 .45-.107.45-.449v-.576c0-.342-.108-.44-.45-.44h-.576c-.342 0-.459.098-.459.44v.576c0 .342.117.45.459.45Zm3.242 0h.576c.342 0 .46-.107.46-.449v-.576c0-.342-.118-.44-.46-.44h-.576c-.342 0-.459.098-.459.44v.576c0 .342.117.45.46.45Z'/%3e%3c/svg%3e");
+}
+
+input[data-task="?"]:checked,
+li[data-task="?"] > input:checked,
+li[data-task="?"] > p > input:checked,
+input[type=checkbox][data-indeterminate=true]:not(:checked) {
+  --checkbox-color: var(--color-pink);
+  border: none;
+}
+input[data-task="?"]:checked:hover,
+li[data-task="?"] > input:checked:hover,
+li[data-task="?"] > p > input:checked:hover,
+input[type=checkbox][data-indeterminate=true]:not(:checked):hover {
+  background-color: var(--checkbox-color-hover);
+}
+input[data-task="?"]:checked:after,
+li[data-task="?"] > input:checked:after,
+li[data-task="?"] > p > input:checked:after,
+input[type=checkbox][data-indeterminate=true]:not(:checked):after {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cpath fill='black' d='M8.643 14.004c0 .576.507 1.045 1.093 1.045s1.094-.46 1.094-1.045c0-.586-.498-1.055-1.094-1.055-.595 0-1.093.479-1.093 1.055ZM6.924 6.553a1.665 1.665 0 0 0-.088.498c0 .449.361.693.693.693.342 0 .567-.166.752-.4l.176-.244c.361-.586.879-.918 1.553-.918.908 0 1.504.517 1.504 1.279 0 .684-.42 1.016-1.3 1.63-.722.509-1.269 1.036-1.269 2.032v.127c0 .527.293.8.81.8.509 0 .821-.322.821-.722v-.117c0-.566.322-.928 1.026-1.387.976-.644 1.68-1.23 1.68-2.441 0-1.68-1.495-2.569-3.214-2.569-1.738 0-2.87.811-3.144 1.739Z'/%3e%3c/svg%3e");
+}
+
+input[data-task="!"]:checked,
+li[data-task="!"] > input:checked,
+li[data-task="!"] > p > input:checked {
+  --checkbox-color: var(--color-orange);
+}
+input[data-task="!"]:checked:after,
+li[data-task="!"] > input:checked:after,
+li[data-task="!"] > p > input:checked:after {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cpath fill='black' d='M8.867 14.004c0 .576.508 1.045 1.094 1.045.586 0 1.094-.46 1.094-1.045 0-.586-.498-1.055-1.094-1.055-.596 0-1.094.479-1.094 1.055Zm.166-8.35.127 5.323c.01.517.293.8.8.8.49 0 .772-.273.782-.8l.137-5.313c.01-.518-.39-.898-.928-.898-.547 0-.928.37-.918.888Z'/%3e%3c/svg%3e");
+}
+
+input[data-task="*"]:checked::after,
+li[data-task="*"] > input:checked::after,
+li[data-task="*"] > p > input:checked::after {
+  background-color: var(--color-yellow);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='22' height='21' fill='none' viewBox='0 0 22 21'%3e%3cpath fill='black' d='M4.161 20.547c.4.312.908.205 1.514-.235l5.166-3.798 5.176 3.799c.605.439 1.103.546 1.513.234.4-.303.488-.8.244-1.514l-2.04-6.074 5.214-3.75c.606-.43.85-.879.694-1.367-.157-.469-.616-.694-1.368-.694h-6.396l-1.944-6.064C11.7.361 11.35 0 10.841 0c-.498 0-.85.361-1.084 1.084L7.813 7.148H1.417c-.752 0-1.211.225-1.367.694-.166.488.088.937.693 1.367l5.215 3.75-2.041 6.074c-.244.713-.156 1.211.244 1.514Z'/%3e%3c/svg%3e");
+}
+
+input[data-task='"']:checked::after,
+li[data-task='"'] > input:checked::after,
+li[data-task='"'] > p > input:checked::after,
+input[data-task=“]:checked::after,
+li[data-task=“] > input:checked::after,
+li[data-task=“] > p > input:checked::after {
+  background-color: var(--color-purple);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='22' height='21' fill='none' viewBox='0 0 22 21'%3e%3cpath fill='black' d='M21.523 4.473v7.48c0 2.861-1.562 4.463-4.472 4.463h-6.602l-3.525 3.223c-.46.43-.742.625-1.123.625-.557 0-.87-.4-.87-1.006v-2.842h-.458C1.563 16.416 0 14.824 0 11.953v-7.48C0 1.602 1.563 0 4.473 0H17.05c2.91 0 4.472 1.611 4.472 4.473ZM5.898 7.148c0 1.143.713 2.032 1.856 2.032.42 0 .84-.069 1.103-.4h.079a2.863 2.863 0 0 1-1.797 1.542c-.381.098-.489.254-.489.498 0 .254.215.47.498.47 1.016 0 3.057-1.212 3.057-3.77 0-1.368-.879-2.413-2.187-2.413-1.211 0-2.12.84-2.12 2.041Zm5.44 0c0 1.143.713 2.032 1.846 2.032.43 0 .85-.069 1.113-.4h.078a2.855 2.855 0 0 1-1.807 1.542c-.361.098-.478.254-.478.498 0 .254.215.47.498.47 1.016 0 3.057-1.212 3.057-3.77 0-1.368-.89-2.413-2.198-2.413-1.21 0-2.11.84-2.11 2.041Z'/%3e%3c/svg%3e");
+}
+
+input[data-task=l]:checked::after,
+li[data-task=l] > input:checked::after,
+li[data-task=l] > p > input:checked::after {
+  background-color: var(--color-red);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='8' height='21' fill='none' viewBox='0 0 8 21'%3e%3cpath fill='black' d='M7.334 3.682A3.65 3.65 0 0 1 4.57 7.236V16.3c0 2.89-.508 4.453-.908 4.453-.39 0-.908-1.572-.908-4.453V7.236A3.65 3.65 0 0 1 0 3.682C0 1.66 1.63 0 3.662 0a3.676 3.676 0 0 1 3.672 3.682ZM1.357 2.617c0 .684.586 1.27 1.26 1.27.684 0 1.25-.586 1.25-1.27 0-.674-.566-1.25-1.25-1.25-.674 0-1.26.576-1.26 1.25Z'/%3e%3c/svg%3e");
+}
+
+input[data-task=b]:checked::after,
+li[data-task=b] > input:checked::after,
+li[data-task=b] > p > input:checked::after {
+  background-color: var(--color-orange);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='14' height='21' fill='none' viewBox='0 0 14 21'%3e%3cpath fill='black' d='M1.035 20.947c.479 0 .762-.273 1.64-1.123l3.82-3.76c.048-.048.136-.048.175 0l3.818 3.76c.88.85 1.162 1.123 1.64 1.123.655 0 1.036-.43 1.036-1.191V2.803C13.164.947 12.236 0 10.4 0H2.764C.928 0 0 .947 0 2.803v16.953c0 .762.38 1.191 1.035 1.191Z'/%3e%3c/svg%3e");
+}
+
+input[data-task=i]:checked,
+li[data-task=i] > input:checked,
+li[data-task=i] > p > input:checked {
+  --checkbox-color: var(--color-blue);
+}
+input[data-task=i]:checked:after,
+li[data-task=i] > input:checked:after,
+li[data-task=i] > p > input:checked:after {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cpath fill='black' d='M8.37 8.154a.721.721 0 0 0-.733.713c0 .42.322.723.732.723h1.074v4.59h-1.24a.724.724 0 0 0-.742.713c0 .42.322.722.742.722h4.092c.42 0 .742-.303.742-.722a.724.724 0 0 0-.742-.713h-1.24V9.072c0-.547-.274-.918-.791-.918H8.369Zm.185-2.988c0 .742.586 1.328 1.318 1.328.732 0 1.309-.586 1.309-1.328 0-.742-.577-1.328-1.309-1.328s-1.318.586-1.318 1.328Z'/%3e%3c/svg%3e");
+}
+
+input[data-task=S]:checked::after,
+li[data-task=S] > input:checked::after,
+li[data-task=S] > p > input:checked::after {
+  background-color: var(--color-green);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='13' height='23' fill='none' viewBox='0 0 13 23'%3e%3cpath fill='black' d='M6.24 19.639c3.301 0 6.143-1.66 6.143-4.824 0-2.93-2.295-3.975-5.02-4.63l-1.875-.458c-1.777-.43-3.252-1.202-3.252-2.891 0-1.895 2.022-2.861 3.994-2.861 2.022 0 3.487.947 4.024 2.685.156.46.459.772.967.772s.879-.352.879-.87c0-.78-.518-1.835-1.192-2.51-1.191-1.19-2.9-1.747-4.678-1.747-3.056 0-5.869 1.62-5.869 4.677 0 2.705 2.305 3.926 4.815 4.502l1.885.44c1.875.44 3.457 1.123 3.457 3.037 0 2.148-1.973 3.018-4.258 3.018-2.158 0-3.906-.87-4.424-2.813-.147-.479-.43-.752-.928-.752-.547 0-.908.371-.908.86 0 .908.596 1.962 1.27 2.607 1.318 1.24 3.173 1.758 4.97 1.758Zm-.049 2.373a.642.642 0 0 0 .635-.645V.635A.64.64 0 0 0 6.191 0a.64.64 0 0 0-.634.635v20.732c0 .352.283.645.634.645Z'/%3e%3c/svg%3e");
+}
+
+input[data-task=I]:checked::after,
+li[data-task=I] > input:checked::after,
+li[data-task=I] > p > input:checked::after {
+  background-color: var(--color-yellow);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='21' height='22' fill='none' viewBox='0 0 21 22'%3e%3cpath fill='black' d='M4.346 12.48c-.215 0-.362.137-.381.362-.371 3.017-.518 3.095-3.574 3.594-.254.029-.391.156-.391.38 0 .215.137.342.342.372 3.086.595 3.252.576 3.623 3.584.02.234.166.37.38.37.206 0 .362-.136.382-.36.39-3.057.507-3.145 3.613-3.595.195-.019.342-.156.342-.37 0-.215-.147-.352-.342-.381-3.106-.596-3.213-.596-3.613-3.614a.367.367 0 0 0-.381-.341ZM11.982 0c-.283 0-.507.205-.546.508-.85 6.181-1.7 7.002-7.793 7.812-.313.03-.538.254-.538.547 0 .303.225.537.538.567 6.113.664 6.992 1.62 7.792 7.793.04.302.264.517.547.517.293 0 .508-.215.557-.517.81-6.172 1.68-7.13 7.793-7.793a.552.552 0 0 0 .527-.567c0-.293-.205-.517-.527-.547-6.113-.683-6.982-1.63-7.793-7.812C12.49.205 12.275 0 11.982 0Z'/%3e%3c/svg%3e");
+}
+
+input[data-task=p]:checked::after,
+li[data-task=p] > input:checked::after,
+li[data-task=p] > p > input:checked::after {
+  background-color: var(--color-green);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cpath fill='black' d='M0 13.74c0 2.89 1.807 5.313 4.229 5.313h1.718c-1.758-1.28-2.48-3.213-2.48-5.41.01-2.442.957-4.19 1.797-5.245H3.867C1.69 8.398 0 10.742 0 13.74Zm4.814-.078c0 3.565 2.784 6.318 7.325 6.318h1.328c1.26 0 2.197-.087 2.724-.234.762-.185 1.495-.654 1.495-1.572 0-.381-.098-.654-.215-.86-.078-.127-.059-.224.058-.273.606-.254 1.104-.82 1.104-1.592 0-.44-.127-.83-.342-1.094-.107-.146-.098-.283.088-.38.43-.254.742-.801.742-1.436 0-.459-.146-.937-.4-1.172-.157-.137-.127-.234.029-.38.303-.255.498-.694.498-1.25a1.69 1.69 0 0 0-1.7-1.71h-3.437c-.869 0-1.445-.449-1.445-1.172 0-1.298 1.63-3.7 1.63-5.42C14.297.528 13.712 0 12.95 0c-.703 0-1.045.479-1.416 1.21-1.455 2.823-3.388 5.108-4.863 7.061-1.25 1.66-1.856 3.096-1.856 5.391Z'/%3e%3c/svg%3e");
+}
+
+input[data-task=c]:checked::after,
+li[data-task=c] > input:checked::after,
+li[data-task=c] > p > input:checked::after {
+  background-color: var(--color-red);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cpath fill='black' d='M19.238 6.24c0-2.89-1.816-5.312-4.228-5.312h-1.72c1.758 1.28 2.54 3.213 2.5 5.41-.03 2.442-.976 4.19-1.826 5.245h1.406c2.178 0 3.867-2.344 3.867-5.342Zm-4.756.07C14.541 2.744 11.65.05 7.11.01L5.791 0c-1.27-.01-2.207.09-2.734.236-.762.185-1.494.644-1.494 1.571 0 .371.097.655.214.86.078.117.069.224-.058.273-.596.244-1.104.82-1.104 1.582 0 .45.127.83.352 1.104.107.146.088.273-.088.38-.44.254-.752.801-.752 1.436 0 .46.146.938.4 1.172.166.137.137.234-.029.38C.195 9.25 0 9.689 0 10.245a1.69 1.69 0 0 0 1.7 1.71h3.437c.869 0 1.445.449 1.445 1.172 0 1.299-1.621 3.691-1.621 5.41 0 .918.576 1.445 1.348 1.445.693 0 1.035-.478 1.406-1.21 1.455-2.823 3.389-5.108 4.863-7.071 1.25-1.66 1.865-3.086 1.904-5.39Z'/%3e%3c/svg%3e");
+}
+
+input[data-task=f]:checked::after,
+li[data-task=f] > input:checked::after,
+li[data-task=f] > p > input:checked::after {
+  background-color: var(--color-orange);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='17' height='22' fill='none' viewBox='0 0 17 22'%3e%3cpath fill='black' d='M7.676 21.123c5.156 0 8.594-3.486 8.594-8.74C16.27 3.643 8.828 0 3.662 0c-.918 0-1.504.322-1.504.947 0 .244.108.498.313.733 1.162 1.386 2.324 3.037 2.343 4.96 0 .44-.048.83-.36 1.378l.487-.098c-.439-1.436-1.62-2.451-2.656-2.451-.4 0-.674.293-.674.732 0 .254.069.85.069 1.28C1.68 9.667 0 10.946 0 14.472c0 3.994 3.057 6.65 7.676 6.65Zm.224-2.744c-1.826 0-3.037-1.104-3.037-2.744 0-1.719 1.221-2.334 1.377-3.438.02-.088.078-.117.147-.058.449.4.742.888.986 1.455.518-.703.762-2.188.596-3.79-.01-.087.049-.136.136-.107 2.14 1.006 3.252 3.135 3.252 5.04 0 1.933-1.132 3.642-3.457 3.642Z'/%3e%3c/svg%3e");
+}
+
+input[data-task=k]:checked::after,
+li[data-task=k] > input:checked::after,
+li[data-task=k] > p > input:checked::after {
+  background-color: var(--color-yellow);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='13' height='25' fill='none' viewBox='0 0 13 25'%3e%3cpath fill='black' d='M6.24 0C2.764 0 0 2.764 0 6.22c0 2.608 1.563 4.913 4.004 5.84v9.64a.83.83 0 0 0 .254.614l1.63 1.641c.167.166.499.215.704.01l3.096-3.096a.487.487 0 0 0 0-.703l-1.924-1.895 2.636-2.627c.186-.195.186-.478-.02-.693l-2.607-2.627c3.018-1.201 4.698-3.428 4.698-6.103A6.22 6.22 0 0 0 6.24 0Zm0 5.723c-.908 0-1.63-.733-1.63-1.631 0-.908.712-1.631 1.63-1.631.899 0 1.631.723 1.631 1.63 0 .9-.732 1.632-1.63 1.632Z'/%3e%3c/svg%3e");
+}
+
+input[data-task=w]:checked::after,
+li[data-task=w] > input:checked::after,
+li[data-task=w] > p > input:checked::after {
+  background-color: var(--color-orange);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='22' fill='none' viewBox='0 0 20 22'%3e%3cpath fill='black' d='M0 3.223c0 4.033 1.934 6.552 5.791 7.734a8.289 8.289 0 0 0 1.953 1.758v4.248H6.211c-1.377 0-2.09.79-2.09 2.09v1.611c0 .44.342.742.752.742h9.356c.41 0 .752-.302.752-.742v-1.611c0-1.3-.723-2.09-2.1-2.09h-1.524v-4.248a8.07 8.07 0 0 0 1.944-1.758c3.867-1.182 5.8-3.701 5.8-7.734 0-1.006-.624-1.621-1.67-1.621h-1.894C15.381.605 14.677 0 13.497 0H5.604C4.433 0 3.72.596 3.564 1.602H1.67C.625 1.602 0 2.217 0 3.222Zm1.396.136c0-.156.118-.283.284-.283h1.836V4.99c0 1.494.39 2.881.996 4.082C2.47 8.037 1.396 6.142 1.396 3.36ZM14.58 9.072a8.947 8.947 0 0 0 1.006-4.082V3.076h1.836c.166 0 .283.127.283.283 0 2.784-1.074 4.678-3.125 5.713Z'/%3e%3c/svg%3e");
+}
+
+input[data-task=u]:checked::after,
+li[data-task=u] > input:checked::after,
+li[data-task=u] > p > input:checked::after {
+  background-color: var(--color-orange);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='15' height='19' fill='none' viewBox='0 0 15 19'%3e%3cpath fill='black' d='M.84 8.271c.234 0 .469-.078.615-.234L3.682 5.85l3.71-4.082 3.731 4.082 2.227 2.187c.156.156.38.234.615.234.488 0 .84-.37.84-.85a.879.879 0 0 0-.264-.634L8.057.293A.885.885 0 0 0 7.402 0a.885.885 0 0 0-.654.293L.273 6.787c-.185.195-.273.4-.273.635 0 .478.352.85.84.85Zm6.562 10.176c.508 0 .87-.351.87-.86V4.728l-.098-2.91c0-.46-.313-.772-.772-.772s-.771.312-.771.771l-.098 2.91v12.862c0 .508.362.86.87.86Z'/%3e%3c/svg%3e");
+}
+
+input[data-task=d]:checked::after,
+li[data-task=d] > input:checked::after,
+li[data-task=d] > p > input:checked::after {
+  background-color: var(--color-blue);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='15' height='19' fill='none' viewBox='0 0 15 19'%3e%3cpath fill='black' d='M7.402 18.447a.885.885 0 0 0 .655-.293l6.484-6.494a.879.879 0 0 0 .264-.635c0-.478-.352-.85-.84-.85a.863.863 0 0 0-.615.235l-2.227 2.188-3.73 4.082-3.711-4.082-2.227-2.188c-.146-.156-.38-.234-.615-.234-.488 0-.84.37-.84.85 0 .234.088.439.273.634l6.475 6.494c.186.196.41.293.654.293Zm0-1.045c.46 0 .772-.312.772-.771l.097-2.91V.859c0-.507-.36-.859-.869-.859-.507 0-.869.352-.869.86v12.86l.098 2.91c0 .46.312.772.771.772Z'/%3e%3c/svg%3e");
+}
+
+input[data-task="+"]:checked,
+li[data-task="+"] > input:checked,
+li[data-task="+"] > p > input:checked {
+  --checkbox-color: var(--color-orange);
+}
+input[data-task="+"]:checked:after,
+li[data-task="+"] > input:checked:after,
+li[data-task="+"] > p > input:checked:after {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='18' height='18' fill='none' viewBox='0 0 18 18'%3e%3cpath fill='black' d='M8.154 5.172v2.963H5.192c-.509 0-.86.352-.86.86 0 .499.351.831.86.831h2.962V12.8c0 .498.342.86.841.86.509 0 .86-.352.86-.86V9.826h2.973c.498 0 .86-.332.86-.83 0-.51-.362-.861-.86-.861H9.856V5.172c0-.508-.352-.87-.86-.87-.5 0-.842.362-.842.87Z'/%3e%3c/svg%3e");
+}
+
+input[data-task=B]:checked::after,
+li[data-task=B] > input:checked::after,
+li[data-task=B] > p > input:checked::after {
+  background-color: var(--color-pink);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='22' height='20' fill='none' viewBox='0 0 22 20'%3e%3cg clip-path='url(%23a)'%3e%3cpath fill='black' d='M14.023 19.365a3.261 3.261 0 0 0 3.262-3.261 3.263 3.263 0 0 0-3.262-3.272 3.263 3.263 0 0 0-3.261 3.271 3.261 3.261 0 0 0 3.261 3.262Zm-7.177 0a3.261 3.261 0 0 0 3.261-3.261 3.263 3.263 0 0 0-3.261-3.272 3.263 3.263 0 0 0-3.262 3.271 3.261 3.261 0 0 0 3.262 3.262Zm10.761-6.425a3.255 3.255 0 0 0 3.262-3.262 3.255 3.255 0 0 0-3.262-3.262 3.263 3.263 0 0 0-3.271 3.262 3.263 3.263 0 0 0 3.271 3.261Zm-14.345 0a3.263 3.263 0 0 0 3.271-3.262 3.263 3.263 0 0 0-3.271-3.262 3.261 3.261 0 1 0 0 6.524Zm10.761-6.417a3.255 3.255 0 0 0 3.262-3.261A3.255 3.255 0 0 0 14.023 0a3.255 3.255 0 0 0-3.261 3.262 3.255 3.255 0 0 0 3.261 3.261Zm-7.177 0a3.255 3.255 0 0 0 3.261-3.261A3.255 3.255 0 0 0 6.846 0a3.255 3.255 0 0 0-3.262 3.262 3.255 3.255 0 0 0 3.262 3.261Z'/%3e%3c/g%3e%3cdefs%3e%3cclipPath id='a'%3e%3cpath fill='white' d='M0 0h21.23v19.365H0z'/%3e%3c/clipPath%3e%3c/defs%3e%3c/svg%3e");
+}
+
+input[data-task=a]:checked::after,
+li[data-task=a] > input:checked::after,
+li[data-task=a] > p > input:checked::after {
+  background-color: var(--color-pink);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='22' fill='none' viewBox='0 0 20 22'%3e%3cg clip-path='url(%23a)'%3e%3cpath fill='black' d='M9.336 20.254a9.336 9.336 0 0 0 9.336-9.336c0-5.156-4.18-9.346-9.336-9.346C4.18 1.572 0 5.762 0 10.918a9.336 9.336 0 0 0 9.336 9.336Zm-4.443-8.262a.663.663 0 0 1-.674-.674c0-.38.293-.683.674-.683h3.76V5.4a.68.68 0 1 1 1.357 0v5.918a.672.672 0 0 1-.684.674H4.893Zm-3.575-7.91c.147 0 .254-.02.391-.127l3.271-2.47c.157-.118.245-.274.245-.44 0-.205-.098-.371-.264-.527C4.59.186 3.926 0 3.34 0A2.734 2.734 0 0 0 .596 2.744c0 .361.058.723.166.947.107.245.312.391.556.391Zm16.035 0c.245 0 .45-.156.567-.39.098-.215.156-.587.156-.948A2.728 2.728 0 0 0 15.332 0c-.586 0-1.25.186-1.621.518-.166.156-.264.322-.264.527 0 .166.088.322.254.44l3.262 2.47a.568.568 0 0 0 .39.127ZM1.172 19.971a.74.74 0 0 0 1.074-.01l1.846-1.836-1.055-1.045-1.855 1.836a.743.743 0 0 0-.01 1.055Zm16.328 0a.734.734 0 0 0-.01-1.055l-1.855-1.836-1.045 1.045 1.836 1.836a.74.74 0 0 0 1.074.01Z'/%3e%3c/g%3e%3cdefs%3e%3cclipPath id='a'%3e%3cpath fill='white' d='M0 0h19.033v21.924H0z'/%3e%3c/clipPath%3e%3c/defs%3e%3c/svg%3e");
+}
+
+input[data-task=n]:checked::after,
+li[data-task=n] > input:checked::after,
+li[data-task=n] > p > input:checked::after {
+  background-color: var(--color-blue);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3e%3cg clip-path='url(%23a)'%3e%3cpath fill='black'  d='M2.668 14.63 13.322 3.985l-1.709-1.719L.95 12.911l-.928 2.178c-.097.234.157.508.391.41l2.256-.87ZM14.182 3.145l.986-.966c.498-.499.527-1.036.078-1.485l-.332-.332c-.44-.44-.976-.4-1.475.088l-.986.977 1.729 1.718Z'/%3e%3c/g%3e%3cdefs%3e%3cclipPath id='a'%3e%3cpath fill='white' d='M0 0h15.932v15.52H0z'/%3e%3c/clipPath%3e%3c/defs%3e%3c/svg%3e");
+}
+
+input[data-task=R]:checked::after,
+li[data-task=R] > input:checked::after,
+li[data-task=R] > p > input:checked::after {
+  background-color: var(--color-cyan);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='22' height='18' fill='none' viewBox='0 0 22 18'%3e%3cg clip-path='url(%23a)'%3e%3cpath fill='black'  d='M8.652 16.777v-6.181c0-.4-.224-.616-.625-.616a.803.803 0 0 0-.507.176l-3.692 3.057c-.303.264-.322.664 0 .928l3.692 3.066a.812.812 0 0 0 .507.186c.4 0 .625-.225.625-.616ZM20.02 8.36a.81.81 0 0 0-.82.83v.928c0 1.67-1.163 2.764-2.93 2.764H7.216c-.45 0-.82.371-.82.81 0 .45.37.82.82.82h8.896c2.91 0 4.727-1.65 4.727-4.277V9.19a.81.81 0 0 0-.82-.83ZM12.188.635v6.181c0 .391.224.616.624.616a.812.812 0 0 0 .508-.186l3.692-3.057c.312-.253.332-.654 0-.927L13.32.195a.803.803 0 0 0-.508-.175c-.4 0-.624.214-.624.615ZM.82 9.053c.47 0 .83-.362.83-.83v-.928c0-1.67 1.153-2.774 2.92-2.774h9.063c.44 0 .81-.36.81-.81a.82.82 0 0 0-.81-.81H4.727C1.827 2.9 0 4.54 0 7.177v1.045c0 .468.361.83.82.83Z'/%3e%3c/g%3e%3cdefs%3e%3cclipPath id='a'%3e%3cpath fill='white' d='M0 0h21.201v17.393H0z'/%3e%3c/clipPath%3e%3c/defs%3e%3c/svg%3e");
+}
+
+input[data-task=t]:checked::after,
+li[data-task=t] > input:checked::after,
+li[data-task=t] > p > input:checked::after {
+  background-color: var(--color-orange);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='21' height='20' fill='none' viewBox='0 0 21 20'%3e%3cg clip-path='url(%23a)'%3e%3cpath fill='white' d='M4.854 11.016a.667.667 0 0 1-.684-.684c0-.38.293-.674.684-.674h4.423V3.75c0-.38.293-.674.674-.674.381 0 .684.293.684.674v6.582c0 .39-.303.684-.684.684H4.854Zm5.107 8.906c5.498 0 9.96-4.473 9.96-9.961C19.922 4.463 15.46 0 9.962 0 4.473 0 0 4.463 0 9.96c0 5.49 4.473 9.962 9.96 9.962Z'/%3e%3c/g%3e%3cdefs%3e%3cclipPath id='a'%3e%3cpath fill='white' d='M0 0h20.283v19.932H0z'/%3e%3c/clipPath%3e%3c/defs%3e%3c/svg%3e");
+}
+
+input[data-task=P]:checked::after,
+li[data-task=P] > input:checked::after,
+li[data-task=P] > p > input:checked::after {
+  background-color: var(--color-green);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='19' height='19' fill='none' viewBox='0 0 19 19'%3e%3cg clip-path='url(%23a)'%3e%3cpath fill='white' d='M5 13.154c2.871 2.881 6.309 5.069 9.072 5.069 1.3 0 2.432-.518 3.174-1.348.713-.8.957-1.396.957-1.924 0-.41-.254-.79-.898-1.24l-2.383-1.709c-.596-.42-.86-.498-1.211-.498-.303 0-.557.059-1.065.332l-1.562.86c-.186.107-.264.126-.4.126-.186 0-.313-.049-.498-.127-.743-.341-1.788-1.162-2.715-2.09-.928-.927-1.65-1.875-2.022-2.607a.971.971 0 0 1-.107-.41c0-.127.068-.234.146-.371l.918-1.572c.254-.43.323-.665.323-.997 0-.38-.127-.79-.489-1.308L4.6 1.055C4.13.4 3.78 0 3.252 0 2.598 0 1.807.498 1.24 1.045.43 1.826 0 2.92 0 4.15c0 2.784 2.139 6.153 5 9.004Z'/%3e%3c/g%3e%3cdefs%3e%3cclipPath id='a'%3e%3cpath fill='white' d='M0 0h18.564v18.232H0z'/%3e%3c/clipPath%3e%3c/defs%3e%3c/svg%3e");
+}
+
+input[data-task=L]:checked::after,
+li[data-task=L] > input:checked::after,
+li[data-task=L] > p > input:checked::after {
+  background-color: var(--color-pink);
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='19' fill='none' viewBox='0 0 20 19'%3e%3cg clip-path='url(%23a)'%3e%3cpath fill='white' d='M9.697 18.525c.205 0 .498-.136.713-.263 5.498-3.516 8.985-7.608 8.985-11.768 0-3.457-2.373-5.898-5.44-5.898-1.904 0-3.37 1.054-4.258 2.666C8.828 1.66 7.344.596 5.44.596 2.373.596 0 3.037 0 6.494c0 4.16 3.486 8.252 8.994 11.768.205.127.498.263.703.263Z'/%3e%3c/g%3e%3cdefs%3e%3cclipPath id='a'%3e%3cpath fill='white' d='M0 0h19.756v18.525H0z'/%3e%3c/clipPath%3e%3c/defs%3e%3c/svg%3e");
+}
+
+body:not(.banner-off) {
+  --banner-image-object-fit: cover;
+  --banner-image-inset: 8px;
+  --banner-image-height: 320px;
+  --banner-image-height-s: 240px;
+  --banner-image-radius: var(--radius-s);
+  --banner-fade-height: 80px;
+  --banner-icon-size: 3rem;
+  --banner-mobile-offset: 0px;
+}
+body:not(.banner-off):where(.is-mobile) {
+  --banner-image-height: var(--banner-image-height-s);
+}
+body:not(.banner-off):where(.is-mobile) .markdown-preview-view:not(.banner),
+body:not(.banner-off):where(.is-mobile) .is-live-preview:not(.banner) {
+  --banner-mobile-offset: 0px;
+}
+body:not(.banner-off):not(.is-phone) {
+  --view-top-spacing-markdown: 0px;
+}
+body:not(.banner-off).is-mobile .banner:not(.banner-icon) {
+  --banner-mobile-offset: 0.5rem;
+}
+body:not(.banner-off).is-mobile .banner.banner-icon {
+  --banner-mobile-offset: 1.5rem;
+}
+body:not(.banner-off):not(.is-phone) .banner-icon.banner-title .inline-title ~ .metadata-container {
+  padding-top: 0px;
+}
+body:not(.banner-off).is-mobile .banner-icon .inline-title {
+  padding-top: 0px;
+}
+body:not(.banner-off).is-phone .banner-icon.banner-title .inline-title ~ .metadata-container {
+  padding-top: 8px;
+}
+body:not(.banner-off) .banner.y0 img[alt=banner] {
+  object-position: center 0%;
+}
+body:not(.banner-off) .banner.y5 img[alt=banner] {
+  object-position: center 5%;
+}
+body:not(.banner-off) .banner.y10 img[alt=banner] {
+  object-position: center 10%;
+}
+body:not(.banner-off) .banner.y15 img[alt=banner] {
+  object-position: center 15%;
+}
+body:not(.banner-off) .banner.y20 img[alt=banner] {
+  object-position: center 20%;
+}
+body:not(.banner-off) .banner.y25 img[alt=banner] {
+  object-position: center 25%;
+}
+body:not(.banner-off) .banner.y30 img[alt=banner] {
+  object-position: center 30%;
+}
+body:not(.banner-off) .banner.y35 img[alt=banner] {
+  object-position: center 35%;
+}
+body:not(.banner-off) .banner.y40 img[alt=banner] {
+  object-position: center 40%;
+}
+body:not(.banner-off) .banner.y45 img[alt=banner] {
+  object-position: center 45%;
+}
+body:not(.banner-off) .banner.y50 img[alt=banner] {
+  object-position: center 50%;
+}
+body:not(.banner-off) .banner.y55 img[alt=banner] {
+  object-position: center 55%;
+}
+body:not(.banner-off) .banner.y60 img[alt=banner] {
+  object-position: center 60%;
+}
+body:not(.banner-off) .banner.y65 img[alt=banner] {
+  object-position: center 65%;
+}
+body:not(.banner-off) .banner.y70 img[alt=banner] {
+  object-position: center 70%;
+}
+body:not(.banner-off) .banner.y75 img[alt=banner] {
+  object-position: center 75%;
+}
+body:not(.banner-off) .banner.y80 img[alt=banner] {
+  object-position: center 80%;
+}
+body:not(.banner-off) .banner.y85 img[alt=banner] {
+  object-position: center 85%;
+}
+body:not(.banner-off) .banner.y90 img[alt=banner] {
+  object-position: center 90%;
+}
+body:not(.banner-off) .banner.y95 img[alt=banner] {
+  object-position: center 95%;
+}
+body:not(.banner-off) .banner.y100 img[alt=banner] {
+  object-position: center 100%;
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview) .markdown-preview-sizer,
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview) .cm-editor > .cm-scroller > .cm-sizer {
+  margin-top: calc(var(--banner-image-height) + var(--banner-icon-size) - var(--banner-fade-height) + var(--banner-mobile-offset));
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview):not(.banner) {
+  --banner-image-height: 0px;
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview):not(.banner.banner-fade) {
+  --banner-fade-height: 0px;
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview):not(.banner-icon) {
+  --banner-icon-size: 0px;
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner-icon:not(.banner) {
+  --banner-image-height: var(--banner-icon-size);
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner-icon:not(.banner.banner-fade) {
+  --banner-fade-height: var(--banner-icon-size);
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner.banner-icon.banner-title:not(.banner-fade) {
+  --banner-fade-height: 0px;
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner-image-contain {
+  --banner-image-object-fit: contain;
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner-image-cover {
+  --banner-image-object-fit: cover;
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner-image-fill {
+  --banner-image-object-fit: fill;
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner img[alt=banner]:not([contenteditable]) {
+  position: absolute;
+  inset: var(--view-top-spacing-markdown) var(--banner-image-inset) auto;
+  border-radius: var(--banner-image-radius);
+  width: stretch;
+  height: var(--banner-image-height);
+  overflow: hidden;
+  object-fit: var(--banner-image-object-fit);
+  line-height: 0;
+  max-width: calc(100% - var(--banner-image-inset) * 2);
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner .image-embed[alt=banner],
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner .image-embed[alt=banner] > .image-wrapper,
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner .image-embed[alt=banner] > .image-resize-container {
+  display: contents !important;
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner .image-embed[alt=banner]::before, body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner .image-embed[alt=banner]::after,
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner .image-embed[alt=banner] .image-resize-corner,
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner .image-embed[alt=banner] .image-resize-handle,
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner .image-embed[alt=banner] > .image-wrapper::before,
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner .image-embed[alt=banner] > .image-wrapper::after,
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner .image-embed[alt=banner] > .image-wrapper .image-resize-corner,
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner .image-embed[alt=banner] > .image-wrapper .image-resize-handle,
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner .image-embed[alt=banner] > .image-resize-container::before,
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner .image-embed[alt=banner] > .image-resize-container::after,
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner .image-embed[alt=banner] > .image-resize-container .image-resize-corner,
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner .image-embed[alt=banner] > .image-resize-container .image-resize-handle {
+  display: none !important;
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner div:is(.mod-header, .inline-title, .metadata-container) {
+  z-index: 1;
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner.banner-fade img[alt=banner] {
+  mask: linear-gradient(to bottom, hsl(0, 0%, 0%) 0%, hsla(0, 0%, 0%, 0.987) 14%, hsla(0, 0%, 0%, 0.951) 26.2%, hsla(0, 0%, 0%, 0.896) 36.8%, hsla(0, 0%, 0%, 0.825) 45.9%, hsla(0, 0%, 0%, 0.741) 53.7%, hsla(0, 0%, 0%, 0.648) 60.4%, hsla(0, 0%, 0%, 0.55) 66.2%, hsla(0, 0%, 0%, 0.45) 71.2%, hsla(0, 0%, 0%, 0.352) 75.6%, hsla(0, 0%, 0%, 0.259) 79.6%, hsla(0, 0%, 0%, 0.175) 83.4%, hsla(0, 0%, 0%, 0.104) 87.2%, hsla(0, 0%, 0%, 0.049) 91.1%, hsla(0, 0%, 0%, 0.013) 95.3%, hsla(0, 0%, 0%, 0) 100%);
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner-icon .cm-callout:has(.callout[data-callout=banner-icon]) {
+  display: contents !important;
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner-icon .callout[data-callout=banner-icon] {
+  z-index: 1;
+  position: absolute;
+  top: calc(var(--view-top-spacing-markdown) + var(--banner-image-height) - var(--banner-fade-height) + 1rem);
+  margin: 0 !important;
+  border: none !important;
+  background: none !important;
+  padding: 0 !important;
+  width: var(--banner-icon-size);
+  height: var(--banner-icon-size);
+  font-size: var(--banner-icon-size);
+  display: flex;
+  justify-content: center;
+  overflow: visible;
+  box-shadow: none;
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner-icon .callout[data-callout=banner-icon] .callout-title-inner {
+  line-height: 1;
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner-icon .callout[data-callout=banner-icon] .callout-icon,
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner-icon .callout[data-callout=banner-icon] .callout-content {
+  display: none;
+}
+@keyframes bannerTitleEditIn {
+  from {
+    transform: translateY(-0.5rem);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+@keyframes bannerTitleEditOut {
+  from {
+    transform: translateY(0.5rem);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner-icon.banner-title .inline-title {
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline), margin-left 0s;
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner-icon.banner-title .inline-title:focus-within {
+  animation: bannerTitleEditIn var(--anim-duration-moderate) var(--anim-motion-baseline) forwards;
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner-icon.banner-title .inline-title:not(:focus-within) {
+  position: absolute;
+  top: calc(var(--view-top-spacing-markdown) + var(--banner-image-height) - var(--banner-fade-height) + 1rem);
+  align-items: center;
+  animation: bannerTitleEditOut var(--anim-duration-moderate) var(--anim-motion-baseline) forwards;
+  margin-bottom: 0;
+  margin-left: calc(var(--banner-icon-size) + 1rem);
+  width: calc(var(--file-line-width) - var(--banner-icon-size) - 1rem);
+  max-width: calc(100% - var(--file-margins-x) * 2 - var(--banner-icon-size) - 1rem);
+  height: var(--banner-icon-size);
+  overflow: hidden;
+  line-height: var(--banner-icon-size);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+body:not(.banner-off) .mod-root .view-content:not(.pixel-banner, .has-banner) div:is(.markdown-preview-view, .is-live-preview).banner-icon.banner-title .inline-title:not(:focus-within)::before {
+  content: none;
+}
+
+body {
+  --file-line-width: var(--line-width);
+  --line-width: 700px;
+}
+
+body:not(.block-width-off) {
+  --line-width-wide: 50rem;
+}
+body:not(.block-width-off) .wide {
+  --file-line-width: min(100cqw, var(--line-width-wide));
+}
+body:not(.block-width-off) .max {
+  --file-line-width: 100%;
+}
+body:not(.block-width-off) {
+  --block-width-wide: min(100cqw, var(--line-width-wide));
+  --block-width-max: calc(100cqw - (var(--file-margins-x) * 2));
+  --block-width-offset: calc(-1 * var(--file-margins-x));
+}
+body:not(.block-width-off) .mod-root .workspace-tab-container {
+  container-type: inline-size;
+}
+body:not(.block-width-off) div:is(.table-wide, .table-max, .table-100) .markdown-preview-sizer > .el-table,
+body:not(.block-width-off) div:is(.table-wide, .table-max, .table-100) .markdown-preview-sizer > .el-pre .block-language-dataview,
+body:not(.block-width-off) div:is(.table-wide, .table-max, .table-100) .markdown-preview-sizer > .el-pre .block-language-dataviewjs,
+body:not(.block-width-off) div:is(.table-wide, .table-max, .table-100) .markdown-preview-sizer > .el-pre .block-language-datacorejsx,
+body:not(.block-width-off) div:is(.table-wide, .table-max, .table-100) .cm-content > .cm-table-widget,
+body:not(.block-width-off) div:is(.table-wide, .table-max, .table-100) .cm-content > .cm-lang-dataview,
+body:not(.block-width-off) div:is(.table-wide, .table-max, .table-100) .cm-content > .cm-lang-dataviewjs,
+body:not(.block-width-off) div:is(.table-wide, .table-max, .table-100) .cm-content > .cm-lang-datacorejsx {
+  max-width: var(--table-line-max-width);
+  width: var(--table-line-width) !important;
+  justify-self: center;
+  margin-inline: var(--table-line-width-offset) !important;
+}
+body:not(.block-width-off) .table-wide {
+  --table-line-max-width: var(--block-width-max);
+  --table-line-width: var(--block-width-wide);
+}
+body:not(.block-width-off) .table-max {
+  --table-line-max-width: var(--block-width-max);
+  --table-line-width: var(--block-width-max);
+}
+body:not(.block-width-off) .table-100 {
+  --table-line-max-width: 100cqw;
+  --table-line-width: 100cqw;
+  --table-line-width-offset: var(--block-width-offset);
+}
+body:not(.block-width-off) .table-100 .markdown-preview-sizer > .el-table tbody > tr > td,
+body:not(.block-width-off) .table-100 .cm-content > .cm-table-widget tbody > tr > td {
+  border-radius: 0;
+}
+body:not(.block-width-off) .table-100 .markdown-preview-sizer > .el-table tbody tr:first-child > td,
+body:not(.block-width-off) .table-100 .cm-content > .cm-table-widget tbody tr:first-child > td {
+  border-block-start-width: 0;
+}
+body:not(.block-width-off) .table-100 .markdown-preview-sizer > .el-table tbody tr > td:last-child,
+body:not(.block-width-off) .table-100 .cm-content > .cm-table-widget tbody tr > td:last-child {
+  border-inline-end-width: 0;
+}
+body:not(.block-width-off) .table-100 .markdown-preview-sizer > .el-table tbody tr > td:first-child,
+body:not(.block-width-off) .table-100 .cm-content > .cm-table-widget tbody tr > td:first-child {
+  border-inline-start-width: 0;
+}
+body:not(.block-width-off) .table-100 .markdown-preview-sizer > .el-table tbody tr:last-child > td,
+body:not(.block-width-off) .table-100 .cm-content > .cm-table-widget tbody tr:last-child > td {
+  border-block-end-width: 0;
+}
+body:not(.block-width-off) div:is(.bases-wide, .bases-max, .bases-100) .markdown-preview-sizer > .el-pre .bases-embed,
+body:not(.block-width-off) div:is(.bases-wide, .bases-max, .bases-100) .markdown-preview-sizer > .el-p .bases-embed,
+body:not(.block-width-off) div:is(.bases-wide, .bases-max, .bases-100) .cm-content > .bases-embed,
+body:not(.block-width-off) div:is(.bases-wide, .bases-max, .bases-100) .cm-content > .cm-lang-base {
+  max-width: var(--bases-line-max-width);
+  width: var(--bases-line-width) !important;
+  justify-self: center;
+  margin-inline: var(--bases-line-width-offset) !important;
+}
+body:not(.block-width-off) .bases-wide {
+  --bases-line-max-width: var(--block-width-max);
+  --bases-line-width: var(--block-width-wide);
+}
+body:not(.block-width-off) .bases-max {
+  --bases-line-max-width: var(--block-width-max);
+  --bases-line-width: var(--block-width-max);
+}
+body:not(.block-width-off) .bases-100 {
+  --bases-line-max-width: 100cqw;
+  --bases-line-width: 100cqw;
+  --bases-line-width-offset: var(--block-width-offset);
+}
+body:not(.block-width-off) div:is(.img-wide, .img-max, .img-100) .markdown-preview-sizer > .el-p p:has(img),
+body:not(.block-width-off) div:is(.img-wide, .img-max, .img-100) .markdown-preview-sizer > .el-iframe,
+body:not(.block-width-off) div:is(.img-wide, .img-max, .img-100) .cm-content .image-embed {
+  max-width: var(--img-line-max-width);
+  width: var(--img-line-width) !important;
+  justify-self: center;
+  margin-inline: var(--img-line-width-offset) !important;
+}
+body:not(.block-width-off) .cm-content .image-embed {
+  display: block;
+}
+body:not(.block-width-off) .img-wide {
+  --img-line-max-width: var(--block-width-max);
+  --img-line-width: var(--block-width-wide);
+}
+body:not(.block-width-off) .img-max {
+  --img-line-max-width: var(--block-width-max);
+  --img-line-width: var(--block-width-max);
+}
+body:not(.block-width-off) .img-100 {
+  --img-line-max-width: 100cqw;
+  --img-line-width: 100cqw;
+  --img-line-width-offset: var(--block-width-offset);
+}
+body:not(.block-width-off) .img-100 .markdown-preview-sizer img:not([alt=banner]),
+body:not(.block-width-off) .img-100 .cm-content img:not([alt=banner]) {
+  border-radius: 0 !important;
+}
+
+.callout-icon .lucide-pencil,
+.callout-icon .lucide-clipboard-list,
+.callout-icon .lucide-info,
+.callout-icon .lucide-check-circle-2,
+.callout-icon .lucide-flame,
+.callout-icon .lucide-check,
+.callout-icon .lucide-help-circle,
+.callout-icon .lucide-alert-triangle,
+.callout-icon .lucide-x,
+.callout-icon .lucide-zap,
+.callout-icon .lucide-bug,
+.callout-icon .lucide-list,
+.callout-icon .lucide-quote {
+  -webkit-mask-position: 50% 50%;
+  -webkit-mask-size: 100% 100%;
+  background-color: rgb(var(--callout-color));
+}
+.callout-icon .lucide-pencil path,
+.callout-icon .lucide-pencil rect,
+.callout-icon .lucide-pencil circle,
+.callout-icon .lucide-clipboard-list path,
+.callout-icon .lucide-clipboard-list rect,
+.callout-icon .lucide-clipboard-list circle,
+.callout-icon .lucide-info path,
+.callout-icon .lucide-info rect,
+.callout-icon .lucide-info circle,
+.callout-icon .lucide-check-circle-2 path,
+.callout-icon .lucide-check-circle-2 rect,
+.callout-icon .lucide-check-circle-2 circle,
+.callout-icon .lucide-flame path,
+.callout-icon .lucide-flame rect,
+.callout-icon .lucide-flame circle,
+.callout-icon .lucide-check path,
+.callout-icon .lucide-check rect,
+.callout-icon .lucide-check circle,
+.callout-icon .lucide-help-circle path,
+.callout-icon .lucide-help-circle rect,
+.callout-icon .lucide-help-circle circle,
+.callout-icon .lucide-alert-triangle path,
+.callout-icon .lucide-alert-triangle rect,
+.callout-icon .lucide-alert-triangle circle,
+.callout-icon .lucide-x path,
+.callout-icon .lucide-x rect,
+.callout-icon .lucide-x circle,
+.callout-icon .lucide-zap path,
+.callout-icon .lucide-zap rect,
+.callout-icon .lucide-zap circle,
+.callout-icon .lucide-bug path,
+.callout-icon .lucide-bug rect,
+.callout-icon .lucide-bug circle,
+.callout-icon .lucide-list path,
+.callout-icon .lucide-list rect,
+.callout-icon .lucide-list circle,
+.callout-icon .lucide-quote path,
+.callout-icon .lucide-quote rect,
+.callout-icon .lucide-quote circle {
+  visibility: hidden;
+}
+.callout-icon .lucide-pencil {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3e%3cpath fill='black' d='M2.668 14.573 13.322 3.93l-1.709-1.72L.95 12.856l-.928 2.177c-.097.235.157.508.391.41l2.256-.869ZM14.182 3.09l.986-.967c.498-.498.527-1.035.078-1.484l-.332-.332c-.44-.44-.976-.4-1.475.087l-.986.977 1.729 1.719Z'/%3e%3c/svg%3e");
+}
+.callout-icon .lucide-clipboard-list {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='17' height='21' fill='none' viewBox='0 0 17 21'%3e%3cg fill='black'%3e%3cpath d='M0 17.88c0 2.042 1.006 3.058 3.027 3.058h10.371c2.022 0 3.028-1.016 3.028-3.057V3.066C16.426 1.036 15.42 0 13.398 0H3.028C1.005 0 0 1.035 0 3.066v14.815Zm1.572-.028V3.096c0-.977.518-1.524 1.533-1.524H13.32c1.016 0 1.534.547 1.534 1.524v14.756c0 .976-.518 1.513-1.534 1.513H3.105c-1.015 0-1.533-.537-1.533-1.513Z'/%3e%3cpath d='M4.512 5.654h7.412a.588.588 0 0 0 .596-.605.586.586 0 0 0-.596-.596H4.512a.588.588 0 0 0-.606.596.59.59 0 0 0 .606.605Zm0 3.409h7.412a.588.588 0 0 0 .596-.606.586.586 0 0 0-.596-.596H4.512a.588.588 0 0 0-.606.596.59.59 0 0 0 .606.605Zm0 3.407h3.506c.351 0 .605-.253.605-.585a.593.593 0 0 0-.605-.615H4.512a.593.593 0 0 0-.606.615c0 .332.254.586.606.586Z'/%3e%3c/g%3e%3c/svg%3e");
+}
+.callout-icon .lucide-info {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cg fill='black'%3e%3cpath d='M9.96 19.922c5.499 0 9.962-4.463 9.962-9.961S15.459 0 9.96 0 0 4.463 0 9.96c0 5.499 4.463 9.962 9.96 9.962Zm0-1.66c-4.589 0-8.3-3.711-8.3-8.301s3.711-8.3 8.3-8.3c4.59 0 8.302 3.71 8.302 8.3 0 4.59-3.711 8.3-8.301 8.3Z'/%3e%3cpath d='M8.252 15.43h3.975c.4 0 .713-.293.713-.694 0-.38-.313-.683-.713-.683h-1.211V9.082c0-.527-.264-.879-.762-.879H8.418c-.4 0-.713.303-.713.684 0 .4.313.693.713.693h1.045v4.473H8.252c-.4 0-.713.302-.713.683 0 .4.313.694.713.694Zm1.621-8.848c.713 0 1.27-.566 1.27-1.28 0-.712-.557-1.279-1.27-1.279a1.27 1.27 0 0 0-1.27 1.28 1.27 1.27 0 0 0 1.27 1.279Z'/%3e%3c/g%3e%3c/svg%3e");
+}
+.callout-icon .lucide-check-circle-2 {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cg fill='black'%3e%3cpath d='M9.96 19.922c5.499 0 9.962-4.463 9.962-9.961S15.459 0 9.96 0 0 4.463 0 9.96c0 5.499 4.463 9.962 9.96 9.962Zm0-1.66c-4.589 0-8.3-3.711-8.3-8.301s3.711-8.3 8.3-8.3c4.59 0 8.302 3.71 8.302 8.3 0 4.59-3.711 8.3-8.301 8.3Z'/%3e%3cpath d='M8.887 14.6c.322 0 .595-.157.79-.46l4.464-7.02c.107-.196.234-.411.234-.626 0-.44-.39-.723-.8-.723-.245 0-.49.157-.675.44l-4.052 6.504-1.924-2.49c-.235-.313-.45-.391-.723-.391a.757.757 0 0 0-.752.771c0 .215.088.42.225.606l2.383 2.93c.244.322.507.459.83.459Z'/%3e%3c/g%3e%3c/svg%3e");
+}
+.callout-icon .lucide-flame {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='14' height='23' fill='none' viewBox='0 0 14 23'%3e%3cpath fill='black' d='M0 6.016c0 3.75 2.246 4.677 2.871 11.191.04.352.234.576.606.576H9.59c.38 0 .576-.224.615-.576.625-6.514 2.861-7.441 2.861-11.191 0-3.37-2.88-6.016-6.533-6.016C2.881 0 0 2.646 0 6.016Zm1.475 0c0-2.637 2.314-4.541 5.058-4.541 2.744 0 5.059 1.904 5.059 4.54 0 2.803-1.856 3.467-2.735 10.294H4.22c-.89-6.827-2.745-7.49-2.745-10.293Zm1.972 13.877H9.63a.563.563 0 0 0 .566-.577.56.56 0 0 0-.566-.566H3.447a.571.571 0 1 0 0 1.143Zm3.086 2.832c1.514 0 2.774-.743 2.871-1.866H3.672c.068 1.123 1.338 1.866 2.861 1.866Z'/%3e%3c/svg%3e");
+}
+.callout-icon .lucide-check {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='17' height='17' fill='none' viewBox='0 0 17 17'%3e%3cpath fill='black' d='M6.367 16.69c.42 0 .752-.186.987-.547L16.582 1.61c.176-.283.244-.498.244-.722 0-.537-.351-.889-.889-.889-.39 0-.605.127-.84.498L6.329 14.473l-4.55-5.957c-.245-.342-.489-.479-.84-.479-.557 0-.938.381-.938.918 0 .225.098.479.283.713l5.069 6.455c.293.38.595.566 1.015.566Z'/%3e%3c/svg%3e");
+}
+.callout-icon .lucide-help-circle {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cg fill='black'%3e%3cpath d='M9.96 19.922c5.499 0 9.962-4.463 9.962-9.961S15.459 0 9.96 0 0 4.463 0 9.96c0 5.499 4.463 9.962 9.96 9.962Zm0-1.66c-4.589 0-8.3-3.711-8.3-8.301s3.711-8.3 8.3-8.3c4.59 0 8.302 3.71 8.302 8.3 0 4.59-3.711 8.3-8.301 8.3Z'/%3e%3cpath d='M9.756 11.982c.488 0 .79-.312.79-.693v-.117c0-.547.313-.899.997-1.348.947-.625 1.621-1.191 1.621-2.363 0-1.621-1.445-2.5-3.105-2.5-1.68 0-2.784.8-3.047 1.7a1.584 1.584 0 0 0-.078.478c0 .44.341.673.664.673.332 0 .547-.156.722-.39l.176-.234c.342-.567.85-.899 1.504-.899.889 0 1.465.508 1.465 1.25 0 .664-.41.986-1.26 1.582-.703.488-1.23 1.006-1.23 1.963v.127c0 .508.283.771.78.771Zm-.02 2.91c.567 0 1.055-.449 1.055-1.015 0-.567-.479-1.016-1.055-1.016s-1.054.46-1.054 1.016c0 .557.488 1.016 1.054 1.016Z'/%3e%3c/g%3e%3c/svg%3e");
+}
+.callout-icon .lucide-alert-triangle {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='20' height='20' fill='none' viewBox='0 0 20 20'%3e%3cg fill='black'%3e%3cpath d='M9.96 19.922c5.499 0 9.962-4.463 9.962-9.961S15.459 0 9.96 0 0 4.463 0 9.96c0 5.499 4.463 9.962 9.96 9.962Zm0-1.66c-4.589 0-8.3-3.711-8.3-8.301s3.711-8.3 8.3-8.3c4.59 0 8.302 3.71 8.302 8.3 0 4.59-3.711 8.3-8.301 8.3Z'/%3e%3cpath d='M9.951 11.719c.46 0 .733-.264.742-.772l.147-5.156c.01-.498-.381-.87-.899-.87-.527 0-.898.362-.888.86l.127 5.166c.01.498.283.772.771.772Zm0 3.174c.557 0 1.045-.45 1.045-1.016 0-.567-.478-1.016-1.045-1.016-.576 0-1.055.46-1.055 1.016 0 .557.489 1.016 1.055 1.016Z'/%3e%3c/g%3e%3c/svg%3e");
+}
+.callout-icon .lucide-x {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' fill='none' viewBox='0 0 16 16'%3e%3cpath fill='black' d='M13.993.26.253 14a.875.875 0 0 0 0 1.23.896.896 0 0 0 1.24 0l13.74-13.74a.875.875 0 0 0 0-1.23.87.87 0 0 0-1.24 0ZM15.233 14 1.493.26a.87.87 0 0 0-1.24 0 .884.884 0 0 0 0 1.23l13.74 13.74c.332.333.908.342 1.24 0a.884.884 0 0 0 0-1.23Z'/%3e%3c/svg%3e");
+}
+.callout-icon .lucide-zap {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='21' height='19' fill='none' viewBox='0 0 21 19'%3e%3cg fill='black'%3e%3cpath d='M2.666 18.555h15.137c1.66 0 2.666-1.153 2.666-2.647 0-.459-.137-.937-.381-1.367L12.51 1.338A2.588 2.588 0 0 0 10.234 0C9.336 0 8.457.45 7.96 1.338L.381 14.54c-.264.44-.381.908-.381 1.367 0 1.494 1.006 2.647 2.666 2.647Zm.01-1.534c-.684 0-1.094-.527-1.094-1.123 0-.185.04-.42.147-.625L9.297 2.08c.205-.361.576-.518.937-.518.362 0 .723.157.928.518l7.568 13.203c.108.205.157.43.157.615 0 .596-.43 1.123-1.104 1.123H2.676Z'/%3e%3cpath d='M10.234 11.973c.47 0 .743-.274.752-.782l.137-5.146c.01-.498-.38-.87-.898-.87-.528 0-.899.362-.89.86l.128 5.156c.01.498.283.782.771.782Zm0 3.173c.567 0 1.055-.449 1.055-1.015 0-.576-.479-1.016-1.055-1.016s-1.054.45-1.054 1.016c0 .556.488 1.015 1.054 1.015Z'/%3e%3c/g%3e%3c/svg%3e");
+}
+.callout-icon .lucide-bug {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='23' height='23' fill='none' viewBox='0 0 23 23'%3e%3cpath fill='black' d='M11.065 22.94c5.156 0 8.583-3.515 8.583-8.818 0-2.93-1.298-5.927-3.369-7.744-.02-2.705-2.08-4.336-5.214-4.336-3.135 0-5.186 1.641-5.206 4.346-2.07 1.816-3.369 4.766-3.369 7.734 0 5.303 3.428 8.819 8.575 8.819Zm0-14.237c1.728 0 3.437-.333 4.55-.83 1.211 1.26 2.5 3.476 2.5 6.25 0 4.374-2.822 7.294-7.05 7.294-4.23 0-7.051-2.92-7.051-7.295 0-2.763 1.279-4.97 2.51-6.25 1.113.498 2.822.83 4.54.83Zm-.674 13.144h1.279V10.538a.642.642 0 0 0-.645-.634.634.634 0 0 0-.634.635v11.308ZM7.949 12.12a1.24 1.24 0 0 0 1.23-1.24 1.23 1.23 0 0 0-1.23-1.23 1.23 1.23 0 0 0-1.22 1.23c0 .674.546 1.24 1.22 1.24Zm-1.162 3.868a1.436 1.436 0 0 0 0-2.871c-.8 0-1.445.644-1.445 1.435a1.44 1.44 0 0 0 1.445 1.436Zm1.162 3.34a1.138 1.138 0 1 0 .01-2.275 1.138 1.138 0 0 0-.01 2.274Zm6.24-7.207c.674 0 1.221-.567 1.221-1.24a1.23 1.23 0 0 0-1.22-1.231c-.684 0-1.231.556-1.231 1.23 0 .674.547 1.24 1.23 1.24Zm1.163 3.867c.79 0 1.445-.645 1.445-1.436 0-.79-.654-1.435-1.445-1.435-.782 0-1.436.644-1.436 1.435s.654 1.436 1.436 1.436Zm-1.162 3.34c.625 0 1.132-.508 1.132-1.133a1.138 1.138 0 1 0-1.133 1.133ZM6.768 1.407l.664.244c.42.146.586.37.507.722l-.117.489 1.436-.01.068-.498c.108-.947-.332-1.65-1.299-1.992L7.256.05c-.967-.332-1.426 1.084-.488 1.358Zm8.603 0c.938-.274.479-1.69-.488-1.358l-.772.313c-.966.341-1.406 1.045-1.299 1.992l.069.498 1.435.01-.117-.489c-.078-.351.088-.576.508-.722l.664-.244ZM4.981 8.195 3.163 6.652c-.361-.303-.83-.342-1.133.02-.293.35-.185.83.176 1.122l1.846 1.553.927-1.152Zm-1.778 4.61-2.402.009c-.489 0-.801.303-.801.742 0 .45.313.752.81.752l2.393-.01v-1.494Zm.791 5.712L2.168 20.05c-.352.293-.459.762-.166 1.123.303.362.762.323 1.133.02l1.797-1.524-.938-1.152ZM17.148 8.195l.938 1.152 1.846-1.553c.351-.293.468-.771.175-1.123-.302-.361-.771-.322-1.132-.02l-1.827 1.544Zm1.788 4.61v1.493l2.392.01c.488 0 .81-.303.81-.752 0-.44-.322-.742-.8-.742l-2.402-.01Zm-.801 5.712-.938 1.143 1.807 1.533c.361.302.83.341 1.133-.02.293-.361.185-.83-.176-1.123l-1.826-1.533Z'/%3e%3c/svg%3e");
+}
+.callout-icon .lucide-list {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='19' height='23' fill='none' viewBox='0 0 19 23'%3e%3cpath fill='black' d='M8.486 4.756c.127 0 .196-.078.215-.195.293-1.582.264-1.66 1.963-1.963.117-.03.195-.098.195-.225 0-.117-.078-.195-.195-.215-1.7-.303-1.67-.38-1.963-1.963C8.681.078 8.613 0 8.486 0s-.195.078-.215.195c-.292 1.582-.263 1.66-1.962 1.963-.127.02-.196.098-.196.215 0 .127.069.195.196.225 1.699.302 1.67.38 1.962 1.963.02.117.088.195.215.195ZM3.76 11.475a.324.324 0 0 0 .332-.303c.351-2.608.44-2.608 3.135-3.125.166-.03.293-.147.293-.332a.32.32 0 0 0-.293-.322c-2.696-.381-2.793-.47-3.135-3.116-.02-.185-.147-.312-.332-.312-.176 0-.303.127-.332.322-.313 2.608-.46 2.598-3.135 3.106-.166.029-.293.146-.293.322 0 .195.127.303.332.332 2.656.43 2.783.498 3.096 3.105.029.196.156.323.332.323Zm6.62 10.8c.255 0 .44-.185.49-.449.693-5.342 1.445-6.162 6.737-6.748.274-.03.46-.224.46-.488 0-.254-.186-.45-.46-.479-5.292-.586-6.044-1.406-6.738-6.757-.049-.264-.234-.44-.488-.44s-.44.176-.479.44c-.693 5.351-1.455 6.171-6.738 6.757-.283.03-.469.225-.469.479 0 .264.186.459.47.488 5.272.694 6.005 1.406 6.737 6.748.04.264.225.45.479.45Z'/%3e%3c/svg%3e");
+}
+.callout-icon .lucide-quote {
+  -webkit-mask-image: url("data:image/svg+xml,%3csvg xmlns='http://www.w3.org/2000/svg' width='22' height='14' fill='none' viewBox='0 0 22 14'%3e%3cpath fill='black' d='M0 4.697c0 2.598 1.934 4.668 4.404 4.668A4.09 4.09 0 0 0 7.48 8.008h.264C7.178 9.854 5.46 11.396 3.33 12.03c-.312.098-.537.186-.674.303a.604.604 0 0 0-.234.508c0 .41.303.693.752.693.322 0 .547-.059.976-.195a8.532 8.532 0 0 0 3.496-2.197c1.31-1.368 2.12-3.194 2.12-5.362C9.766 2.12 7.44 0 4.716 0 2.032 0 0 2.05 0 4.697Zm11.729 0c0 2.598 1.923 4.668 4.404 4.668a4.105 4.105 0 0 0 3.076-1.357h.254c-.557 1.846-2.276 3.388-4.414 4.023-.313.098-.527.186-.664.303a.612.612 0 0 0-.244.508c0 .41.312.693.771.693.303 0 .537-.059.957-.195a8.372 8.372 0 0 0 3.486-2.197c1.329-1.368 2.14-3.194 2.14-5.362C21.494 2.12 19.17 0 16.444 0 13.76 0 11.73 2.05 11.73 4.697Z'/%3e%3c/svg%3e");
+}
+
+body:not(.is-mobile):not(.zoom-off) .markdown-preview-view .image-embed:not(.canvas-node-content, [alt=banner]) img,
+body:not(.is-mobile):not(.zoom-off) .markdown-preview-view img[referrerpolicy=no-referrer]:not([alt=banner]) {
+  cursor: zoom-in;
+}
+body:not(.is-mobile):not(.zoom-off) .markdown-preview-view .image-embed:not(.canvas-node-content, [alt=banner]):active img,
+body:not(.is-mobile):not(.zoom-off) .markdown-preview-view img[referrerpolicy=no-referrer]:not([alt=banner]):active {
+  position: fixed;
+  z-index: 1000;
+  cursor: zoom-out;
+  inset: 0;
+  background-color: var(--background-primary);
+  width: 100%;
+  height: 100%;
+  max-height: unset;
+  object-fit: contain;
+  mask: none;
+  padding: 0;
+  border-radius: 0 !important;
+  border: none;
+}
+
+/* MIT License | Copyright (c) Stephan Ango (@kepano) 
+
+Cards snippet for Obsidian
+
+author: @kepano
+version: 3.0.1
+
+Support my work:
+https://github.com/sponsors/kepano
+
+*/
+body {
+  --cards-min-width: 160px;
+  --cards-max-width: 1fr;
+  --cards-mobile-width: 120px;
+  --cards-image-height: 400px;
+  --cards-image-fit: contain;
+  --cards-background: transparent;
+  --cards-background-hover: transparent;
+  --cards-padding: 4px;
+  --cards-aspect-ratio: auto;
+  --cards-columns: repeat(auto-fit, minmax(var(--cards-min-width), var(--cards-max-width)));
+}
+
+@media (max-width: 400pt) {
+  body {
+    --cards-min-width: var(--cards-mobile-width);
+  }
+}
+.cards.table-100 table.dataview tbody,
+.table-100 .cards table.dataview tbody {
+  padding: 0 8px;
+}
+
+.cards table.dataview.table-view-table tbody {
+  clear: both;
+  display: grid;
+  grid-template-columns: var(--cards-columns);
+  grid-column-gap: 8px;
+  grid-row-gap: 8px;
+  background-color: transparent;
+}
+.cards table.dataview.table-view-table > tbody > tr {
+  background-color: var(--cards-background);
+  border: var(--table-border-width) solid var(--background-modifier-border);
+  display: flex;
+  flex-direction: column;
+  margin: 0;
+  padding: var(--cards-padding);
+  border-radius: var(--radius-s);
+  overflow: hidden;
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline);
+  max-width: var(--cards-max-width);
+  height: auto;
+}
+.cards table.dataview.table-view-table > tbody > tr:hover {
+  background-color: var(--cards-background-hover);
+}
+.cards table.dataview.table-view-table tbody > tr > td {
+  text-wrap: wrap;
+}
+.cards table.dataview.table-view-table tbody > tr > td:first-child {
+  font-weight: calc(var(--font-weight) + var(--bold-modifier));
+}
+.cards table.dataview.table-view-table tbody > tr > td:not(:first-child) {
+  font-size: var(--font-small);
+  color: var(--text-muted);
+}
+.cards table.dataview.table-view-table tbody > tr > td {
+  /* Lists */
+}
+.cards table.dataview.table-view-table tbody > tr > td > ul {
+  width: 100%;
+  margin: 0 auto !important;
+}
+.cards table.dataview.table-view-table tbody > tr > td img {
+  aspect-ratio: var(--cards-aspect-ratio);
+  width: 100%;
+  object-fit: var(--cards-image-fit);
+  max-height: var(--cards-image-height);
+  background-color: var(--background-secondary);
+  vertical-align: bottom;
+}
+
+.markdown-source-view.mod-cm6.cards .dataview.table-view-table > tbody > tr > td,
+.trim-cols .cards table.dataview tbody > tr > td {
+  white-space: normal;
+}
+
+.links-int-on .cards table {
+  --link-decoration: none;
+}
+
+/* ------------------- */
+/* Sorting menu */
+.cards.table-100 table.dataview thead > tr,
+.table-100 .cards table.dataview thead > tr {
+  right: 8px;
+}
+
+.table-100 .cards table.dataview thead:before,
+.cards.table-100 table.dataview thead:before {
+  margin-right: 8px;
+}
+
+.cards table.dataview thead {
+  user-select: none;
+  width: 160px;
+  height: 24px;
+  float: right;
+  position: relative;
+}
+.cards table.dataview thead:after,
+.cards table.dataview thead:before {
+  content: "";
+  position: absolute;
+  right: 0;
+  top: 0;
+  width: var(--icon-size);
+  height: var(--icon-size);
+}
+.cards table.dataview thead:before {
+  background-color: var(--text-faint);
+  -webkit-mask-repeat: no-repeat;
+  -webkit-mask-size: 16px;
+  -webkit-mask-position: center center;
+  -webkit-mask-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 100 100"><path fill="currentColor" d="M49.792 33.125l-5.892 5.892L33.333 28.45V83.333H25V28.45L14.438 39.017L8.542 33.125L29.167 12.5l20.625 20.625zm41.667 33.75L70.833 87.5l-20.625 -20.625l5.892 -5.892l10.571 10.567L66.667 16.667h8.333v54.883l10.567 -10.567l5.892 5.892z"></path></svg>');
+}
+.cards table.dataview thead > tr {
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline);
+  position: absolute;
+  z-index: 1;
+  border: 1px solid var(--background-modifier-border-hover);
+  background-color: var(--background-secondary);
+  box-shadow: var(--shadow-s);
+  padding: 4px;
+  border-radius: var(--radius-s);
+  flex-direction: column;
+  margin-top: 24px;
+  width: 100%;
+}
+.cards table.dataview thead:not(:hover) > tr {
+  opacity: 0;
+  filter: blur(4px);
+  transform: translateY(-8px);
+  pointer-events: none;
+}
+.cards table.dataview thead:hover > tr {
+  display: flex;
+}
+.cards table.dataview thead > tr > th {
+  display: block;
+  padding: 6px 8px;
+  border-radius: var(--radius-s);
+  font-weight: var(--font-normal);
+  color: var(--text-normal);
+  font-size: var(--font-ui-small);
+}
+
+/* ------------------- */
+/* Card lists */
+.list-cards.markdown-preview-view .list-bullet,
+.list-cards.markdown-preview-view .list-collapse-indicator, .list-cards.markdown-preview-view.markdown-rendered.show-indentation-guide li > ul::before {
+  display: none;
+}
+.list-cards.markdown-preview-view div > ul {
+  display: grid;
+  gap: 8px;
+  grid-template-columns: var(--cards-columns);
+  padding: 0;
+  line-height: var(--line-height-tight);
+}
+.list-cards.markdown-preview-view div > ul > li.task-list-item > .task-list-item-checkbox {
+  margin-inline-start: 4px;
+}
+.list-cards.markdown-preview-view div > ul > li {
+  background-color: var(--cards-background);
+  border-radius: var(--radius-s);
+  border: var(--table-border-width) solid var(--background-modifier-border);
+  overflow: hidden;
+  padding: 8px;
+  margin-inline-start: 0;
+  transition: var(--anim-duration-moderate) var(--anim-motion-baseline);
+}
+.list-cards.markdown-preview-view div > ul > li:hover {
+  background-color: var(--cards-background-hover);
+}
+.list-cards.markdown-preview-view div > ul .image-embed {
+  padding: 0;
+  display: block;
+}
+.list-cards.markdown-preview-view div > ul .image-embed img {
+  aspect-ratio: var(--cards-aspect-ratio);
+  object-fit: var(--cards-image-fit);
+  max-height: var(--cards-image-height);
+  background-color: var(--background-secondary);
+  vertical-align: bottom;
+}
+.list-cards.markdown-preview-view div > ul > li > a {
+  --link-decoration: none;
+  --link-external-decoration: none;
+  font-weight: calc(var(--font-weight) + var(--bold-modifier));
+}
+.list-cards.markdown-preview-view div ul ul {
+  display: block;
+  width: 100%;
+  color: var(--text-muted);
+  font-size: var(--font-smallest);
+}
+.list-cards.markdown-preview-view div ul ul > li {
+  display: block;
+  margin-inline-start: 0;
+}
+
+/* ------------------- */
+/* Helper classes */
+.cards.cards-16-9,
+.list-cards.cards-16-9 {
+  --cards-aspect-ratio: 16/9;
+}
+.cards.cards-1-1,
+.list-cards.cards-1-1 {
+  --cards-aspect-ratio: 1/1;
+}
+.cards.cards-2-1,
+.list-cards.cards-2-1 {
+  --cards-aspect-ratio: 2/1;
+}
+.cards.cards-2-3,
+.list-cards.cards-2-3 {
+  --cards-aspect-ratio: 2/3;
+}
+.cards.cards-cols-1,
+.list-cards.cards-cols-1 {
+  --cards-columns: repeat(1, minmax(0, 1fr));
+}
+.cards.cards-cols-2,
+.list-cards.cards-cols-2 {
+  --cards-columns: repeat(2, minmax(0, 1fr));
+}
+.cards.cards-cover,
+.list-cards.cards-cover {
+  --cards-image-fit: cover;
+  /* Images */
+}
+.cards.cards-cover tbody > tr > td:first-child,
+.list-cards.cards-cover tbody > tr > td:first-child {
+  padding: 0 !important;
+  background-color: var(--background-secondary);
+  display: block;
+  margin: calc(var(--cards-padding) * -1) calc(var(--cards-padding) * -1) 0;
+  width: calc(100% + var(--cards-padding) * 2);
+}
+.cards.cards-cover tbody > tr > td:first-child img,
+.list-cards.cards-cover tbody > tr > td:first-child img {
+  border-radius: 0;
+}
+.cards.cards-align-bottom table.dataview tbody > tr > td:last-child,
+.list-cards.cards-align-bottom table.dataview tbody > tr > td:last-child {
+  margin-top: auto;
+}
+
+@media (max-width: 400pt) {
+  .cards table.dataview tbody > tr > td:not(:first-child) {
+    font-size: 80%;
+  }
+}
+@media (min-width: 400pt) {
+  .cards-cols-3 {
+    --cards-columns: repeat(3, minmax(0, 1fr));
+  }
+  .cards-cols-4 {
+    --cards-columns: repeat(4, minmax(0, 1fr));
+  }
+  .cards-cols-5 {
+    --cards-columns: repeat(5, minmax(0, 1fr));
+  }
+  .cards-cols-6 {
+    --cards-columns: repeat(6, minmax(0, 1fr));
+  }
+  .cards-cols-7 {
+    --cards-columns: repeat(7, minmax(0, 1fr));
+  }
+  .cards-cols-8 {
+    --cards-columns: repeat(8, minmax(0, 1fr));
+  }
+}
+/* Table helper classes for alternate styles */
+/* MIT License | Copyright (c) Stephan Ango (@kepano) */
+.table-small {
+  --table-text-size: var(--font-smaller);
+}
+
+.table-tiny {
+  --table-text-size: var(--font-smallest);
+}
+
+.row-hover {
+  --table-row-background-hover: var(--background-modifier-hover);
+  --table-row-alt-background-hover: var(--background-modifier-hover);
+}
+
+.row-alt {
+  --table-row-alt-background: var(--background-primary);
+  --table-row-alt-background-hover: var(--background-primary);
+}
+
+.col-alt .markdown-rendered:not(.cards) {
+  --table-column-alt-background: var(--background-primary);
+}
+
+.table-tabular table:not(.calendar) {
+  font-variant-numeric: tabular-nums;
+}
+
+.table-center .markdown-preview-sizer table,
+.table-center .table-wrapper {
+  margin: 0 auto;
+}
+
+.table-nowrap {
+  --table-white-space: nowrap;
+}
+
+.table-nowrap-first table thead > tr > th:first-child,
+.table-nowrap-first table tbody > tr > td:first-child {
+  --table-white-space: nowrap;
+}
+
+.trim-cols,
+.table-nowrap .table-wrap {
+  --table-white-space: normal;
+}
+
+.table-numbers table {
+  counter-reset: section;
+}
+.table-numbers table:not(.table-editor) > :is(thead, tbody) > tr > :is(th, td):first-child, .table-numbers table.table-editor > :is(thead, tbody) > tr > :is(th, td):first-child .table-cell-wrapper {
+  position: relative;
+  padding-left: 3em;
+}
+.table-numbers table:not(.table-editor) tbody > tr > td:first-child::before, .table-numbers table.table-editor tbody > tr > td:first-child .table-cell-wrapper::before {
+  display: inline-block;
+  position: absolute;
+  top: 0.5em;
+  left: 0.5em;
+  counter-increment: section;
+  min-width: 2em;
+  content: counter(section);
+  color: var(--text-faint);
+  font-variant-numeric: tabular-nums;
+  text-align: center;
+}
+
+.row-lines div:not(.el-table):not(.table-wrapper) > table > tbody > tr > td {
+  border-bottom: var(--table-border-width) solid var(--table-border-color);
+}
+.row-lines div:not(.el-table):not(.table-wrapper) > table > tbody > tr:last-child > td {
+  border-bottom: none;
+}
+
+.col-lines div:not(.el-table):not(.table-wrapper) > table > tbody > tr > td {
+  border-right: var(--table-border-width) solid var(--table-border-color);
+}
+.col-lines div:not(.el-table):not(.table-wrapper) > table > tbody > tr > td:last-child {
+  border-right: none;
+}
+
+/* Dark mode images  */
+/* MIT License | Copyright (c) Stephan Ango (@kepano) */
+/* Invert  */
+.theme-light img[src$="#blend"],
+.theme-light div[src$="#blend"] img,
+.theme-light span[src$="#blend"] img {
+  mix-blend-mode: multiply;
+}
+.theme-light img[src$="#invertW"],
+.theme-light div[src$="#invertW"] img,
+.theme-light span[src$=invertW] img {
+  filter: invert(1) hue-rotate(180deg);
+}
+.theme-light .img-blend {
+  mix-blend-mode: multiply;
+}
+
+.theme-dark div[src$="#invert"],
+.theme-dark div[src$="#blend"] {
+  background-color: var(--background-primary);
+}
+.theme-dark img[src$="#invert"],
+.theme-dark div[src$="#invert"] img,
+.theme-dark span[src$="#invert"] img {
+  filter: invert(1) hue-rotate(180deg);
+  mix-blend-mode: screen;
+}
+.theme-dark img[src$="#blend"],
+.theme-dark div[src$="#blend"] img,
+.theme-dark span[src$="#blend"] img {
+  mix-blend-mode: screen;
+}
+.theme-dark .img-blend {
+  mix-blend-mode: screen;
+}
+
+/* Alignment */
+img[alt=left]:not(.emoji),
+span[alt=left] img:not(.emoji),
+span[alt=left] img:not(.emoji) {
+  display: block;
+  justify-self: left;
+}
+
+img[alt=center]:not(.emoji),
+span[alt=center] img:not(.emoji),
+span[alt=center] img:not(.emoji) {
+  display: block;
+  justify-self: center;
+}
+
+img[alt=right]:not(.emoji),
+span[alt=right] img:not(.emoji),
+span[alt=right] img:not(.emoji) {
+  display: block;
+  justify-self: right;
+}
+
+/* Circle */
+img[src$="#circle"]:not(.emoji),
+span[src$="#circle"] img:not(.emoji),
+span[src$="#round"] img:not(.emoji) {
+  border-radius: 50% !important;
+  aspect-ratio: 1/1;
+  object-fit: cover;
+}
+
+/* Outline */
+img[src$="#outline"],
+div[src$="#outline"] img,
+span[src$="#outline"] img {
+  border: 1px solid var(--background-modifier-border);
+}
+
+/* Interface */
+img[src$="#interface"],
+span[src$="#interface"] img {
+  border: 1px solid var(--background-modifier-border);
+  box-shadow: var(--shadow-l);
+  border-radius: var(--radius-m);
+}
+
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile):not(.is-translucent).colorful-frame.theme-light .mod-sidedock.mod-left-split {
+  background-color: color-mix(in srgb, #fff, var(--color-accent) 2%);
+}
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile):not(.is-translucent).colorful-frame.theme-dark .mod-sidedock.mod-left-split {
+  background-color: color-mix(in srgb, var(--background-modifier-cover), var(--color-accent) 2%);
+}
+
+body.focus-view:not(.is-mobile):not(.is-popout-window) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root {
+  --view-top-spacing-markdown: var(--header-height);
+  --file-margins: calc(var(--file-margins-y) + var(--header-height)) var(--file-margins-y);
+}
+body.focus-view:not(.is-mobile):not(.is-popout-window) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root .workspace-tab-header-container {
+  height: 0;
+  border-width: 0px;
+}
+body.focus-view:not(.is-mobile):not(.is-popout-window) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root .workspace-tab-header-container > div:not(.sidebar-toggle-button) {
+  opacity: 0;
+}
+body.focus-view:not(.is-mobile):not(.is-popout-window) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root .view-header {
+  -webkit-app-region: drag;
+  position: absolute;
+  left: calc(var(--frame-left-space) + var(--tab-action-width));
+  right: calc(var(--frame-right-space) + var(--tab-action-width));
+  background-color: transparent;
+  transition: var(--anim-duration-fast);
+}
+body.focus-view:not(.is-mobile):not(.is-popout-window) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root .view-header:not(:hover) {
+  opacity: 0.5;
+}
+body.focus-view:not(.is-mobile):not(.is-popout-window) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root .workspace-leaf-content:not([data-type=markdown]) > .view-content {
+  margin-top: var(--header-height);
+}
+body.focus-view:not(.is-mobile):not(.is-popout-window) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root .sidebar-toggle-button {
+  position: absolute;
+  height: var(--header-height);
+  z-index: 1;
+}
+body.focus-view:not(.is-mobile):not(.is-popout-window) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root .sidebar-toggle-button.mod-left {
+  left: calc(var(--frame-left-space) + 8px);
+}
+body.focus-view:not(.is-mobile):not(.is-popout-window) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root .sidebar-toggle-button.mod-right {
+  right: calc(var(--frame-right-space) + 8px);
+}
+body.focus-view:not(.is-mobile):not(.is-popout-window) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root .sidebar-toggle-button:not(:hover) {
+  opacity: 0.5;
+}
+
+body.focus-view.mod-macos:not(.is-mobile):not(.is-popout-window):not(.is-hidden-frameless) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root {
+  --frame-left-space: 0px;
+}
+
+body.focus-view:not(.mod-macos):not(.is-mobile):not(.is-popout-window):not(.is-hidden-frameless) .workspace:not(.is-left-sidedock-open):not(.is-right-sidedock-open) .mod-root {
+  --frame-right-space: 0px;
+}
+
+body:not(.is-mobile) {
+  --hover-sidedock-width: 320px;
+  --hover-sidedock-delay: 160ms;
+  --hover-sidedock-trigger-area: 4px;
+}
+
+body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed.mod-left-split:hover + .mod-root div:is(.workspace-tab-header-container, .workspace-tab-header-container-inner),
+body:not(.is-mobile).hover-sidedock .mod-root:has(+ .mod-sidedock.is-sidedock-collapsed.mod-right-split:hover) div:is(.workspace-tab-header-container, .workspace-tab-header-container-inner),
+body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed div:is(.workspace-tab-header-container, .workspace-tab-header-container-inner),
+body:not(.is-mobile).hover-ribbon .workspace-ribbon.mod-left:hover ~ .mod-root div:is(.workspace-tab-header-container, .workspace-tab-header-container-inner) {
+  -webkit-app-region: no-drag;
+}
+
+body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display] {
+  display: flex !important;
+  position: absolute;
+  opacity: 0;
+  z-index: 11;
+  background-color: transparent;
+  width: var(--hover-sidedock-width) !important;
+}
+body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display] .workspace-tabs {
+  visibility: visible;
+}
+body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display].mod-left-split {
+  transform: translateX(calc(-1 * (var(--hover-sidedock-width) - var(--hover-sidedock-trigger-area))));
+}
+body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display].mod-right-split {
+  transform: translateX(calc(var(--hover-sidedock-width) - var(--hover-sidedock-trigger-area)));
+}
+body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display].mod-left-split, body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display].mod-left-split::before {
+  right: auto;
+  left: 0;
+}
+body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display].mod-right-split, body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display].mod-right-split::before {
+  right: 0;
+  left: auto;
+}
+body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display]::before {
+  position: absolute;
+  z-index: 0;
+  transition: var(--anim-duration-moderate);
+  inset-block: 0;
+  width: 150%;
+  content: "";
+  pointer-events: none;
+}
+body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display].mod-left-split::before {
+  background: linear-gradient(to right, var(--background-primary) 50%, transparent);
+}
+body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display].mod-right-split::before {
+  background: linear-gradient(to left, var(--background-primary) 50%, transparent);
+}
+body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display]:hover, body:not(.is-mobile).hover-sidedock.hover-ribbon .workspace-ribbon.mod-left.is-collapsed:hover + .mod-sidedock, body:not(.is-mobile).hover-sidedock:not(.hover-sidedock-active-off) > .app-container > .horizontal-main-container > .workspace > .mod-sidedock:has(> .workspace-tabs.mod-active) {
+  transition-delay: var(--hover-sidedock-delay);
+  transform: none;
+  opacity: 1;
+}
+body:not(.is-mobile).hover-sidedock .mod-sidedock.is-sidedock-collapsed[style*=display]:hover::before, body:not(.is-mobile).hover-sidedock.hover-ribbon .workspace-ribbon.mod-left.is-collapsed:hover + .mod-sidedock::before, body:not(.is-mobile).hover-sidedock:not(.hover-sidedock-active-off) > .app-container > .horizontal-main-container > .workspace > .mod-sidedock:has(> .workspace-tabs.mod-active)::before {
+  opacity: 1;
+}
+
+body:not(.is-mobile).hover-ribbon.show-ribbon .workspace-ribbon.mod-left {
+  position: absolute;
+  z-index: 12;
+  height: -webkit-fill-available;
+  opacity: 0;
+  transform: translateX(calc(-1 * var(--ribbon-width) + var(--hover-sidedock-trigger-area)));
+  background-color: transparent;
+}
+body:not(.is-mobile).hover-ribbon.show-ribbon .workspace-ribbon.mod-left:hover {
+  opacity: 1;
+  transform: none;
+}
+body:not(.is-mobile).hover-ribbon.show-ribbon .workspace-ribbon.mod-left:hover + .mod-sidedock {
+  padding-left: calc(var(--ribbon-width) - 8px);
+}
+body:not(.is-mobile).hover-ribbon.show-ribbon .workspace-ribbon.mod-left.is-collapsed:hover,
+body:not(.is-mobile).hover-ribbon.show-ribbon .workspace-ribbon.mod-left.is-collapsed:hover + .mod-sidedock {
+  transition-delay: var(--hover-sidedock-delay) !important;
+}
+body:not(.is-mobile).hover-ribbon.show-ribbon.hover-sidedock .workspace-ribbon.mod-left.is-collapsed {
+  z-index: 13;
+}
+body:not(.is-mobile).hover-ribbon.show-ribbon.mod-macos:not(.is-fullscreen).is-hidden-frameless .mod-sidedock.mod-left-split .mod-top-left-space .workspace-tab-header-container {
+  transition-timing-function: ease;
+}
+body:not(.is-mobile).hover-ribbon.show-ribbon.mod-macos:not(.is-fullscreen).is-hidden-frameless .workspace-ribbon.mod-left:not(.is-collapsed):hover ~ .mod-sidedock.mod-left-split .mod-top-left-space .workspace-tab-header-container {
+  padding-left: 52px;
+}
+body:not(.is-mobile).hover-ribbon.show-ribbon.mod-macos:not(.is-fullscreen).is-hidden-frameless .workspace-ribbon.mod-left:not(.is-collapsed):not(:hover) ~ .mod-sidedock.mod-left-split .mod-top-left-space .workspace-tab-header-container,
+body:not(.is-mobile).hover-ribbon.show-ribbon.mod-macos:not(.is-fullscreen).is-hidden-frameless .workspace-ribbon.mod-left.is-collapsed ~ .mod-root > div:first-of-type .workspace-tab-header-container {
+  padding-left: 88px;
+}
+
+body.mod-windows:not(.adaptive-mode-off) .nav-files-container > div {
+  --nav-item-background-active: var(--background-modifier-hover);
+  --nav-item-color-active: var(--nav-item-color);
+}
+body.mod-windows:not(.adaptive-mode-off) .nav-files-container > div .tree-item-self.is-active::before {
+  position: absolute;
+  top: 8px;
+  bottom: 8px;
+  left: 0;
+  margin-left: 0;
+  border-radius: var(--button-radius);
+  background-color: var(--interactive-accent);
+  width: 4px;
+  height: auto;
+  content: "";
+}
+
+body.is-android:not(.adaptive-mode-off) .nav-files-container > div {
+  --nav-item-background-active: var(--background-primary);
+  --nav-item-background-selected: var(--background-primary);
+  --nav-item-color-active: var(--text-normal);
+}
+
+body:is(.mod-macos, .adaptive-mode-off):not(.is-mobile) .nav-files-container > div {
+  --nav-item-background-hover: transparent;
+  --nav-item-background-active: var(--background-modifier-hover);
+  --nav-item-color: var(--text-normal);
+  --nav-item-color-hover: var(--text-normal);
+  --nav-item-color-active: var(--text-accent);
+}
+
+/*
+Adwaita
+GNOME Project
+https://gitlab.gnome.org/GNOME/libadwaita/
+*/
+body.mod-linux:not(.is-android):not(.adaptive-mode-off) {
+  --background-modifier-border: color-mix(in srgb, var(--background-secondary), var(--text-normal) 15%);
+  --interactive-normal: color-mix(in srgb, var(--background-secondary), var(--text-normal) 10%);
+  --interactive-hover: color-mix(in srgb, var(--background-secondary), var(--text-normal) 15%);
+  --menu-border-color: color-mix(in srgb, var(--background-secondary), var(--text-normal) 10%);
+}
+
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).theme-light {
+  --color-red-rgb: 237, 51, 59;
+  --color-orange-rgb: 255, 120, 0;
+  --color-yellow-rgb: 246, 211, 45;
+  --color-green-rgb: 46, 194, 126;
+  --color-cyan-rgb: 35, 164, 173;
+  --color-blue-rgb: 98, 160, 234;
+  --color-purple-rgb: 192, 97, 203;
+  --color-pink-rgb: 224, 97, 178;
+  --color-base-00: #ffffff;
+  --color-base-05: #fdfdfc;
+  --color-base-10: #fbfafa;
+  --color-base-20: #f6f5f4;
+  --color-base-25: #eeedeb;
+  --color-base-30: #e6e5e3;
+  --color-base-35: #deddda;
+  --color-base-40: #c0bfbc;
+  --color-base-50: #9a9996;
+  --color-base-60: #77767b;
+  --color-base-70: #5e5c64;
+  --color-base-100: #000000;
+  --mono-rgb-adwaita: 0, 0, 6;
+  --background-primary: #fff;
+  --background-primary-alt: #fff;
+  --background-secondary: #ebebed;
+  --background-secondary-alt: #f3f3f5;
+  --text-normal: #333338;
+  --text-muted: #5c5c60;
+  --text-faint: #858587;
+  --menu-background: #fff;
+  --modal-background: #fafafb;
+  --code-background: var(--background-secondary-alt);
+  --blockquote-background-color: var(--background-secondary-alt);
+  --embed-background-color: var(--background-secondary-alt);
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).theme-light:not(.is-focused) {
+  --background-secondary: #f2f2f4;
+}
+
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).theme-dark {
+  --color-red-rgb: 224, 27, 36;
+  --color-orange-rgb: 230, 97, 0;
+  --color-yellow-rgb: 245, 194, 17;
+  --color-green-rgb: 38, 162, 105;
+  --color-cyan-rgb: 33, 144, 164;
+  --color-blue-rgb: 53, 132, 228;
+  --color-purple-rgb: 145, 65, 172;
+  --color-pink-rgb: 213, 97, 170;
+  --color-base-00: #000000;
+  --color-base-05: #121019;
+  --color-base-10: #241f31;
+  --color-base-20: #3d3846;
+  --color-base-25: #4e4a55;
+  --color-base-30: #5e5c64;
+  --color-base-35: #6b6970;
+  --color-base-40: #77767b;
+  --color-base-50: #9a9996;
+  --color-base-60: #c0bfbc;
+  --color-base-70: #e6e5e3;
+  --color-base-100: #ffffff;
+  --mono-rgb-adwaita: 255, 255, 255;
+  --background-primary: #1d1d20;
+  --background-primary-alt: #2e2e32;
+  --background-secondary: #2e2e32;
+  --background-secondary-alt: #28282c;
+  --text-normal: #fff;
+  --text-muted: #d2d2d2;
+  --text-faint: #99999b;
+  --menu-background: #36363a;
+  --modal-background: #222226;
+}
+body.mod-linux:not(.is-android):not(.adaptive-mode-off).theme-dark:not(.is-focused) {
+  --background-secondary: #28282c;
+}
+
+/*
+Cupertino
+https://developer.apple.com/design/human-interface-guidelines/color
+*/
+body:is(.mod-macos, .adaptive-mode-off).theme-light {
+  --color-red-rgb: 255, 56, 60;
+  --color-orange-rgb: 255, 141, 40;
+  --color-yellow-rgb: 255, 204, 0;
+  --color-green-rgb: 52, 199, 89;
+  --color-cyan-rgb: 0, 192, 232;
+  --color-blue-rgb: 0, 136, 255;
+  --color-purple-rgb: 203, 48, 224;
+  --color-pink-rgb: 255, 45, 85;
+}
+
+body:is(.mod-macos, .adaptive-mode-off).theme-light:not(.is-mobile) {
+  --background-primary: #fff;
+  --background-primary-alt: color-mix(in srgb, var(--background-primary), black 3%);
+  --background-secondary: color-mix(in srgb, var(--background-primary), black 5%);
+  --background-secondary-alt: color-mix(in srgb, var(--background-primary), black 8%);
+  --interactive-normal: hsl(0 0% 0% / 5%);
+  --interactive-hover: hsl(0 0% 0% / 5%);
+  --text-normal: #262626;
+  --text-muted: #737373;
+  --text-faint: #bfbfbf;
+}
+
+body:is(.mod-macos, .adaptive-mode-off).theme-light.is-mobile {
+  --background-primary: #fff;
+  --background-primary-alt: #f2f2f7;
+  --background-secondary: #f2f2f7;
+  --background-secondary-alt: #fff;
+  --interactive-normal: rgba(118, 118, 128, 12%);
+  --interactive-hover: rgba(120, 120, 120, 20%);
+  --text-normal: #000;
+  --text-muted: #8a8a8e;
+  --text-faint: #c4c4c7;
+}
+
+body:is(.mod-macos, .adaptive-mode-off).theme-dark {
+  --color-red-rgb: 255, 66, 69;
+  --color-orange-rgb: 255, 146, 48;
+  --color-yellow-rgb: 255, 214, 0;
+  --color-green-rgb: 48, 209, 88;
+  --color-cyan-rgb: 60, 211, 254;
+  --color-blue-rgb: 0, 145, 255;
+  --color-purple-rgb: 107, 52, 242;
+  --color-pink-rgb: 255, 55, 95;
+}
+
+body:is(.mod-macos, .adaptive-mode-off).theme-dark:not(.is-mobile) {
+  --background-primary: #1e1e1e;
+  --background-primary-alt: color-mix(in srgb, var(--background-primary), white 3%);
+  --background-secondary: color-mix(in srgb, var(--background-primary), white 5%);
+  --background-secondary-alt: color-mix(in srgb, var(--background-primary), white 8%);
+  --interactive-normal: hsl(0 0% 100% / 5%);
+  --interactive-hover: hsl(0 0% 100% / 5%);
+  --text-normal: #dddddd;
+  --text-muted: #9a9a9a;
+  --text-faint: #565656;
+}
+
+body:is(.mod-macos, .adaptive-mode-off).theme-dark.is-mobile {
+  --background-primary: #000;
+  --background-primary-alt: #1c1c1e;
+  --background-secondary: #1c1c1e;
+  --background-secondary-alt: #2c2c2e;
+  --interactive-normal: rgba(118, 118, 128, 24%);
+  --interactive-hover: rgba(120, 120, 120, 36%);
+  --text-normal: #fff;
+  --text-muted: #8d8d93;
+  --text-faint: #47474a;
+}
+
+/*
+Material Design
+https://m3.material.io/styles/color/system/overview
+*/
+body.is-android:not(.adaptive-mode-off).material-color .modal:where(.mod-settings) .vertical-tab-nav-item .vertical-tab-nav-item-icon {
+  --setting-nav-icon-background: var(--neutral-60);
+  background-color: var(--setting-nav-icon-background);
+}
+body.is-android:not(.adaptive-mode-off).material-color {
+  /* Secondary Palette (chroma 16 in HCT ≈ 0.07 in OKLCH) */
+  --secondary-0: oklch(from hsl(var(--color-accent-hsl)) 0 0.07 h);
+  --secondary-10: oklch(from hsl(var(--color-accent-hsl)) 0.17 0.07 h);
+  --secondary-20: oklch(from hsl(var(--color-accent-hsl)) 0.29 0.07 h);
+  --secondary-30: oklch(from hsl(var(--color-accent-hsl)) 0.41 0.07 h);
+  --secondary-40: oklch(from hsl(var(--color-accent-hsl)) 0.53 0.07 h);
+  --secondary-50: oklch(from hsl(var(--color-accent-hsl)) 0.64 0.07 h);
+  --secondary-60: oklch(from hsl(var(--color-accent-hsl)) 0.73 0.07 h);
+  --secondary-70: oklch(from hsl(var(--color-accent-hsl)) 0.81 0.07 h);
+  --secondary-80: oklch(from hsl(var(--color-accent-hsl)) 0.87 0.07 h);
+  --secondary-90: oklch(from hsl(var(--color-accent-hsl)) 0.93 0.07 h);
+  --secondary-95: oklch(from hsl(var(--color-accent-hsl)) 0.96 0.06 h);
+  --secondary-99: oklch(from hsl(var(--color-accent-hsl)) 0.99 0.04 h);
+  --secondary-100: oklch(from hsl(var(--color-accent-hsl)) 1 0.02 h);
+  --tertiary-0: oklch(from hsl(var(--color-accent-hsl)) 0 0.1 calc(h + 60));
+  --tertiary-10: oklch(from hsl(var(--color-accent-hsl)) 0.17 0.1 calc(h + 60));
+  --tertiary-20: oklch(from hsl(var(--color-accent-hsl)) 0.29 0.1 calc(h + 60));
+  --tertiary-30: oklch(from hsl(var(--color-accent-hsl)) 0.41 0.1 calc(h + 60));
+  --tertiary-40: oklch(from hsl(var(--color-accent-hsl)) 0.53 0.1 calc(h + 60));
+  --tertiary-50: oklch(from hsl(var(--color-accent-hsl)) 0.64 0.1 calc(h + 60));
+  --tertiary-60: oklch(from hsl(var(--color-accent-hsl)) 0.73 0.1 calc(h + 60));
+  --tertiary-70: oklch(from hsl(var(--color-accent-hsl)) 0.81 0.1 calc(h + 60));
+  --tertiary-80: oklch(from hsl(var(--color-accent-hsl)) 0.87 0.1 calc(h + 60));
+  --tertiary-90: oklch(from hsl(var(--color-accent-hsl)) 0.93 0.1 calc(h + 60));
+  --tertiary-95: oklch(from hsl(var(--color-accent-hsl)) 0.96 0.06 calc(h + 60));
+  --tertiary-99: oklch(from hsl(var(--color-accent-hsl)) 0.99 0.04 calc(h + 60));
+  --tertiary-100: oklch(from hsl(var(--color-accent-hsl)) 1 0.02 calc(h + 60));
+  --neutral-0: oklch(from hsl(var(--color-accent-hsl)) 0 0.035 h);
+  --neutral-4: oklch(from hsl(var(--color-accent-hsl)) 0.06 0.035 h);
+  --neutral-6: oklch(from hsl(var(--color-accent-hsl)) 0.1 0.035 h);
+  --neutral-10: oklch(from hsl(var(--color-accent-hsl)) 0.17 0.035 h);
+  --neutral-12: oklch(from hsl(var(--color-accent-hsl)) 0.19 0.035 h);
+  --neutral-17: oklch(from hsl(var(--color-accent-hsl)) 0.25 0.035 h);
+  --neutral-20: oklch(from hsl(var(--color-accent-hsl)) 0.29 0.035 h);
+  --neutral-22: oklch(from hsl(var(--color-accent-hsl)) 0.31 0.035 h);
+  --neutral-24: oklch(from hsl(var(--color-accent-hsl)) 0.33 0.035 h);
+  --neutral-30: oklch(from hsl(var(--color-accent-hsl)) 0.41 0.035 h);
+  --neutral-40: oklch(from hsl(var(--color-accent-hsl)) 0.53 0.035 h);
+  --neutral-50: oklch(from hsl(var(--color-accent-hsl)) 0.64 0.035 h);
+  --neutral-60: oklch(from hsl(var(--color-accent-hsl)) 0.73 0.035 h);
+  --neutral-70: oklch(from hsl(var(--color-accent-hsl)) 0.81 0.035 h);
+  --neutral-80: oklch(from hsl(var(--color-accent-hsl)) 0.87 0.035 h);
+  --neutral-87: oklch(from hsl(var(--color-accent-hsl)) 0.89 0.035 h);
+  --neutral-90: oklch(from hsl(var(--color-accent-hsl)) 0.93 0.035 h);
+  --neutral-92: oklch(from hsl(var(--color-accent-hsl)) 0.94 0.035 h);
+  --neutral-94: oklch(from hsl(var(--color-accent-hsl)) 0.95 0.035 h);
+  --neutral-95: oklch(from hsl(var(--color-accent-hsl)) 0.96 0.035 h);
+  --neutral-96: oklch(from hsl(var(--color-accent-hsl)) 0.97 0.035 h);
+  --neutral-98: oklch(from hsl(var(--color-accent-hsl)) 0.98 0.026 h);
+  --neutral-99: oklch(from hsl(var(--color-accent-hsl)) 0.99 0.016 h);
+  --neutral-100: oklch(from hsl(var(--color-accent-hsl)) 1 0.012 h);
+  --neutral-variant-0: oklch(from hsl(var(--color-accent-hsl)) 0 0.04 h);
+  --neutral-variant-10: oklch(from hsl(var(--color-accent-hsl)) 0.17 0.037 h);
+  --neutral-variant-20: oklch(from hsl(var(--color-accent-hsl)) 0.29 0.037 h);
+  --neutral-variant-30: oklch(from hsl(var(--color-accent-hsl)) 0.41 0.037 h);
+  --neutral-variant-40: oklch(from hsl(var(--color-accent-hsl)) 0.53 0.037 h);
+  --neutral-variant-50: oklch(from hsl(var(--color-accent-hsl)) 0.64 0.037 h);
+  --neutral-variant-60: oklch(from hsl(var(--color-accent-hsl)) 0.73 0.037 h);
+  --neutral-variant-70: oklch(from hsl(var(--color-accent-hsl)) 0.81 0.037 h);
+  --neutral-variant-80: oklch(from hsl(var(--color-accent-hsl)) 0.87 0.037 h);
+  --neutral-variant-90: oklch(from hsl(var(--color-accent-hsl)) 0.93 0.037 h);
+  --neutral-variant-95: oklch(from hsl(var(--color-accent-hsl)) 0.96 0.026 h);
+  --neutral-variant-99: oklch(from hsl(var(--color-accent-hsl)) 0.99 0.02 h);
+  --neutral-variant-100: oklch(from hsl(var(--color-accent-hsl)) 1 0.01 h);
+}
+
+body.is-android:not(.adaptive-mode-off).theme-light.material-color .checkbox-container {
+  --interactive-accent: var(--color-base-50);
+  --text-muted: var(--neutral-30);
+}
+body.is-android:not(.adaptive-mode-off).theme-light.material-color.is-phone .mobile-navbar {
+  background-color: var(--secondary-95) !important;
+}
+body.is-android:not(.adaptive-mode-off).theme-light.material-color.is-phone .mobile-navbar-action {
+  --icon-color: var(--secondary-30);
+}
+body.is-android:not(.adaptive-mode-off).theme-light.material-color.is-phone:not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2) {
+  background-color: var(--tertiary-95);
+  color: var(--tertiary-30);
+}
+body.is-android:not(.adaptive-mode-off).theme-light.material-color {
+  --color-red: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-red-rgb))) max(l, 0.82) min(c, 0.12) h);
+  --color-orange: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-orange-rgb))) max(l, 0.82) min(c, 0.12) h);
+  --color-yellow: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-yellow-rgb))) max(l, 0.82) min(c, 0.12) h);
+  --color-green: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-green-rgb))) max(l, 0.82) min(c, 0.12) h);
+  --color-cyan: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-cyan-rgb))) max(l, 0.82) min(c, 0.12) h);
+  --color-blue: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-blue-rgb))) max(l, 0.82) min(c, 0.12) h);
+  --color-purple: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-purple-rgb))) max(l, 0.82) min(c, 0.12) h);
+  --color-pink: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-pink-rgb))) max(l, 0.82) min(c, 0.12) h);
+  --color-base-00: oklch(from hsl(var(--color-accent-hsl)) 1 0.04 h);
+  --color-base-05: oklch(from hsl(var(--color-accent-hsl)) 0.99 0.08 h);
+  --color-base-10: oklch(from hsl(var(--color-accent-hsl)) 0.96 0.12 h);
+  --color-base-20: oklch(from hsl(var(--color-accent-hsl)) 0.93 0.14 h);
+  --color-base-25: oklch(from hsl(var(--color-accent-hsl)) 0.87 0.14 h);
+  --color-base-30: oklch(from hsl(var(--color-accent-hsl)) 0.81 0.14 h);
+  --color-base-35: oklch(from hsl(var(--color-accent-hsl)) 0.73 0.14 h);
+  --color-base-40: oklch(from hsl(var(--color-accent-hsl)) 0.64 0.14 h);
+  --color-base-50: oklch(from hsl(var(--color-accent-hsl)) 0.53 0.14 h);
+  --color-base-60: oklch(from hsl(var(--color-accent-hsl)) 0.41 0.14 h);
+  --color-base-70: oklch(from hsl(var(--color-accent-hsl)) 0.29 0.14 h);
+  --color-base-100: oklch(from hsl(var(--color-accent-hsl)) 0.17 0.14 h);
+  --text-muted: var(--neutral-40);
+  --text-faint: var(--neutral-60);
+  --text-accent: var(--color-base-50);
+  --background-primary: var(--neutral-98);
+  --background-primary-alt: var(--neutral-100);
+  --background-secondary: var(--neutral-94);
+  --background-secondary-alt: var(--neutral-96);
+  --interactive-normal: var(--background-primary);
+  --interactive-hover: var(--background-secondary);
+  --interactive-accent: var(--tertiary-40);
+  --interactive-accent-hover: oklch(from var(--tertiary-40) calc(l + 0.05) c h);
+  --text-on-accent: var(--tertiary-100);
+  --text-on-accent-inverted: var(--tertiary-100);
+  --background-modifier-form-field: var(--neutral-90);
+  --background-modifier-border: var(--neutral-variant-80);
+  --background-modifier-border-hover: var(--neutral-variant-70);
+  --background-modifier-border-focus: var(--neutral-variant-50);
+  --tag-background: var(--secondary-95);
+  --tag-color: var(--secondary-30);
+}
+
+body.is-android:not(.adaptive-mode-off).theme-dark.material-color .checkbox-container {
+  --interactive-accent: var(--color-base-30);
+  --text-muted: var(--neutral-60);
+}
+body.is-android:not(.adaptive-mode-off).theme-dark.material-color.is-phone .mobile-navbar {
+  background-color: var(--secondary-20) !important;
+}
+body.is-android:not(.adaptive-mode-off).theme-dark.material-color.is-phone .mobile-navbar-action {
+  --icon-color: var(--secondary-80);
+}
+body.is-android:not(.adaptive-mode-off).theme-dark.material-color.is-phone:not(.mode-switcher-off) .mod-root .workspace-leaf-content[data-type=markdown] .view-actions button:nth-last-child(2) {
+  background-color: var(--tertiary-20);
+  color: var(--tertiary-80);
+}
+body.is-android:not(.adaptive-mode-off).theme-dark.material-color {
+  --color-accent: oklch(from hsl(var(--color-accent-hsl)) min(l, 0.82) min(c, 0.12) h);
+  --color-accent-1: oklch(from hsl(calc(var(--accent-h) - 3), calc(var(--accent-s) * 1.02), calc(var(--accent-l) * 1.15)) min(l, 0.82) min(c, 0.12) h);
+  --color-accent-2: oklch(from hsl(calc(var(--accent-h) - 5), calc(var(--accent-s) * 1.05), calc(var(--accent-l) * 1.29)) min(l, 0.82) min(c, 0.12) h);
+  --color-red: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-red-rgb))) min(l, 0.82) min(c, 0.12) h);
+  --color-orange: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-orange-rgb))) min(l, 0.82) min(c, 0.12) h);
+  --color-yellow: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-yellow-rgb))) min(l, 0.82) min(c, 0.12) h);
+  --color-green: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-green-rgb))) min(l, 0.82) min(c, 0.12) h);
+  --color-cyan: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-cyan-rgb))) min(l, 0.82) min(c, 0.12) h);
+  --color-blue: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-blue-rgb))) min(l, 0.82) min(c, 0.12) h);
+  --color-purple: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-purple-rgb))) min(l, 0.82) min(c, 0.12) h);
+  --color-pink: oklch(from color-mix(in oklch, hsl(var(--color-accent-hsl)) 10%, rgb(var(--color-pink-rgb))) min(l, 0.82) min(c, 0.12) h);
+  --color-base-00: oklch(from hsl(var(--color-accent-hsl)) 0 0.11 h);
+  --color-base-05: oklch(from hsl(var(--color-accent-hsl)) 0.17 0.11 h);
+  --color-base-10: oklch(from hsl(var(--color-accent-hsl)) 0.29 0.11 h);
+  --color-base-20: oklch(from hsl(var(--color-accent-hsl)) 0.41 0.11 h);
+  --color-base-25: oklch(from hsl(var(--color-accent-hsl)) 0.53 0.11 h);
+  --color-base-30: oklch(from hsl(var(--color-accent-hsl)) 0.64 0.11 h);
+  --color-base-35: oklch(from hsl(var(--color-accent-hsl)) 0.73 0.11 h);
+  --color-base-40: oklch(from hsl(var(--color-accent-hsl)) 0.81 0.11 h);
+  --color-base-50: oklch(from hsl(var(--color-accent-hsl)) 0.87 0.11 h);
+  --color-base-60: oklch(from hsl(var(--color-accent-hsl)) 0.93 0.11 h);
+  --color-base-70: oklch(from hsl(var(--color-accent-hsl)) 0.96 0.09 h);
+  --color-base-100: oklch(from hsl(var(--color-accent-hsl)) 0.99 0.06 h);
+  --text-muted: var(--neutral-60);
+  --text-faint: var(--neutral-40);
+  --background-primary: var(--neutral-10);
+  --background-primary-alt: var(--neutral-17);
+  --background-secondary: var(--neutral-17);
+  --background-secondary-alt: var(--neutral-20);
+  --interactive-normal: var(--background-primary);
+  --interactive-hover: var(--background-secondary);
+  --interactive-accent: var(--tertiary-60);
+  --interactive-accent-hover: oklch(from var(--tertiary-80) calc(l + 0.05) c h);
+  --text-on-accent: var(--tertiary-20);
+  --text-on-accent-inverted: var(--tertiary-20);
+  --background-modifier-form-field: var(--neutral-22);
+  --background-modifier-border: var(--neutral-variant-30);
+  --background-modifier-border-hover: var(--neutral-variant-40);
+  --background-modifier-border-focus: var(--neutral-variant-60);
+  --tag-background: var(--secondary-20);
+  --tag-color: var(--secondary-80);
+}

--- a/theme.css
+++ b/theme.css
@@ -2222,7 +2222,7 @@ body.minimal-theme .workspace::before {
 # 主文案为中文，保证任意语言回退时仍为中文；英文界面通过 Style Settings 的 title.en / description.en 读取。
 # Primary strings are Chinese so UI stays Chinese even when title.zh does not match Obsidian’s language code.
 
-name: 库比蒂诺（Cupertino）
+name: Cupertino · 库比蒂诺
 id: cupertino
 settings:
     -
@@ -2371,13 +2371,13 @@ settings:
         default: image-align-center
         options:
             -
-                label: 左
+                label: Left / 左
                 value: image-align-left
             -
-                label: 居中
+                label: Center / 居中
                 value: image-align-center
             -
-                label: 右
+                label: Right / 右
                 value: image-align-right
     -
         id: clean-link-off

--- a/theme.css
+++ b/theme.css
@@ -2219,211 +2219,214 @@ body.minimal-theme .workspace::before {
 /*!
 /* @settings
 
-name: Cupertino · 库比蒂诺
+# 主文案为中文，保证任意语言回退时仍为中文；英文界面通过 Style Settings 的 title.en / description.en 读取。
+# Primary strings are Chinese so UI stays Chinese even when title.zh does not match Obsidian’s language code.
+
+name: 库比蒂诺（Cupertino）
 id: cupertino
 settings:
     -
         id: cupertino-desc
-        description: "Cupertino offers simplified, native-style UI. For granular controls, try [Baseline](obsidian://show-theme?name=Baseline)."
-        description.zh: "Cupertino 提供简洁的原生风格界面。若需要更细粒度选项，可尝试 [Baseline](obsidian://show-theme?name=Baseline)。"
+        description: "Cupertino 提供简洁的原生风格界面。若需要更细粒度选项，可尝试 [Baseline](obsidian://show-theme?name=Baseline)。"
+        description.en: "Cupertino offers simplified, native-style UI. For granular controls, try [Baseline](obsidian://show-theme?name=Baseline)."
         type: info-text
         markdown: true
     -
         id: colorful-frame
-        title: Tinted sidebar
-        title.zh: 侧边栏着色
-        description: Apply a subtle tint to the sidebar based on accent color.
-        description.zh: 根据强调色为侧边栏施加淡淡着色。
+        title: 侧边栏着色
+        title.en: Tinted sidebar
+        description: 根据强调色为侧边栏施加淡淡着色。
+        description.en: Apply a subtle tint to the sidebar based on accent color.
         type: class-toggle
     -
         id: material-color
-        title: Dynamic color
-        title.zh: 动态配色
-        description: Apply dynamic theming based on accent color.
-        description.zh: 根据强调色应用动态主题配色。
+        title: 动态配色
+        title.en: Dynamic color
+        description: 根据强调色应用动态主题配色。
+        description.en: Apply dynamic theming based on accent color.
         type: class-toggle
     -
         id: adaptive-mode-off
-        title: Disable adaptive mode
-        title.zh: 关闭自适应模式
-        description: Prevent automatic styling based on operating system.
-        description.zh: 停止根据操作系统自动调整样式。
+        title: 关闭自适应模式
+        title.en: Disable adaptive mode
+        description: 停止根据操作系统自动调整样式。
+        description.en: Prevent automatic styling based on operating system.
         type: class-toggle
     -
         id: tab-floating
-        title: Disable centered tabs
-        title.zh: 取消标签居中
-        description: Use left-aligned tabs instead of centered tabs in the tab bar.
-        description.zh: 将标签栏改为传统左侧对齐，而非居中排列。
+        title: 取消标签居中
+        title.en: Disable centered tabs
+        description: 将标签栏改为传统左侧对齐，而非居中排列。
+        description.en: Use left-aligned tabs instead of centered tabs in the tab bar.
         type: class-toggle
     -
         id: desktop-header
-        title: Desktop
-        title.zh: 桌面端
+        title: 桌面端
+        title.en: Desktop
         type: heading
         level: 1
         collapsed: true
     -
         id: hover-ribbon
-        title: Hover ribbon
-        title.zh: 悬停显示功能区
-        description: Reveal ribbon by hovering over left window edge.
-        description.zh: 鼠标靠近左侧窗口边缘时显示功能区（Ribbon）。
+        title: 悬停显示功能区
+        title.en: Hover ribbon
+        description: 鼠标靠近左侧窗口边缘时显示功能区（Ribbon）。
+        description.en: Reveal ribbon by hovering over left window edge.
         type: class-toggle
         addCommand: true
     -
         id: hover-sidedock
-        title: Hover sidebar
-        title.zh: 悬停显示侧边栏
-        description: Reveal collapsed sidebars by hovering over window edges.
-        description.zh: 鼠标靠近窗口边缘时展开已收起的侧边栏。
+        title: 悬停显示侧边栏
+        title.en: Hover sidebar
+        description: 鼠标靠近窗口边缘时展开已收起的侧边栏。
+        description.en: Reveal collapsed sidebars by hovering over window edges.
         type: class-toggle
         addCommand: true
     -
         id: focus-view
-        title: Focus view
-        title.zh: 专注视图
-        description: Hide tabs and table title bar when both sidebars are collapsed.
-        description.zh: 当两侧栏均收起时隐藏标签与表格标题栏。
+        title: 专注视图
+        title.en: Focus view
+        description: 当两侧栏均收起时隐藏标签与表格标题栏。
+        description.en: Hide tabs and table title bar when both sidebars are collapsed.
         type: class-toggle
         addCommand: true
     -
         id: nav-action-center
-        title: Disable compact panel actions
-        title.zh: 取消紧凑面板操作区
-        description: Use default alignment for narrow sidebar header actions.
-        description.zh: 窄侧边栏顶栏操作按钮恢复默认对齐，不再居中紧凑排列。
+        title: 取消紧凑面板操作区
+        title.en: Disable compact panel actions
+        description: 窄侧边栏顶栏操作按钮恢复默认对齐，不再居中紧凑排列。
+        description.en: Use default alignment for narrow sidebar header actions.
         type: class-toggle
     -
         id: tab-icon
-        title: Disable compact sidebar tabs
-        title.zh: 取消紧凑侧边栏标签
-        description: Keep full sidebar tab labels instead of icon-only compact tabs.
-        description.zh: 保留侧边栏标签的完整文字，而非仅图标的紧凑标签。
+        title: 取消紧凑侧边栏标签
+        title.en: Disable compact sidebar tabs
+        description: 保留侧边栏标签的完整文字，而非仅图标的紧凑标签。
+        description.en: Keep full sidebar tab labels instead of icon-only compact tabs.
         type: class-toggle
     -
         id: status-bar-baseline
-        title: Disable compact status bar
-        title.zh: 取消紧凑状态栏
-        description: Use a taller default-style status bar instead of the compact row.
-        description.zh: 使用更高的默认风格状态栏，而非单行紧凑状态栏。
+        title: 取消紧凑状态栏
+        title.en: Disable compact status bar
+        description: 使用更高的默认风格状态栏，而非单行紧凑状态栏。
+        description.en: Use a taller default-style status bar instead of the compact row.
         type: class-toggle
     -
         id: zoom-off
-        title: Disable media zoom
-        title.zh: 关闭媒体缩放
-        description: Disable click-to-zoom behavior on images and media.
-        description.zh: 关闭图片与媒体的点击放大效果。
+        title: 关闭媒体缩放
+        title.en: Disable media zoom
+        description: 关闭图片与媒体的点击放大效果。
+        description.en: Disable click-to-zoom behavior on images and media.
         type: class-toggle
     -
         id: editor
-        title: Editor
-        title.zh: 编辑器
+        title: 编辑器
+        title.en: Editor
         type: heading
         level: 1
         collapsed: true
     -
         id: active-line-off
-        title: Disable active line highlight
-        title.zh: 关闭当前行高亮
-        description: Turn off background highlight for the active line in the editor.
-        description.zh: 关闭编辑器中当前行的背景高亮。
+        title: 关闭当前行高亮
+        title.en: Disable active line highlight
+        description: 关闭编辑器中当前行的背景高亮。
+        description.en: Turn off background highlight for the active line in the editor.
         type: class-toggle
     -
         id: banner-off
-        title: Disable banner
-        title.zh: 关闭 Banner
-        description: Disable styling for banner areas used by banner-style plugins.
-        description.zh: 关闭 Banner 类插件常用的顶部横幅区域样式。
+        title: 关闭 Banner
+        title.en: Disable banner
+        description: 关闭 Banner 类插件常用的顶部横幅区域样式。
+        description.en: Disable styling for banner areas used by banner-style plugins.
         type: class-toggle
     -
         id: block-width-off
-        title: Disable block width
-        title.zh: 关闭块级宽度
-        description: Do not widen blocks beyond the default reading column.
-        description.zh: 不将块元素加宽到默认阅读栏之外。
+        title: 关闭块级宽度
+        title.en: Disable block width
+        description: 不将块元素加宽到默认阅读栏之外。
+        description.en: Do not widen blocks beyond the default reading column.
         type: class-toggle
     -
         id: font-variant-off
-        title: Disable font variants
-        title.zh: 关闭字体变体
-        description: Disable OpenType stylistic alternates for interface fonts.
-        description.zh: 关闭界面字体的 OpenType 变体与替代字形特性。
+        title: 关闭字体变体
+        title.en: Disable font variants
+        description: 关闭界面字体的 OpenType 变体与替代字形特性。
+        description.en: Disable OpenType stylistic alternates for interface fonts.
         type: class-toggle
     -
         id: full-width-media-off
-        title: Disable full-width elements
-        title.zh: 关闭全宽元素
-        description: Keep embeds and wide elements within the main text column.
-        description.zh: 将嵌入与全宽元素限制在正文主栏宽度内。
+        title: 关闭全宽元素
+        title.en: Disable full-width elements
+        description: 将嵌入与全宽元素限制在正文主栏宽度内。
+        description.en: Keep embeds and wide elements within the main text column.
         type: class-toggle
     -
         id: image-align
-        title: Image alignment
-        title.zh: 图片对齐
-        description: Set default image alignment in editor and reading view.
-        description.zh: 设置编辑与阅读模式下的默认图片对齐方式。
+        title: 图片对齐
+        title.en: Image alignment
+        description: 设置编辑与阅读模式下的默认图片对齐方式。
+        description.en: Set default image alignment in editor and reading view.
         type: class-select
         allowEmpty: false
         default: image-align-center
         options:
             -
-                label: Left / 左
+                label: 左
                 value: image-align-left
             -
-                label: Center / 居中
+                label: 居中
                 value: image-align-center
             -
-                label: Right / 右
+                label: 右
                 value: image-align-right
     -
         id: clean-link-off
-        title: Underlined links
-        title.zh: 链接始终下划线
-        description: Always underline links for improved visibility.
-        description.zh: 始终为链接添加下划线以提高辨识度。
+        title: 链接始终下划线
+        title.en: Underlined links
+        description: 始终为链接添加下划线以提高辨识度。
+        description.en: Always underline links for improved visibility.
         type: class-toggle
     -
         id: mode-switcher-off
-        title: Disable quick mode switcher
-        title.zh: 关闭快速配色切换
-        description: Hide the quick light/dark switch in the status bar area.
-        description.zh: 隐藏状态栏区域的快速明暗配色切换入口。
+        title: 关闭快速配色切换
+        title.en: Disable quick mode switcher
+        description: 隐藏状态栏区域的快速明暗配色切换入口。
+        description.en: Hide the quick light/dark switch in the status bar area.
         type: class-toggle
     -
         id: accessibility
-        title: Accessibility
-        title.zh: 辅助功能
+        title: 辅助功能
+        title.en: Accessibility
         type: heading
         level: 1
         collapsed: true
     -
         id: reduce-contrast-change
-        title: Reduce contrast change
-        title.zh: 减弱失焦对比变化
-        description: Minimize contrast shifts when window loses focus.
-        description.zh: 减轻窗口失焦时的对比度变化。
+        title: 减弱失焦对比变化
+        title.en: Reduce contrast change
+        description: 减轻窗口失焦时的对比度变化。
+        description.en: Minimize contrast shifts when window loses focus.
         type: class-toggle
     -
         id: reduce-motion
-        title: Reduce motion
-        title.zh: 减少动态效果
-        description: Minimize animation effects.
-        description.zh: 尽量减少动画与过渡效果。
+        title: 减少动态效果
+        title.en: Reduce motion
+        description: 尽量减少动画与过渡效果。
+        description.en: Minimize animation effects.
         type: class-toggle
     -
         id: dynamic-type-off
-        title: Standard font size
-        title.zh: 固定界面字号层级
-        description: Disable operating system-based dynamic font sizes.
-        description.zh: 关闭随系统「动态字体」调整的界面字号层级。
+        title: 固定界面字号层级
+        title.en: Standard font size
+        description: 关闭随系统「动态字体」调整的界面字号层级。
+        description.en: Disable operating system-based dynamic font sizes.
         type: class-toggle
     -
         id: font-ui-modifier
-        title: Interface font size
-        title.zh: 界面字号微调
-        description: Fine-tune interface text size.
-        description.zh: 细调界面文字大小。
+        title: 界面字号微调
+        title.en: Interface font size
+        description: 细调界面文字大小。
+        description.en: Fine-tune interface text size.
         type: variable-number-slider
         default: 0
         min: -8
@@ -2432,10 +2435,10 @@ settings:
         format: px
     -
         id: icon-size-modifier
-        title: Icon size
-        title.zh: 图标尺寸微调
-        description: Fine-tune icon size.
-        description.zh: 细调界面图标大小。
+        title: 图标尺寸微调
+        title.en: Icon size
+        description: 细调界面图标大小。
+        description.en: Fine-tune icon size.
         type: variable-number-slider
         default: 0
         min: -4


### PR DESCRIPTION
## Summary

This PR adds a new Style Settings option for default image alignment and fixes an image sizing inconsistency between Edit mode and Reading view.

### What changed

1. Added a new Style Settings select option:
   - `Image alignment`
   - Options: `Left`, `Center`, `Right`
   - Default: `Center`
   - File: `src/app/style-settings.scss`

2. Added alignment CSS hooks in editor styles:
   - New body classes: `image-align-left`, `image-align-center`, `image-align-right`
   - Applied to image blocks using logical margins (`margin-inline-start/end`)
   - File: `src/editor/editor.scss`

3. Fixed tall image behavior in Reading view:
   - Previously, un-sized images were forced to `width: 100%`, which could make very tall images appear excessively large.
   - Updated image sizing to:
     - `width: auto`
     - `max-width: 100%`
     - `height: auto`
   - Kept `iframe` and `video` at `width: 100%`.

4. Rebuilt `theme.css` from `src/theme.scss`.

## Why

- Very tall images (long screenshots / flowcharts) could be over-enlarged in Reading view.
- Image sizing could look inconsistent between Edit mode and Reading view.
- Users needed an easy way to choose default image alignment.

## Test plan

- Switch `Image alignment` between Left / Center / Right in Style Settings and verify alignment updates in both Edit mode and Reading view.
- Insert a very tall image and verify it no longer gets over-expanded in Reading view.
- Insert regular landscape images and verify they still render correctly.
- Verify videos and iframes still use full-width behavior.